### PR TITLE
docs: extend vision with user document upload and personal workspaces

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -124,9 +124,16 @@ Workspaces can be organized in layers. When a user searches, OPAA retrieves resu
 
 1. **Organization-wide workspace** — Company policies, all-hands notes, public documentation (visible to everyone)
 2. **Team/Project workspaces** — Engineering docs, marketing plans, project-specific knowledge (visible to team members)
-3. **Personal workspace** — Individual notes, personal bookmarks, private documents (visible only to the user)
+3. **Personal workspace ("My Documents")** — Auto-created for each user. Stores documents uploaded by the user. Private by default, but documents can be shared into team workspaces.
 
 This means a search for "remote work policy" could return the company-wide HR policy (from the organization workspace) alongside your team's specific remote work guidelines (from your team workspace) and your personal notes on the topic.
+
+**Personal Workspace Details:**
+- Automatically created when a user first logs in or uploads a document
+- One per user, cannot be deleted (deactivated on offboarding)
+- User is always the Owner with full control
+- Documents can be shared OUT into team workspaces (not the reverse)
+- See [Access Control & Workspaces — Personal Workspaces](./features/access-control-workspaces.md#personal-workspaces)
 
 **Analogy:**
 - Like separate Slack workspaces or Google Drive folders with permissions
@@ -254,6 +261,46 @@ Software that knows how to connect to a specific data source and extract documen
 - S3 connector — Knows how to authenticate with AWS, list and download files
 - Google Drive connector — Knows how to use Google APIs, download documents
 - Jira connector — Knows how to read issues, comments, and attachments
+
+---
+
+### User Document Upload
+
+The act of a user pushing a document into OPAA through a frontend interface (Web UI, Chat, REST API), as opposed to OPAA pulling documents from configured data sources via connectors.
+
+**Key differences from connector-based ingestion:**
+- User actively pushes documents (vs. OPAA pulling from sources)
+- Triggered on-demand by user action (vs. scheduled or event-based)
+- Documents land in the user's personal workspace by default
+- Original files are stored on OPAA's configurable storage backend
+
+See [Data Indexing & RAG — User Document Upload](./features/data-indexing-rag.md#user-document-upload) for details.
+
+---
+
+### Storage Backend
+
+The pluggable file storage system where uploaded documents are persisted. This is separate from the vector database — the storage backend holds original files (PDF, DOCX, etc.) for download and re-processing, while the vector database holds embeddings for search.
+
+**Supported backends (chosen at deployment time):**
+- **S3-Compatible Object Storage** — AWS S3, MinIO (cloud/hybrid)
+- **Network Drive (SMB/NFS)** — Shared file system mount (on-premises)
+- **Local Filesystem** — Direct disk storage (development/small deployments)
+
+---
+
+### Cross-Workspace Document Sharing
+
+Making a document from one workspace (typically personal) visible and searchable in another workspace. The document is not duplicated — instead, its indexed data is tagged with multiple workspace IDs.
+
+**How it works:**
+- User shares a document from "My Documents" into a team workspace
+- User must have Editor role (or higher) in the target workspace
+- The document's indexed chunks gain additional workspace tags
+- Members of the target workspace can now find the document in search results
+- Owner can revoke sharing at any time
+
+See [Access Control & Workspaces — Cross-Workspace Document Sharing](./features/access-control-workspaces.md#cross-workspace-document-sharing) for details.
 
 ---
 
@@ -529,6 +576,10 @@ Immediately updating OPAA when source documents change (within seconds).
 | **Semantic** | Based on meaning, not keywords | "Remote work" ≈ "work from home" |
 | **LLM** | AI language model | GPT-4, Claude, Llama |
 | **Workspace** | Isolated knowledge base area | "Engineering" team docs |
+| **Personal Workspace** | Auto-created private workspace per user | "My Documents" for each user |
+| **User Upload** | User pushes document into OPAA | Drag-and-drop in Web UI |
+| **Storage Backend** | Pluggable file storage for uploads | S3, network drive, local |
+| **Cross-Workspace Sharing** | Make document visible in another workspace | Share from "My Documents" to "Engineering" |
 | **Role** | Permission set | Admin, Editor, Viewer |
 | **Vector DB** | Database optimized for similarity | Elasticsearch, Milvus, pgvector |
 | **Latency** | Time to answer | < 4 seconds target |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -43,7 +43,9 @@ Each feature spec provides:
 **[`features/data-indexing-rag.md`](./features/data-indexing-rag.md)** — How documents are indexed and retrieved
 
 - 5 data source categories (wikis, email, file systems, APIs, custom)
+- User document uploads (via Web UI, Chat, REST API)
 - Document processing pipeline (extraction → chunking → embedding → storage)
+- Storage backend abstraction (S3, network drive, local filesystem)
 - Multiple vector database backends (Elasticsearch, PostgreSQL, Milvus, cloud options)
 - Retrieval & ranking with confidence scoring
 - Advanced features (multi-language, caching, semantic deduplication)
@@ -86,6 +88,8 @@ Each feature spec provides:
 **[`features/access-control-workspaces.md`](./features/access-control-workspaces.md)** — Permissions and multi-tenancy
 
 - Workspace isolation and management
+- Personal workspaces ("My Documents") auto-created per user
+- Cross-workspace document sharing
 - Role-based access control (Viewer, Editor, Admin, Owner)
 - Document-level permissions
 - Query-time permission enforcement
@@ -114,8 +118,9 @@ Orchestration Layer
     └→ LLM Integration (Generate response)
 
 Data Indexing & RAG
-    ├→ Supported Data Sources
-    └→ Vector Databases
+    ├→ Supported Data Sources (Connectors)
+    ├→ User Document Uploads (via Frontends)
+    └→ Document Storage Backends + Vector Databases
 
 Deployment & Infrastructure
     └→ All other features (Infrastructure for all)
@@ -173,6 +178,9 @@ Deployment & Infrastructure
 
 **How do I index my documents?**
 → Read [Data Indexing & RAG](./features/data-indexing-rag.md) — Supported Data Sources section
+
+**Can users upload their own documents?**
+→ Yes! Read [Data Indexing & RAG](./features/data-indexing-rag.md) — User Document Upload section and [Access Control](./features/access-control-workspaces.md) — Personal Workspaces section
 
 **Can I use my own LLM?**
 → Yes! See [LLM Integration](./features/llm-integration.md) — OpenAI-Compatible APIs section

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -18,6 +18,7 @@ Modern organizations face a critical knowledge challenge:
 - **Discovery Friction:** Employees spend hours searching for information rather than using it
 - **Context Loss:** Documents exist but are difficult to find, understand, and trust
 - **Dependency on People:** Key information often exists only in people's heads
+- **Individual Knowledge Silos:** Employees accumulate personal documents, notes, and research that are valuable to the organization but have no easy path into the shared knowledge base
 - **Tool Proliferation:** Each data source requires a different search interface
 
 OPAA solves this by creating a unified intelligence layer over disparate knowledge sources, making organizational knowledge instantly accessible, searchable, and actionable.
@@ -32,6 +33,7 @@ OPAA solves this by creating a unified intelligence layer over disparate knowled
 | **Authority & Trust** | Every answer includes source documents, ensuring users can verify information and trust recommendations |
 | **Cross-Silo Visibility** | Seamless search across Confluence, email archives, file systems, and other repositories as a single interface |
 | **Flexible Integration** | Deploy on your infrastructure with your choice of LLM provider (OpenAI, open-source models, private APIs) |
+| **Personal Knowledge Management** | Employees can upload their own documents into a private workspace, making personal knowledge searchable and shareable with teams on demand |
 | **Evolving Knowledge** | New and updated documents are automatically detected and re-indexed, keeping answers always up-to-date |
 
 ---
@@ -50,6 +52,9 @@ A support team uses OPAA's web interface to provide better customer answers. Ins
 ### 4. **Compliance & Audit Trail** (Regulated Industries)
 A healthcare organization uses OPAA to index compliance policies, audit documents, and regulatory guidance. When questioned, the system provides exact source references, creating an auditable trail for compliance investigations.
 
+### 5. **Personal Knowledge Contributor** (Individual Users)
+A senior engineer uploads technical research papers, meeting notes, and design sketches into their personal "My Documents" workspace. The documents are immediately indexed and searchable in their private area. When a design document is finalized, they share it into the "Engineering" team workspace, making it discoverable by the entire engineering team. The original stays in their personal workspace for their own reference.
+
 ---
 
 ## System Architecture (High Level)
@@ -58,14 +63,17 @@ A healthcare organization uses OPAA to index compliance policies, audit document
 ┌─────────────────────────────────────────────────────────┐
 │                    USER INTERFACES                      │
 ├─────────────────────────────────────────────────────────┤
-│  Web │ Mattermost │ Slack │ Telegram │ Signal │ Custom    │
-└────────────────────┬────────────────────────────────────┘
-                     │
-┌────────────────────▼────────────────────────────────────┐
+│  Web │ Mattermost │ Slack │ Telegram │ Signal │ Custom  │
+│                                                         │
+│  Questions & Answers          Document Upload           │
+└────────────┬──────────────────────┬─────────────────────┘
+             │                      │
+┌────────────▼──────────────────────▼─────────────────────┐
 │              OPAA ORCHESTRATION LAYER                   │
 ├─────────────────────────────────────────────────────────┤
 │  • Request Processing  • Permissions & Access Control  │
 │  • Response Generation  • Document Retrieval           │
+│  • Upload Processing    • Workspace Management         │
 └────────────┬─────────────────────┬─────────────────────┘
              │                     │
     ┌────────▼──────┐    ┌─────────▼────────┐
@@ -85,7 +93,17 @@ A healthcare organization uses OPAA to index compliance policies, audit document
 ┌────────────▼──────────────────────────────────────────┐
 │            DATA INDEXING & INGESTION LAYER            │
 ├──────────────────────────────────────────────────────┤
+│  Connectors:                                          │
 │  • Confluence │ Email │ File Systems │ Custom Sources │
+│                                                       │
+│  User Uploads:                                        │
+│  • Web UI │ Chat Attachments │ REST API               │
+└──────────────────────┬───────────────────────────────┘
+                       │
+┌──────────────────────▼───────────────────────────────┐
+│            DOCUMENT STORAGE                           │
+├──────────────────────────────────────────────────────┤
+│  • S3 │ Network Drive (SMB/NFS) │ Local Filesystem   │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -98,6 +116,7 @@ Multiple interfaces for different usage patterns:
 - **Web Interface:** Browser-based chat UI with search and document browsing
 - **Chat Integrations:** Native plugins for Mattermost, Slack, Telegram, RocketChat, Signal, WhatsApp, and other platforms
 - **REST API:** Programmatic access for custom integrations
+- **Document Upload:** Users can upload documents directly through the Web UI, chat integrations, or REST API. Uploaded documents are stored and indexed into the user's personal workspace.
 
 ### 2. **Orchestration Layer** (Request Processing)
 The central coordination system:
@@ -122,8 +141,11 @@ Flexible model configuration:
 - Enables response generation and summarization
 
 ### 5. **Data Indexing Pipeline** (Knowledge Ingestion)
-Continuous document processing:
-- Monitors data sources (Confluence, email servers, file systems)
+Two ingestion modes feed the same processing pipeline:
+- **Connector-Based:** Monitors data sources (Confluence, email servers, file systems) and pulls documents automatically on schedule or via events
+- **User Upload:** Receives documents uploaded by users through frontends, stores them on a configurable storage backend (S3, network drive, local filesystem)
+
+Both pathways share the same document processing pipeline:
 - Extracts, chunks, and embeds documents
 - Stores embeddings in vector databases
 - Updates indices incrementally as new documents arrive
@@ -137,6 +159,7 @@ Every component should be swappable and configurable. Organizations choose their
 - LLM provider (OpenAI, open-source models, private APIs)
 - Vector database (Elasticsearch, PostgreSQL + pgvector, Milvus, etc.)
 - Data sources (Confluence, Jira, Gmail, SharePoint, Google Drive, Dropbox, S3, issue trackers, etc.)
+- Document storage backends (S3, network drives, local filesystem)
 - Chat platforms (Mattermost, Slack, Telegram, RocketChat, Signal, WhatsApp, custom)
 
 ### 🏢 **Digital Sovereignty & On-Premises by Default**
@@ -182,8 +205,10 @@ Every answer includes:
 
 ### **Data & Knowledge Management**
 - Index documents from multiple sources simultaneously
+- Upload personal documents through Web UI, chat clients, or REST API
 - Support for multiple file formats (Markdown, AsciiDoc, PDF, Word, PowerPoint)
 - Automatic change detection in data sources with event-based or scheduled re-indexing
+- Share documents from personal workspace into team workspaces
 - Manage document lifecycles (archive, delete, re-index)
 - Configure indexing schedules and priorities
 
@@ -201,7 +226,9 @@ Every answer includes:
 - Scaling for large organizations
 
 ### **Access Control & Workspaces**
+- Personal workspaces auto-created per user ("My Documents")
 - Multi-user workspaces
+- Cross-workspace document sharing
 - Role-based access control (RBAC)
 - Document-level permissions
 - Audit logging
@@ -280,10 +307,17 @@ Understanding how the five major feature areas connect and depend on each other:
        ┌──────────▼──────────────────────┐
        │   DATA SOURCES                  │
        │                                 │
+       │ Connectors:                     │
        │ - Confluence                    │
        │ - Email Archives                │
        │ - File Systems                  │
        │ - Custom APIs                   │
+       │                                 │
+       │ User Uploads:                   │
+       │ - Web UI / Chat / REST API      │
+       │                                 │
+       │ Document Storage:               │
+       │ - S3 / Network Drive / Local    │
        └─────────────────────────────────┘
 
 ┌──────────────────────────────────────────────────────────────┐
@@ -303,7 +337,7 @@ How features depend on and interact with each other:
 
 | Feature | Depends On | Used By | Key Integration Point |
 |---------|-----------|---------|----------------------|
-| **User Frontends** | Access Control | All users | Request entry point |
+| **User Frontends** | Access Control | All users | Request entry point + document upload |
 | **Orchestration** | RAG, LLM, Access Control | All requests | Central coordinator |
 | **Data Indexing & RAG** | LLM (for embeddings) | Orchestration | Document retrieval |
 | **LLM Integration** | Deployment | Data Indexing, Orchestration | Answer generation & embeddings |
@@ -328,6 +362,9 @@ The system is model-agnostic.
 **Q: Can multiple teams use the same OPAA instance?**
 A: Yes, through workspace isolation and role-based access control.
 Each team can have its own workspace with separate documents and permissions.
+
+**Q: Can individual users upload their own documents?**
+A: Yes. Every user gets an auto-created personal workspace ("My Documents") where they can upload and index documents privately. Users can then share documents into team workspaces they have access to.
 
 **Q: How does OPAA handle sensitive documents?**
 A: Documents can be tagged with access controls.

--- a/docs/features/access-control-workspaces.md
+++ b/docs/features/access-control-workspaces.md
@@ -17,9 +17,10 @@ This feature describes how OPAA controls who can see what, enabling multi-team, 
 OPAA provides access control at multiple levels:
 
 1. **Workspaces** — Logical groupings of documents and users (teams, departments)
-2. **Roles** — Job functions with specific permissions
-3. **Document Permissions** — Fine-grained control over individual documents
-4. **Query-Time Enforcement** — Permissions checked when user searches
+2. **Personal Workspaces** — Auto-created private spaces for individual user documents
+3. **Roles** — Job functions with specific permissions
+4. **Document Permissions** — Fine-grained control over individual documents
+5. **Query-Time Enforcement** — Permissions checked when user searches
 
 ---
 
@@ -33,6 +34,8 @@ A **workspace** is a self-contained area of OPAA:
 - Users in one workspace don't see documents from another
 - Each workspace can have its own indexing schedule
 
+A special type of workspace, the **Personal Workspace** ("My Documents"), is automatically created for each user. It functions identically to a regular workspace but is owned and visible exclusively to a single user. Users cannot be added as members of another user's personal workspace. See [Personal Workspaces](#personal-workspaces) below.
+
 ### Workspace Examples
 
 | Workspace | Members | Documents | Visibility |
@@ -41,6 +44,7 @@ A **workspace** is a self-contained area of OPAA:
 | Marketing | Marketing team | Brand guidelines, Campaign plans | Only marketing |
 | HR | HR staff | Policies, Handbooks | Only HR (sensitive) |
 | Company | All employees | Public policies, All-hands notes | Everyone |
+| My Documents (Sarah) | Sarah only | Uploaded research, notes, drafts | Only Sarah |
 
 ### Workspace Management
 
@@ -86,6 +90,85 @@ Optional: **Shared workspaces** (for cross-team needs)
 - Role-based permissions within shared workspace
 - Audit logging tracks who searched what
 
+### Personal Workspaces
+
+#### Auto-Creation
+
+When a user first logs in or uploads their first document, OPAA automatically creates a personal workspace:
+
+```
+Workspace: "My Documents"
+  Type: personal
+  Owner: [user]
+  Members: [user] (cannot be changed)
+  Visibility: private (only the owner)
+  Auto-created: true
+  Deletable: no (exists as long as user account exists)
+```
+
+#### Characteristics
+
+- One per user, cannot be duplicated
+- User is always Owner with full control
+- Cannot invite other members directly
+- Documents are shared OUT of the personal workspace into team workspaces (not the reverse)
+- Has its own indexing scope for RAG queries
+- Included in cross-workspace search results (for the owning user only)
+
+#### Storage
+
+Personal workspace documents are stored on the deployment's configured storage backend (S3, network drive, or local filesystem). The storage location is transparent to the user. See [Data Indexing & RAG — User Document Upload](./data-indexing-rag.md#user-document-upload) for details.
+
+---
+
+## Cross-Workspace Document Sharing
+
+### Concept
+
+Users can share documents from their personal workspace into team workspaces where they have Editor (or higher) role. This makes personal documents discoverable and searchable by other workspace members.
+
+### How Sharing Works
+
+1. User has a document in "My Documents"
+2. User selects "Share to workspace" and picks a target workspace (e.g., "Engineering")
+3. User must have at least Editor role in the target workspace
+4. The document's indexed chunks gain the target workspace ID
+5. Members of "Engineering" can now find the document in search results
+6. The original document remains in the user's personal workspace
+
+### Sharing Model
+
+```
+Document: "Q1 Design Review"
+  Owner: Sarah Chen
+  Home workspace: My Documents (Sarah)
+  Shared to: [Engineering, Architecture]
+
+  Visibility:
+    - Sarah: always (owner)
+    - Engineering members: yes (shared)
+    - Architecture members: yes (shared)
+    - Marketing members: no (not shared)
+```
+
+### Sharing vs. Moving
+
+- **Share:** Document visible in multiple workspaces. Single source of truth. Owner retains control.
+- **Move:** (Not supported) Documents always have a home workspace. If a user wants to permanently place a document in a team workspace, they upload directly to that workspace (requires Editor role).
+
+### Revoking Shared Access
+
+- Document owner can revoke sharing at any time
+- Workspace Admin can remove a shared document from their workspace
+- When sharing is revoked, the document's chunks lose the workspace tag and are no longer returned in that workspace's search results
+
+### Upload Directly to Team Workspace
+
+Users with Editor role in a team workspace can also upload documents directly to that workspace (bypassing the personal workspace). In this case:
+- The document's home workspace is the team workspace
+- The uploading user is the document owner
+- Standard workspace permissions apply
+
 ---
 
 ## Roles & Permissions
@@ -116,6 +199,7 @@ Can:
 - Edit document metadata
 - Add/remove documents
 - Change document permissions
+- Share personal documents into the workspace
 
 Cannot:
 - Manage users
@@ -169,6 +253,8 @@ CustomRole:
 | View sources | ✅ | ✅ | ✅ | ✅ |
 | Add documents | ❌ | ✅ | ✅ | ✅ |
 | Edit documents | ❌ | ✅* | ✅ | ✅ |
+| Upload documents | ❌ | ✅ | ✅ | ✅ |
+| Share documents into workspace | ❌ | ✅ | ✅ | ✅ |
 | Delete documents | ❌ | ❌ | ✅ | ✅ |
 | Change permissions | ❌ | ❌ | ✅ | ✅ |
 | Manage users | ❌ | ❌ | ✅ | ✅ |
@@ -401,6 +487,7 @@ All documents in one workspace, role-based permissions:
 
 ### Strategy 3: Hybrid (Recommended)
 Multiple workspaces + cross-team searches:
+- **Personal Workspaces:** Every user has "My Documents" (private, auto-created)
 - **Public Workspace:** Everyone included (policies, all-hands notes)
 - **Team Workspaces:** Isolated by team (engineering, marketing, hr)
 - **Special Workspaces:** Cross-functional (executive, board)
@@ -408,13 +495,14 @@ Multiple workspaces + cross-team searches:
 User access example:
 ```
 Employee: Sarah Chen
-  Workspaces: [Company, Engineering, Executive]
-  Roles: [viewer in Company, editor in Engineering, viewer in Executive]
+  Workspaces: [My Documents, Company, Engineering, Executive]
+  Roles: [owner in My Documents, viewer in Company, editor in Engineering, viewer in Executive]
 ```
 
 Cross-team search:
-- Sarah can search all three workspaces simultaneously
+- Sarah can search all four workspaces simultaneously
 - Results filtered by her role in each workspace
+- Documents she uploaded privately appear alongside team and company documents
 - Workspace name shown in results
 
 ---
@@ -464,6 +552,22 @@ Restrictions:
   - Downloads logged
 ```
 
+### User Offboarding with Personal Workspace
+
+When a user leaves the organization, their personal workspace requires special handling:
+
+```
+1. Personal workspace documents shared to team workspaces remain accessible
+   (ownership transfers to workspace admin)
+2. Unshared personal documents can be:
+   - Transferred to another user or workspace
+   - Archived
+   - Deleted (after retention period)
+3. Personal workspace is deactivated (not deleted, for audit purposes)
+4. All sharing relationships from the personal workspace are preserved
+   under the new owner
+```
+
 ---
 
 ## Integration Points
@@ -484,6 +588,9 @@ Restrictions:
 - Should we support approval workflows for sensitive documents?
 - Should we support delegation (user A delegates their permissions to B)?
 - Should we support document classification (public/internal/confidential)?
+- Should shared documents support read-only vs. editable sharing?
+- Should there be a limit on how many workspaces a document can be shared to?
+- Should workspace admins be able to "request" documents from users' personal workspaces?
 
 ---
 

--- a/docs/features/data-indexing-rag.md
+++ b/docs/features/data-indexing-rag.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-OPAA's value comes from having access to organizational knowledge. This feature describes how documents from diverse sources (wikis, email, file systems) are discovered, processed, and made searchable through semantic embeddings.
+OPAA's value comes from having access to organizational knowledge. This feature describes how documents from diverse sources (wikis, email, file systems) are discovered, processed, and made searchable through semantic embeddings. In addition to organizational data sources discovered by connectors, OPAA also supports direct document uploads by individual users, enabling personal knowledge to enter the RAG pipeline.
 
 The Retrieval-Augmented Generation (RAG) pipeline ensures answers are grounded in actual organizational documents, with full attribution and traceability.
 
@@ -12,9 +12,13 @@ The Retrieval-Augmented Generation (RAG) pipeline ensures answers are grounded i
 
 The Data Indexing & RAG system consists of three phases:
 
-1. **Source Discovery & Ingestion** — Finding documents in various sources
+1. **Source Discovery, Upload & Ingestion** — Finding documents in various sources or receiving them via user uploads
 2. **Document Processing** — Extracting, chunking, and embedding documents
 3. **Retrieval & Ranking** — Finding relevant documents for user questions
+
+Documents enter the pipeline through two paths:
+- **Connector-Based Ingestion:** OPAA pulls documents from configured data sources (Confluence, email, file systems) on schedule or via events.
+- **User Upload Ingestion:** Users push documents directly into OPAA through frontends (Web UI, Chat, REST API).
 
 ---
 
@@ -84,6 +88,96 @@ Permissions:
 
 ---
 
+## User Document Upload
+
+### Concept
+
+In addition to connector-based ingestion, users can upload documents directly into OPAA through any frontend (Web UI, Chat, REST API). Uploaded documents are stored on a configurable storage backend and processed through the same document processing pipeline as connector-sourced documents.
+
+### How It Differs from Connectors
+
+| Aspect | Connectors | User Upload |
+|--------|-----------|-------------|
+| Direction | OPAA pulls from sources | User pushes to OPAA |
+| Trigger | Scheduled or event-based | On-demand (user action) |
+| Scope | Organizational data sources | Individual user documents |
+| Workspace | Configured per connector | User's personal workspace (default) |
+| Storage | Original stays in source system | Stored on OPAA's storage backend |
+
+### Upload Flow
+
+1. User selects file(s) through frontend (Web UI drag-and-drop, chat attachment, or API multipart upload)
+2. File is validated (format, size limits, virus scan)
+3. File is stored on the configured storage backend (S3, network drive, local FS)
+4. Document enters the standard processing pipeline (extraction, chunking, embedding, vector storage)
+5. Document is indexed into the user's personal workspace by default
+6. User can optionally share/publish into other workspaces they have access to
+
+### Storage Backend Abstraction
+
+Uploaded files are stored on a pluggable storage backend, chosen at deployment time. This is separate from the vector database — the storage backend holds the original uploaded files (PDF, DOCX, etc.) for download and re-processing, while the vector database holds the embeddings and chunk text for search.
+
+#### Option 1: S3-Compatible Object Storage
+- AWS S3, MinIO, or any S3-compatible store
+- Best for cloud and hybrid deployments
+- Built-in redundancy and lifecycle management
+
+#### Option 2: Network Drive (SMB/NFS)
+- Shared file system mount
+- Best for on-premises deployments with existing file servers
+- Familiar to operations teams
+
+#### Option 3: Local Filesystem
+- Direct disk storage on OPAA server
+- Simplest option for small deployments and development
+- Requires separate backup strategy
+
+**Storage Backend Configuration:**
+```yaml
+storage:
+  backend: "s3"  # or "network-drive" or "local"
+  s3:
+    endpoint: "https://s3.company.com"
+    bucket: "opaa-uploads"
+    region: "eu-central-1"
+  network-drive:
+    path: "//fileserver/opaa-uploads"
+  local:
+    path: "/data/opaa/uploads"
+  limits:
+    max_file_size: "50MB"
+    allowed_formats: ["pdf", "docx", "md", "txt", "pptx", "xlsx"]
+```
+
+### Supported Upload Formats
+
+Same document formats as connector-sourced documents (see Document Formats section above), with these additions for the upload context:
+- Maximum file size configurable (default: 50 MB)
+- Batch upload support (multiple files at once)
+- Drag-and-drop in Web UI
+- File attachment in chat platforms
+
+### Upload Metadata
+
+Each uploaded document stores:
+```json
+{
+  "document_id": "upload-456",
+  "filename": "design-review-q1.pdf",
+  "uploaded_by": "user-123",
+  "uploaded_at": "2026-02-16T10:30:00Z",
+  "workspace_id": "personal-user-123",
+  "storage_backend": "s3",
+  "storage_path": "s3://opaa-uploads/user-123/design-review-q1.pdf",
+  "file_size_bytes": 2048576,
+  "content_type": "application/pdf",
+  "source_type": "user_upload",
+  "shared_to_workspaces": ["workspace-eng"]
+}
+```
+
+---
+
 ## Document Processing Pipeline
 
 ### Step 1: Discovery & Extraction
@@ -94,6 +188,8 @@ For each source, OPAA:
 - Checks modification timestamp against last index
 - Downloads new/modified documents
 - Extracts text content (handles binary formats like PDF)
+
+**For user uploads:** The discovery step is replaced by the upload event itself. The uploaded file is retrieved from the storage backend and enters the pipeline at the extraction phase. All subsequent steps (chunking, embedding, storage) are identical to connector-sourced documents.
 
 **Error Handling:**
 - Skips documents that can't be extracted
@@ -152,6 +248,7 @@ Processed chunks stored with:
   "document_title": "Enterprise Architecture Guide",
   "workspace_id": "workspace-eng",
   "source": "confluence",
+  "source_type": "connector",
   "source_url": "https://wiki.company.com/pages/view/123456",
   "chunk_index": 5,
   "chunk_text": "...",
@@ -328,6 +425,7 @@ Indexing can start:
 - On demand (manual admin trigger)
 - Via webhook (source system pings OPAA)
 - On document change (streaming if supported)
+- On user upload (immediate processing when user uploads a file)
 
 ---
 
@@ -345,6 +443,16 @@ At query time, system:
 - Retrieves all relevant chunks
 - Filters out chunks user cannot access
 - Returns only authorized results
+
+### User-Uploaded Document Permissions
+
+Documents uploaded by users follow a specific permission model:
+- **Default:** Private to the uploading user (in their personal workspace)
+- **Shared:** When shared to a team workspace, inherits that workspace's visibility rules
+- **Owner:** The uploading user is always the document owner
+- Document owner can revoke sharing at any time
+
+Cross-workspace sharing does NOT duplicate the document. The same indexed chunks gain additional workspace_id tags, making them visible in multiple workspace contexts while maintaining a single source of truth.
 
 ### Workspace Isolation
 
@@ -397,6 +505,9 @@ System scales to:
 - Should we offer semantic deduplication (remove redundant documents automatically)?
 - How to handle very large documents (100K+ pages)?
 - Should we support hybrid retrieval (vector + keyword search together)?
+- Should there be storage quotas per user or per workspace for uploaded documents?
+- Should uploaded documents support versioning (upload new version of same document)?
+- Should we support bulk import from a user's local drive?
 
 ---
 

--- a/docs/features/user-frontends.md
+++ b/docs/features/user-frontends.md
@@ -21,6 +21,7 @@ All interfaces share:
 - Common permission model
 - Consistent response format
 - Source document attribution
+- Document upload capability (files processed and indexed)
 
 ---
 
@@ -33,6 +34,7 @@ The web interface is a browser-based chat application with document browsing cap
 **Core Screens:**
 - **Chat Screen:** Ask questions, see responses with sources
 - **Document Browser:** Search and browse indexed documents
+- **My Documents:** Personal workspace with upload, manage, and share functionality
 - **History:** View past conversations and searches
 - **Settings:** Manage user preferences, API tokens
 
@@ -76,6 +78,23 @@ OPAA Response:
 - Filter by date indexed
 - Filter by workspace/project
 - Filter by confidence score
+
+#### Document Upload
+- Drag-and-drop file upload area in the personal workspace view
+- Multi-file upload support (batch)
+- Upload progress indicator with file validation feedback
+- Supported format detection and file size validation
+- Post-upload: document appears in "My Documents" within seconds
+- Indexing status shown (processing, indexed, failed)
+- Quick-share action: select target workspace(s) directly after upload
+
+#### Document Management (My Documents)
+- List view of all personally uploaded documents
+- Sort by date, name, size, or indexing status
+- Delete uploaded documents
+- View which workspaces a document is shared to
+- Share/unshare documents to team workspaces
+- Re-upload (new version) of an existing document
 
 ### Configuration
 
@@ -131,6 +150,9 @@ security review. See: Tool Approval Process (updated Jan 2024)"
 ```
 /opaa ask <question>        — Ask a question
 /opaa search <term>         — Full-text search
+/opaa upload <attachment>   — Upload attached file to My Documents
+/opaa share <doc> <workspace> — Share a document to a workspace
+/opaa my-docs              — List recent uploads in My Documents
 /opaa config               — Show workspace settings
 /opaa feedback <message>   — Rate last answer
 /opaa sources             — Show source documents from last answer
@@ -141,6 +163,13 @@ Users can react with 👍 or 👎 to answers. The system:
 - Tracks answer quality
 - Enables model improvement over time
 - Alerts admins to potentially bad answers
+
+#### File Upload via Chat
+- Users attach a file to a message mentioning the bot
+- Bot acknowledges receipt and begins processing
+- Notification when indexing is complete
+- File is stored in user's personal workspace by default
+- User can specify target workspace: "@opaa-bot upload to Engineering"
 
 #### Message Threading
 All conversations happen in a single thread:
@@ -222,6 +251,80 @@ Returns:
 - Metadata
 - Related documents
 - Download links
+```
+
+#### Upload Document
+```
+POST /api/v1/documents/upload
+Content-Type: multipart/form-data
+
+Fields:
+  file: <binary>
+  workspace: "string (optional, defaults to personal workspace)"
+  tags: ["string"] (optional)
+  description: "string" (optional)
+
+Response:
+{
+  "document_id": "upload-456",
+  "filename": "design-review.pdf",
+  "workspace_id": "personal-user-123",
+  "status": "processing",
+  "storage_path": "s3://opaa-uploads/user-123/design-review.pdf",
+  "estimated_index_time_seconds": 30
+}
+```
+
+#### Share Document to Workspace
+```
+POST /api/v1/documents/{id}/share
+{
+  "target_workspace": "workspace-eng",
+  "action": "share"
+}
+
+Response:
+{
+  "document_id": "upload-456",
+  "shared_to": ["workspace-eng", "workspace-arch"],
+  "status": "shared"
+}
+```
+
+#### Unshare Document from Workspace
+```
+POST /api/v1/documents/{id}/share
+{
+  "target_workspace": "workspace-eng",
+  "action": "unshare"
+}
+
+Response:
+{
+  "document_id": "upload-456",
+  "shared_to": ["workspace-arch"],
+  "status": "unshared"
+}
+```
+
+#### List User's Uploaded Documents
+```
+GET /api/v1/documents/my-uploads?status=indexed&limit=20
+
+Response:
+{
+  "documents": [
+    {
+      "id": "upload-456",
+      "filename": "design-review.pdf",
+      "uploaded_at": "2026-02-16T10:30:00Z",
+      "status": "indexed",
+      "shared_to": ["workspace-eng"],
+      "file_size_bytes": 2048576
+    }
+  ],
+  "total": 42
+}
 ```
 
 #### Feedback


### PR DESCRIPTION
## Summary

- Extend product vision with new use case: **User Document Upload with Personal Workspaces**
- Add **Personal Workspace** ("My Documents") concept — auto-created per user, private by default
- Add **Cross-Workspace Document Sharing** — share documents into team workspaces without duplication
- Add **Storage Backend Abstraction** — pluggable storage (S3, network drive, local) for uploaded files
- Document dual ingestion model: connectors (pull) + user uploads (push) feeding the same RAG pipeline
- Add new REST API endpoints: upload, share/unshare, my-uploads

## Changes

6 documentation files updated consistently:

| File | Key Changes |
|------|------------|
| `access-control-workspaces.md` | Personal Workspaces, Cross-Workspace Sharing, updated permission matrix, offboarding |
| `data-indexing-rag.md` | User Document Upload section, Storage Backend Abstraction, upload metadata |
| `user-frontends.md` | Upload UI (Web drag-and-drop, Chat attachments), new API endpoints |
| `VISION.md` | Use Case 5, updated architecture diagram, FAQ, feature categories |
| `CONCEPTS.md` | New glossary entries, expanded workspace hierarchy |
| `INDEX.md` | Updated feature summaries and dependency map |

## Test plan

- [ ] Review all 6 files for consistency of terminology and cross-references
- [ ] Verify architecture diagrams show both ingestion paths
- [ ] Check that new API endpoint specs are consistent with existing API patterns
- [ ] Validate permission matrix additions are coherent with existing roles

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)