### PR TITLE
feat(frontend): add admin sidebar with indexing controls

### DIFF
--- a/frontend/src/components/admin/AdminDrawer.test.tsx
+++ b/frontend/src/components/admin/AdminDrawer.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { renderWithProviders } from '../../test/test-utils'
+import AdminDrawer from './AdminDrawer'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+describe('AdminDrawer', () => {
+  beforeEach(() => {
+    useIndexingStore.setState({
+      status: 'IDLE',
+      documentCount: 0,
+      chunkCount: 0,
+      message: null,
+      timestamp: null,
+      isPolling: false,
+      drawerOpen: true,
+      snackbar: { open: false, message: '', severity: 'success' },
+    })
+  })
+
+  it('renders admin header and indexing button', () => {
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByText('Admin')).toBeInTheDocument()
+    expect(screen.getByText('Index Documents')).toBeInTheDocument()
+  })
+
+  it('shows close button', () => {
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByLabelText('Close admin drawer')).toBeInTheDocument()
+  })
+
+  it('closes drawer on close button click', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminDrawer />)
+
+    await user.click(screen.getByLabelText('Close admin drawer'))
+    expect(useIndexingStore.getState().drawerOpen).toBe(false)
+  })
+
+  it('disables button when indexing is running', () => {
+    useIndexingStore.setState({ status: 'RUNNING' })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByRole('button', { name: /indexing/i })).toBeDisabled()
+  })
+
+  it('shows progress when indexing is running', () => {
+    useIndexingStore.setState({
+      status: 'RUNNING',
+      message: 'Indexing in progress... 10 documents processed',
+    })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    expect(screen.getByText(/10 documents processed/)).toBeInTheDocument()
+  })
+
+  it('shows last indexing info when completed', () => {
+    useIndexingStore.setState({
+      status: 'COMPLETED',
+      documentCount: 42,
+      chunkCount: 1337,
+      timestamp: '2025-01-15T10:30:00Z',
+    })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByText(/completed/i)).toBeInTheDocument()
+    expect(screen.getByText(/documents: 42/i)).toBeInTheDocument()
+    expect(screen.getByText(/chunks: 1337/i)).toBeInTheDocument()
+  })
+
+  it('does not render content when drawer is closed', () => {
+    useIndexingStore.setState({ drawerOpen: false })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/admin/AdminDrawer.tsx
+++ b/frontend/src/components/admin/AdminDrawer.tsx
@@ -1,0 +1,96 @@
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import LinearProgress from '@mui/material/LinearProgress'
+import Typography from '@mui/material/Typography'
+import CloseIcon from '@mui/icons-material/Close'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+const DRAWER_WIDTH = 320
+
+export default function AdminDrawer() {
+  const drawerOpen = useIndexingStore((s) => s.drawerOpen)
+  const setDrawerOpen = useIndexingStore((s) => s.setDrawerOpen)
+  const status = useIndexingStore((s) => s.status)
+  const documentCount = useIndexingStore((s) => s.documentCount)
+  const chunkCount = useIndexingStore((s) => s.chunkCount)
+  const message = useIndexingStore((s) => s.message)
+  const timestamp = useIndexingStore((s) => s.timestamp)
+  const trigger = useIndexingStore((s) => s.triggerIndexing)
+
+  const isRunning = status === 'RUNNING'
+
+  return (
+    <Drawer
+      anchor="right"
+      open={drawerOpen}
+      onClose={() => setDrawerOpen(false)}
+      sx={{ '& .MuiDrawer-paper': { width: DRAWER_WIDTH } }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            p: 2,
+          }}
+        >
+          <Typography variant="h6" fontWeight={700}>
+            Admin
+          </Typography>
+          <IconButton onClick={() => setDrawerOpen(false)} aria-label="Close admin drawer">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Divider />
+
+        <Box sx={{ p: 2 }}>
+          <Typography variant="overline" color="text.secondary">
+            Document Indexing
+          </Typography>
+
+          <Button
+            variant="contained"
+            startIcon={<PlayArrowIcon />}
+            onClick={trigger}
+            disabled={isRunning}
+            fullWidth
+            sx={{ mt: 1.5, mb: 2 }}
+          >
+            {isRunning ? 'Indexing...' : 'Index Documents'}
+          </Button>
+
+          {isRunning && (
+            <Box sx={{ mb: 2 }}>
+              <LinearProgress sx={{ mb: 1 }} />
+              <Typography variant="body2" color="text.secondary">
+                {message ?? `Indexing... ${documentCount} documents processed`}
+              </Typography>
+            </Box>
+          )}
+
+          {status !== 'IDLE' && !isRunning && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                Last indexing: {status === 'COMPLETED' ? 'Completed' : 'Failed'}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Documents: {documentCount} | Chunks: {chunkCount}
+              </Typography>
+              {timestamp && (
+                <Typography variant="caption" color="text.secondary">
+                  {new Date(timestamp).toLocaleString()}
+                </Typography>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Drawer>
+  )
+}

--- a/frontend/src/components/admin/AdminDrawerToggle.test.tsx
+++ b/frontend/src/components/admin/AdminDrawerToggle.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { renderWithProviders } from '../../test/test-utils'
+import AdminDrawerToggle from './AdminDrawerToggle'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+describe('AdminDrawerToggle', () => {
+  beforeEach(() => {
+    useIndexingStore.setState({ drawerOpen: false })
+  })
+
+  it('renders toggle button', () => {
+    renderWithProviders(<AdminDrawerToggle />)
+
+    expect(screen.getByLabelText('Toggle admin drawer')).toBeInTheDocument()
+  })
+
+  it('toggles drawer on click', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AdminDrawerToggle />)
+
+    await user.click(screen.getByLabelText('Toggle admin drawer'))
+    expect(useIndexingStore.getState().drawerOpen).toBe(true)
+
+    await user.click(screen.getByLabelText('Toggle admin drawer'))
+    expect(useIndexingStore.getState().drawerOpen).toBe(false)
+  })
+})

--- a/frontend/src/components/admin/AdminDrawerToggle.tsx
+++ b/frontend/src/components/admin/AdminDrawerToggle.tsx
@@ -1,0 +1,13 @@
+import IconButton from '@mui/material/IconButton'
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+export default function AdminDrawerToggle() {
+  const toggleDrawer = useIndexingStore((s) => s.toggleDrawer)
+
+  return (
+    <IconButton onClick={toggleDrawer} aria-label="Toggle admin drawer" sx={{ ml: 'auto' }}>
+      <AdminPanelSettingsIcon />
+    </IconButton>
+  )
+}

--- a/frontend/src/components/admin/IndexingSnackbar.test.tsx
+++ b/frontend/src/components/admin/IndexingSnackbar.test.tsx
@@ -1,0 +1,39 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { renderWithProviders } from '../../test/test-utils'
+import IndexingSnackbar from './IndexingSnackbar'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+describe('IndexingSnackbar', () => {
+  beforeEach(() => {
+    useIndexingStore.setState({
+      snackbar: { open: false, message: '', severity: 'success' },
+    })
+  })
+
+  it('does not show snackbar when closed', () => {
+    renderWithProviders(<IndexingSnackbar />)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows success snackbar', () => {
+    useIndexingStore.setState({
+      snackbar: { open: true, message: 'Indexing completed: 42 documents', severity: 'success' },
+    })
+    renderWithProviders(<IndexingSnackbar />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Indexing completed: 42 documents')).toBeInTheDocument()
+  })
+
+  it('shows error snackbar', () => {
+    useIndexingStore.setState({
+      snackbar: { open: true, message: 'Indexing failed', severity: 'error' },
+    })
+    renderWithProviders(<IndexingSnackbar />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Indexing failed')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/admin/IndexingSnackbar.tsx
+++ b/frontend/src/components/admin/IndexingSnackbar.tsx
@@ -1,0 +1,21 @@
+import Alert from '@mui/material/Alert'
+import Snackbar from '@mui/material/Snackbar'
+import { useIndexingStore } from '../../stores/indexingStore'
+
+export default function IndexingSnackbar() {
+  const snackbar = useIndexingStore((s) => s.snackbar)
+  const closeSnackbar = useIndexingStore((s) => s.closeSnackbar)
+
+  return (
+    <Snackbar
+      open={snackbar.open}
+      autoHideDuration={6000}
+      onClose={closeSnackbar}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert onClose={closeSnackbar} severity={snackbar.severity} variant="filled">
+        {snackbar.message}
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/frontend/src/layouts/AppShell.tsx
+++ b/frontend/src/layouts/AppShell.tsx
@@ -5,6 +5,9 @@ import { useTheme } from '@mui/material/styles'
 import { Outlet } from 'react-router-dom'
 import Sidebar, { SIDEBAR_WIDTH } from './Sidebar'
 import MobileHeader from './MobileHeader'
+import AdminDrawer from '../components/admin/AdminDrawer'
+import AdminDrawerToggle from '../components/admin/AdminDrawerToggle'
+import IndexingSnackbar from '../components/admin/IndexingSnackbar'
 import { useUiStore } from '../stores/uiStore'
 
 export default function AppShell() {
@@ -41,8 +44,21 @@ export default function AppShell() {
         }}
       >
         <MobileHeader />
+        <Box
+          sx={{
+            display: { xs: 'none', md: 'flex' },
+            justifyContent: 'flex-end',
+            px: 1,
+            py: 0.5,
+          }}
+        >
+          <AdminDrawerToggle />
+        </Box>
         <Outlet />
       </Box>
+
+      <AdminDrawer />
+      <IndexingSnackbar />
     </Box>
   )
 }

--- a/frontend/src/layouts/MobileHeader.tsx
+++ b/frontend/src/layouts/MobileHeader.tsx
@@ -1,8 +1,10 @@
 import AppBar from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
 import MenuIcon from '@mui/icons-material/Menu'
+import AdminDrawerToggle from '../components/admin/AdminDrawerToggle'
 import { useUiStore } from '../stores/uiStore'
 
 export default function MobileHeader() {
@@ -26,6 +28,8 @@ export default function MobileHeader() {
         <Typography variant="h6" fontWeight={700} sx={{ ml: 1 }}>
           OPAA
         </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <AdminDrawerToggle />
       </Toolbar>
     </AppBar>
   )

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -4,13 +4,24 @@ export const mockHealthResponse: HealthResponse = {
   status: 'UP',
 }
 
-export const mockIndexingStatus: IndexingStatusResponse = {
+export const mockIndexingIdle: IndexingStatusResponse = {
+  status: 'IDLE',
+  documentCount: 0,
+  chunkCount: 0,
+  message: null,
+  timestamp: '2025-01-15T10:00:00Z',
+}
+
+export const mockIndexingCompleted: IndexingStatusResponse = {
   status: 'COMPLETED',
   documentCount: 42,
   chunkCount: 1337,
   message: 'Indexing completed successfully',
   timestamp: '2025-01-15T10:30:00Z',
 }
+
+/** @deprecated Use mockIndexingCompleted instead */
+export const mockIndexingStatus = mockIndexingCompleted
 
 export const mockQueryResponses: QueryResponse[] = [
   {

--- a/frontend/src/mocks/handlers.test.ts
+++ b/frontend/src/mocks/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mockIndexingStatus, mockQueryResponses } from './fixtures'
+import { mockQueryResponses } from './fixtures'
 
 describe('MSW Handlers', () => {
   describe('GET /api/health', () => {
@@ -13,24 +13,36 @@ describe('MSW Handlers', () => {
   })
 
   describe('POST /api/v1/indexing/trigger', () => {
-    it('returns indexing status', async () => {
+    it('returns RUNNING status', async () => {
       const response = await fetch('/api/v1/indexing/trigger', { method: 'POST' })
       const data = await response.json()
 
       expect(response.status).toBe(200)
-      expect(data.status).toBe(mockIndexingStatus.status)
-      expect(data.documentCount).toBe(mockIndexingStatus.documentCount)
-      expect(data.chunkCount).toBe(mockIndexingStatus.chunkCount)
+      expect(data.status).toBe('RUNNING')
+      expect(data.documentCount).toBe(0)
     })
   })
 
   describe('GET /api/v1/indexing/status', () => {
-    it('returns indexing status', async () => {
+    it('returns IDLE when no indexing has been triggered', async () => {
       const response = await fetch('/api/v1/indexing/status')
       const data = await response.json()
 
       expect(response.status).toBe(200)
+      expect(data.status).toBe('IDLE')
+    })
+
+    it('progresses to COMPLETED after trigger and multiple polls', async () => {
+      await fetch('/api/v1/indexing/trigger', { method: 'POST' })
+
+      let data
+      for (let i = 0; i < 5; i++) {
+        const response = await fetch('/api/v1/indexing/status')
+        data = await response.json()
+      }
+
       expect(data.status).toBe('COMPLETED')
+      expect(data.documentCount).toBe(42)
     })
   })
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,11 +1,35 @@
 import { http, HttpResponse } from 'msw'
 import {
   mockHealthResponse,
-  mockIndexingStatus,
+  mockIndexingIdle,
+  mockIndexingCompleted,
   getRandomMockResponse,
   mockErrorResponse,
 } from './fixtures'
-import type { QueryRequest } from '../types/api'
+import type { IndexingStatusResponse, QueryRequest } from '../types/api'
+
+let indexingPollCount = 0
+let indexingActive = false
+
+export function resetIndexingState() {
+  indexingPollCount = 0
+  indexingActive = false
+}
+
+const INDEXING_POLL_STEPS = 5
+const TOTAL_DOCUMENTS = 42
+const TOTAL_CHUNKS = 1337
+
+function getRunningStatus(step: number): IndexingStatusResponse {
+  const progress = Math.min(step / INDEXING_POLL_STEPS, 1)
+  return {
+    status: 'RUNNING',
+    documentCount: Math.round(TOTAL_DOCUMENTS * progress),
+    chunkCount: Math.round(TOTAL_CHUNKS * progress),
+    message: `Indexing in progress... ${Math.round(TOTAL_DOCUMENTS * progress)} documents processed`,
+    timestamp: new Date().toISOString(),
+  }
+}
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -13,11 +37,24 @@ export const handlers = [
   }),
 
   http.post('/api/v1/indexing/trigger', () => {
-    return HttpResponse.json(mockIndexingStatus)
+    indexingPollCount = 0
+    indexingActive = true
+    return HttpResponse.json(getRunningStatus(0))
   }),
 
   http.get('/api/v1/indexing/status', () => {
-    return HttpResponse.json(mockIndexingStatus)
+    if (!indexingActive) {
+      return HttpResponse.json(mockIndexingIdle)
+    }
+
+    indexingPollCount++
+
+    if (indexingPollCount >= INDEXING_POLL_STEPS) {
+      indexingActive = false
+      return HttpResponse.json(mockIndexingCompleted)
+    }
+
+    return HttpResponse.json(getRunningStatus(indexingPollCount))
   }),
 
   http.post('/api/v1/query', async ({ request }) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,11 @@
 import axios, { AxiosError } from 'axios'
-import type { ErrorResponse, HealthResponse, QueryRequest, QueryResponse } from '../types/api'
+import type {
+  ErrorResponse,
+  HealthResponse,
+  IndexingStatusResponse,
+  QueryRequest,
+  QueryResponse,
+} from '../types/api'
 
 const client = axios.create({
   baseURL: '/api',
@@ -26,6 +32,24 @@ export async function sendQuery(question: string): Promise<QueryResponse> {
   try {
     const request: QueryRequest = { question }
     const { data } = await client.post<QueryResponse>('/v1/query', request)
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function triggerIndexing(): Promise<IndexingStatusResponse> {
+  try {
+    const { data } = await client.post<IndexingStatusResponse>('/v1/indexing/trigger')
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function getIndexingStatus(): Promise<IndexingStatusResponse> {
+  try {
+    const { data } = await client.get<IndexingStatusResponse>('/v1/indexing/status')
     return data
   } catch (err) {
     normalizeError(err)

--- a/frontend/src/stores/indexingStore.test.ts
+++ b/frontend/src/stores/indexingStore.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { useIndexingStore } from './indexingStore'
+
+describe('indexingStore', () => {
+  beforeEach(() => {
+    useIndexingStore.setState({
+      status: 'IDLE',
+      documentCount: 0,
+      chunkCount: 0,
+      message: null,
+      timestamp: null,
+      isPolling: false,
+      drawerOpen: false,
+      snackbar: { open: false, message: '', severity: 'success' },
+    })
+  })
+
+  afterEach(() => {
+    useIndexingStore.getState().stopPolling()
+  })
+
+  it('starts with idle state', () => {
+    const state = useIndexingStore.getState()
+    expect(state.status).toBe('IDLE')
+    expect(state.isPolling).toBe(false)
+    expect(state.drawerOpen).toBe(false)
+  })
+
+  it('toggles drawer', () => {
+    useIndexingStore.getState().toggleDrawer()
+    expect(useIndexingStore.getState().drawerOpen).toBe(true)
+
+    useIndexingStore.getState().toggleDrawer()
+    expect(useIndexingStore.getState().drawerOpen).toBe(false)
+  })
+
+  it('sets drawer open state', () => {
+    useIndexingStore.getState().setDrawerOpen(true)
+    expect(useIndexingStore.getState().drawerOpen).toBe(true)
+
+    useIndexingStore.getState().setDrawerOpen(false)
+    expect(useIndexingStore.getState().drawerOpen).toBe(false)
+  })
+
+  it('closes snackbar', () => {
+    useIndexingStore.setState({
+      snackbar: { open: true, message: 'Test', severity: 'success' },
+    })
+    useIndexingStore.getState().closeSnackbar()
+    expect(useIndexingStore.getState().snackbar.open).toBe(false)
+  })
+
+  it('triggers indexing and starts polling', async () => {
+    vi.useFakeTimers()
+
+    await useIndexingStore.getState().triggerIndexing()
+
+    const state = useIndexingStore.getState()
+    expect(state.status).toBe('RUNNING')
+    expect(state.isPolling).toBe(true)
+
+    useIndexingStore.getState().stopPolling()
+    vi.useRealTimers()
+  })
+
+  it('stops polling', async () => {
+    vi.useFakeTimers()
+
+    await useIndexingStore.getState().triggerIndexing()
+    expect(useIndexingStore.getState().isPolling).toBe(true)
+
+    useIndexingStore.getState().stopPolling()
+    expect(useIndexingStore.getState().isPolling).toBe(false)
+
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/stores/indexingStore.ts
+++ b/frontend/src/stores/indexingStore.ts
@@ -1,0 +1,124 @@
+import { create } from 'zustand'
+import type { IndexingStatus } from '../types/api'
+import { triggerIndexing, getIndexingStatus } from '../services/api'
+
+const POLL_INTERVAL_MS = 2000
+
+type SnackbarSeverity = 'success' | 'error'
+
+interface Snackbar {
+  open: boolean
+  message: string
+  severity: SnackbarSeverity
+}
+
+interface IndexingState {
+  status: IndexingStatus
+  documentCount: number
+  chunkCount: number
+  message: string | null
+  timestamp: string | null
+  isPolling: boolean
+  drawerOpen: boolean
+  snackbar: Snackbar
+
+  triggerIndexing: () => Promise<void>
+  pollStatus: () => void
+  stopPolling: () => void
+  toggleDrawer: () => void
+  setDrawerOpen: (open: boolean) => void
+  closeSnackbar: () => void
+}
+
+let pollIntervalId: ReturnType<typeof setInterval> | null = null
+
+export const useIndexingStore = create<IndexingState>((set, get) => ({
+  status: 'IDLE',
+  documentCount: 0,
+  chunkCount: 0,
+  message: null,
+  timestamp: null,
+  isPolling: false,
+  drawerOpen: false,
+  snackbar: { open: false, message: '', severity: 'success' },
+
+  triggerIndexing: async () => {
+    try {
+      const response = await triggerIndexing()
+      set({
+        status: response.status,
+        documentCount: response.documentCount,
+        chunkCount: response.chunkCount,
+        message: response.message,
+        timestamp: response.timestamp,
+      })
+      get().pollStatus()
+    } catch (err) {
+      set({
+        status: 'FAILED',
+        message: err instanceof Error ? err.message : 'Failed to trigger indexing',
+        snackbar: {
+          open: true,
+          message: 'Failed to trigger indexing',
+          severity: 'error',
+        },
+      })
+    }
+  },
+
+  pollStatus: () => {
+    if (get().isPolling) return
+
+    set({ isPolling: true })
+
+    pollIntervalId = setInterval(async () => {
+      try {
+        const response = await getIndexingStatus()
+        set({
+          status: response.status,
+          documentCount: response.documentCount,
+          chunkCount: response.chunkCount,
+          message: response.message,
+          timestamp: response.timestamp,
+        })
+
+        if (response.status === 'COMPLETED' || response.status === 'FAILED') {
+          get().stopPolling()
+          set({
+            snackbar: {
+              open: true,
+              message:
+                response.status === 'COMPLETED'
+                  ? `Indexing completed: ${response.documentCount} documents processed`
+                  : (response.message ?? 'Indexing failed'),
+              severity: response.status === 'COMPLETED' ? 'success' : 'error',
+            },
+          })
+        }
+      } catch {
+        get().stopPolling()
+        set({
+          status: 'FAILED',
+          message: 'Failed to fetch indexing status',
+          snackbar: {
+            open: true,
+            message: 'Failed to fetch indexing status',
+            severity: 'error',
+          },
+        })
+      }
+    }, POLL_INTERVAL_MS)
+  },
+
+  stopPolling: () => {
+    if (pollIntervalId) {
+      clearInterval(pollIntervalId)
+      pollIntervalId = null
+    }
+    set({ isPolling: false })
+  },
+
+  toggleDrawer: () => set((s) => ({ drawerOpen: !s.drawerOpen })),
+  setDrawerOpen: (open) => set({ drawerOpen: open }),
+  closeSnackbar: () => set((s) => ({ snackbar: { ...s.snackbar, open: false } })),
+}))

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,7 +1,11 @@
 import '@testing-library/jest-dom/vitest'
 import { beforeAll, afterEach, afterAll } from 'vitest'
 import { server } from '../mocks/server'
+import { resetIndexingState } from '../mocks/handlers'
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  resetIndexingState()
+})
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary

- Add right-side admin drawer (320px) with document indexing controls
- Implement indexing trigger button, status polling (2s interval), and progress display (LinearProgress)
- Show snackbar notifications on indexing completion/failure
- Make MSW mocks stateful: trigger sets RUNNING, polls increment progress, completes after 5 polls
- Admin toggle accessible on both desktop (top-right bar) and mobile (in AppBar)

Closes #15

## Test plan

- [ ] Run `VITE_ENABLE_MOCKS=true npm run dev`, click admin icon, trigger indexing, verify progress and snackbar
- [ ] Verify button is disabled during indexing
- [ ] Verify polling stops on completion
- [ ] Test on mobile viewport (admin toggle in header bar)
- [ ] Run `npm run test -- --run` — all 62 tests pass
- [ ] Run `npm run lint && npm run format:check && npm run build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> 🤖 This PR was authored with the help of an AI coding agent (Claude Code).
> All code has been reviewed and validated by the agent before submission.