### PR TITLE
feat(query): deduplicate source references by file name

### DIFF
--- a/backend/src/main/java/io/opaa/query/QueryService.java
+++ b/backend/src/main/java/io/opaa/query/QueryService.java
@@ -1,8 +1,11 @@
 package io.opaa.query;
 
+import static java.util.stream.Collectors.toMap;
+
 import io.opaa.api.dto.QueryMetadata;
 import io.opaa.api.dto.QueryResponse;
 import io.opaa.api.dto.SourceReference;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +63,14 @@ public class QueryService {
               String excerpt = truncateExcerpt(chunk.getText(), 200);
               return new SourceReference(fileName, score, excerpt);
             })
+        .collect(
+            toMap(
+                SourceReference::fileName,
+                source -> source,
+                (a, b) -> a.relevanceScore() >= b.relevanceScore() ? a : b,
+                LinkedHashMap::new))
+        .values()
+        .stream()
         .toList();
   }
 

--- a/backend/src/test/java/io/opaa/query/QueryServiceTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryServiceTest.java
@@ -100,6 +100,95 @@ class QueryServiceTest {
   }
 
   @Test
+  void queryDeduplicatesSourcesByFileName() {
+    var chunk1 =
+        Document.builder()
+            .text("High relevance chunk")
+            .metadata(Map.of("file_name", "report.pdf"))
+            .score(0.9)
+            .build();
+    var chunk2 =
+        Document.builder()
+            .text("Lower relevance chunk")
+            .metadata(Map.of("file_name", "report.pdf"))
+            .score(0.7)
+            .build();
+    var chunk3 =
+        Document.builder()
+            .text("Readme content")
+            .metadata(Map.of("file_name", "readme.md"))
+            .score(0.8)
+            .build();
+
+    when(vectorStore.similaritySearch(any(SearchRequest.class)))
+        .thenReturn(List.of(chunk1, chunk2, chunk3));
+
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
+    when(answerGenerationService.generateAnswer(any(), any())).thenReturn(chatResponse);
+
+    QueryResponse response = queryService.query("Question");
+
+    assertThat(response.sources()).hasSize(2);
+    assertThat(response.sources().get(0).fileName()).isEqualTo("report.pdf");
+    assertThat(response.sources().get(0).relevanceScore()).isEqualTo(0.9);
+    assertThat(response.sources().get(1).fileName()).isEqualTo("readme.md");
+  }
+
+  @Test
+  void queryKeepsHighestScoreRegardlessOfOrder() {
+    var lowScoreFirst =
+        Document.builder()
+            .text("Low score")
+            .metadata(Map.of("file_name", "data.csv"))
+            .score(0.6)
+            .build();
+    var highScoreSecond =
+        Document.builder()
+            .text("High score")
+            .metadata(Map.of("file_name", "data.csv"))
+            .score(0.95)
+            .build();
+
+    when(vectorStore.similaritySearch(any(SearchRequest.class)))
+        .thenReturn(List.of(lowScoreFirst, highScoreSecond));
+
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
+    when(answerGenerationService.generateAnswer(any(), any())).thenReturn(chatResponse);
+
+    QueryResponse response = queryService.query("Question");
+
+    assertThat(response.sources()).hasSize(1);
+    assertThat(response.sources().getFirst().relevanceScore()).isEqualTo(0.95);
+  }
+
+  @Test
+  void queryUsesExcerptFromHighestScoringChunk() {
+    var lowScore =
+        Document.builder()
+            .text("Wrong excerpt")
+            .metadata(Map.of("file_name", "notes.txt"))
+            .score(0.5)
+            .build();
+    var highScore =
+        Document.builder()
+            .text("Correct excerpt")
+            .metadata(Map.of("file_name", "notes.txt"))
+            .score(0.99)
+            .build();
+
+    when(vectorStore.similaritySearch(any(SearchRequest.class)))
+        .thenReturn(List.of(lowScore, highScore));
+
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
+    when(answerGenerationService.generateAnswer(any(), any())).thenReturn(chatResponse);
+
+    QueryResponse response = queryService.query("Question");
+
+    assertThat(response.sources()).hasSize(1);
+    assertThat(response.sources().getFirst().excerpt()).isEqualTo("Correct excerpt");
+  }
+
+  @Test
   void queryPassesSearchRequestWithCorrectParameters() {
     when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
 

--- a/docs/features/data-indexing-rag.md
+++ b/docs/features/data-indexing-rag.md
@@ -317,7 +317,8 @@ When a user asks a question:
 2. **Vector Search:** Find top-K similar chunks (typically 20-50)
 3. **Permission Filtering:** Remove chunks user doesn't have access to
 4. **Deduplication:** Remove duplicate information from same document
-5. **Re-ranking:** Score results by relevance
+5. **Source Deduplication:** When multiple chunks originate from the same file, only the chunk with the highest relevance score is kept as source reference (implemented in `QueryService.mapSources()`)
+6. **Re-ranking:** Score results by relevance
 
 ### Retrieval Configuration
 
@@ -504,7 +505,7 @@ System scales to:
 - Should we support real-time indexing (as documents change) vs. scheduled batch?
 - Should re-ranking use a learned model or simple scoring?
 - Should we support document clustering (for discovering related docs automatically)?
-- Should we offer semantic deduplication (remove redundant documents automatically)?
+- Should we offer semantic deduplication (remove redundant documents automatically)? *(Note: basic source-reference deduplication by file name is already implemented — see Issue #42)*
 - How to handle very large documents (100K+ pages)?
 - Should we support hybrid retrieval (vector + keyword search together)?
 - Should there be storage quotas per user or per workspace for uploaded documents?


### PR DESCRIPTION
## Summary

- Deduplicate source references in `QueryService.mapSources()` by grouping chunks by `fileName` and keeping only the one with the highest `relevanceScore`
- Uses `Collectors.toMap()` with merge function and `LinkedHashMap` for stable ordering
- Updated RAG feature spec to document the new source deduplication step

Closes #42

## Changes

| File | Change |
|---|---|
| `QueryService.java` | `mapSources()` deduplicates by `fileName`, keeps highest score |
| `QueryServiceTest.java` | 3 new tests: dedup, score ordering, excerpt correctness |
| `data-indexing-rag.md` | Documented source deduplication in retrieval pipeline |

## Test plan

- [x] `queryDeduplicatesSourcesByFileName` — 2 chunks same file → 1 source with highest score
- [x] `queryKeepsHighestScoreRegardlessOfOrder` — low score first, high second → high wins
- [x] `queryUsesExcerptFromHighestScoringChunk` — excerpt from best chunk preserved
- [x] All existing tests still pass
- [x] Full backend build green
- [x] Frontend build + lint + tests green

### AI Contribution Disclosure

This PR was implemented with the assistance of an AI agent (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)