### PR TITLE
feat(indexing): skip unchanged documents using SHA-256 checksum

### DIFF
--- a/backend/src/main/java/io/opaa/api/IndexingController.java
+++ b/backend/src/main/java/io/opaa/api/IndexingController.java
@@ -43,7 +43,7 @@ public class IndexingController {
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(
             new IndexingStatusResponse(
-                IndexingStatus.RUNNING, 0, 0, ex.getMessage(), Instant.now()));
+                IndexingStatus.RUNNING, 0, 0, 0, ex.getMessage(), Instant.now()));
   }
 
   @GetMapping("/status")
@@ -53,7 +53,7 @@ public class IndexingController {
         .map(this::toResponse)
         .orElse(
             new IndexingStatusResponse(
-                IndexingStatus.IDLE, 0, 0, "No indexing job found", Instant.now()));
+                IndexingStatus.IDLE, 0, 0, 0, "No indexing job found", Instant.now()));
   }
 
   private IndexingStatusResponse toResponse(IndexingJob job) {
@@ -65,6 +65,8 @@ public class IndexingController {
               "Indexing completed: "
                   + job.getDocumentsProcessed()
                   + " processed, "
+                  + job.getDocumentsSkipped()
+                  + " skipped, "
                   + job.getDocumentsFailed()
                   + " failed";
           case FAILED -> "Indexing failed: " + job.getErrorMessage();
@@ -73,6 +75,7 @@ public class IndexingController {
         status,
         job.getDocumentsProcessed(),
         job.getDocumentsTotal(),
+        job.getDocumentsSkipped(),
         message,
         job.getCompletedAt() != null ? job.getCompletedAt() : job.getStartedAt());
   }

--- a/backend/src/main/java/io/opaa/api/MockIndexingController.java
+++ b/backend/src/main/java/io/opaa/api/MockIndexingController.java
@@ -17,12 +17,12 @@ public class MockIndexingController {
   @PostMapping("/trigger")
   public IndexingStatusResponse triggerIndexing() {
     return new IndexingStatusResponse(
-        IndexingStatus.COMPLETED, 42, 42, "Indexing completed successfully", Instant.now());
+        IndexingStatus.COMPLETED, 42, 42, 0, "Indexing completed successfully", Instant.now());
   }
 
   @GetMapping("/status")
   public IndexingStatusResponse getIndexingStatus() {
     return new IndexingStatusResponse(
-        IndexingStatus.COMPLETED, 42, 42, "Indexing completed successfully", Instant.now());
+        IndexingStatus.COMPLETED, 42, 42, 0, "Indexing completed successfully", Instant.now());
   }
 }

--- a/backend/src/main/java/io/opaa/api/dto/IndexingStatusResponse.java
+++ b/backend/src/main/java/io/opaa/api/dto/IndexingStatusResponse.java
@@ -6,5 +6,6 @@ public record IndexingStatusResponse(
     IndexingStatus status,
     int documentCount,
     int totalDocuments,
+    int documentsSkipped,
     String message,
     Instant timestamp) {}

--- a/backend/src/main/java/io/opaa/indexing/AsyncIndexingExecutor.java
+++ b/backend/src/main/java/io/opaa/indexing/AsyncIndexingExecutor.java
@@ -32,6 +32,7 @@ public class AsyncIndexingExecutor {
   public void execute(UUID jobId) {
     int processed = 0;
     int failed = 0;
+    int skipped = 0;
 
     try {
       Path documentDir = Path.of(properties.documentPath());
@@ -43,18 +44,22 @@ public class AsyncIndexingExecutor {
       for (Path file : files) {
         String fileName = file.getFileName().toString();
         try {
-          log.info("Indexing started: {}", fileName);
-          fileProcessingService.processFile(file);
-          processed++;
-          log.info("Indexing completed: {}", fileName);
+          log.info("Processing: {}", fileName);
+          FileProcessingResult result = fileProcessingService.processFile(file);
+          if (result == FileProcessingResult.SKIPPED) {
+            skipped++;
+          } else {
+            processed++;
+            log.info("Indexing completed: {}", fileName);
+          }
         } catch (Exception e) {
           log.error("Failed to process file: {}", fileName, e);
           failed++;
         }
-        indexingJobService.updateProgress(jobId, processed, failed);
+        indexingJobService.updateProgress(jobId, processed, failed, skipped);
       }
 
-      indexingJobService.completeJob(jobId, processed, failed);
+      indexingJobService.completeJob(jobId, processed, failed, skipped);
     } catch (IOException e) {
       log.error("Failed to discover files", e);
       indexingJobService.failJob(jobId, e.getMessage());

--- a/backend/src/main/java/io/opaa/indexing/ChecksumService.java
+++ b/backend/src/main/java/io/opaa/indexing/ChecksumService.java
@@ -1,0 +1,26 @@
+package io.opaa.indexing;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public class ChecksumService {
+
+  public String computeSha256(Path file) throws IOException {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (InputStream is = Files.newInputStream(file);
+          DigestInputStream dis = new DigestInputStream(is, digest)) {
+        dis.readAllBytes();
+      }
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm not available", e);
+    }
+  }
+}

--- a/backend/src/main/java/io/opaa/indexing/Document.java
+++ b/backend/src/main/java/io/opaa/indexing/Document.java
@@ -33,6 +33,9 @@ public class Document {
   @Column(name = "indexed_at")
   private Instant indexedAt;
 
+  @Column(name = "checksum", length = 64)
+  private String checksum;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)
   private DocumentStatus status = DocumentStatus.PENDING;
@@ -90,5 +93,13 @@ public class Document {
 
   public void setStatus(DocumentStatus status) {
     this.status = status;
+  }
+
+  public String getChecksum() {
+    return checksum;
+  }
+
+  public void setChecksum(String checksum) {
+    this.checksum = checksum;
   }
 }

--- a/backend/src/main/java/io/opaa/indexing/FileProcessingResult.java
+++ b/backend/src/main/java/io/opaa/indexing/FileProcessingResult.java
@@ -1,0 +1,6 @@
+package io.opaa.indexing;
+
+public enum FileProcessingResult {
+  PROCESSED,
+  SKIPPED
+}

--- a/backend/src/main/java/io/opaa/indexing/FileProcessingService.java
+++ b/backend/src/main/java/io/opaa/indexing/FileProcessingService.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -18,32 +19,44 @@ public class FileProcessingService {
   private final ChunkingService chunkingService;
   private final DocumentRepository documentRepository;
   private final VectorStore vectorStore;
+  private final ChecksumService checksumService;
 
   public FileProcessingService(
       DocumentService documentService,
       ChunkingService chunkingService,
       DocumentRepository documentRepository,
-      VectorStore vectorStore) {
+      VectorStore vectorStore,
+      ChecksumService checksumService) {
     this.documentService = documentService;
     this.chunkingService = chunkingService;
     this.documentRepository = documentRepository;
     this.vectorStore = vectorStore;
+    this.checksumService = checksumService;
   }
 
-  public void processFile(Path file) throws IOException {
+  public FileProcessingResult processFile(Path file) throws IOException {
     String filePath = file.toAbsolutePath().toString();
     String fileName = file.getFileName().toString();
+
+    // Compute checksum before any processing
+    String checksum = checksumService.computeSha256(file);
+
+    // Check if document already exists
+    Optional<Document> existing = documentRepository.findByFilePath(filePath);
+    if (existing.isPresent()) {
+      Document existingDoc = existing.get();
+      if (checksum.equals(existingDoc.getChecksum())
+          && existingDoc.getStatus() == DocumentStatus.INDEXED) {
+        log.info("Skipping unchanged document: {}", fileName);
+        return FileProcessingResult.SKIPPED;
+      }
+      // Document changed or was not successfully indexed — delete old data
+      vectorStore.delete("document_id == '" + existingDoc.getId().toString() + "'");
+      documentRepository.delete(existingDoc);
+    }
+
     String contentType = Files.probeContentType(file);
     long fileSize = Files.size(file);
-
-    // Check if document already exists and delete old chunks
-    documentRepository
-        .findByFilePath(filePath)
-        .ifPresent(
-            existing -> {
-              vectorStore.delete("document_id == '" + existing.getId().toString() + "'");
-              documentRepository.delete(existing);
-            });
 
     var doc = new Document(fileName, filePath, contentType, fileSize);
     doc = documentRepository.save(doc);
@@ -55,7 +68,7 @@ public class FileProcessingService {
         log.warn("No content extracted from: {}", file);
         doc.setStatus(DocumentStatus.FAILED);
         documentRepository.save(doc);
-        return;
+        return FileProcessingResult.PROCESSED;
       }
 
       // Chunk the parsed content
@@ -68,6 +81,7 @@ public class FileProcessingService {
 
       doc.setChunkCount(chunks.size());
       doc.setIndexedAt(Instant.now());
+      doc.setChecksum(checksum);
       doc.setStatus(DocumentStatus.INDEXED);
       documentRepository.save(doc);
     } catch (Exception e) {
@@ -75,6 +89,8 @@ public class FileProcessingService {
       documentRepository.save(doc);
       throw e;
     }
+
+    return FileProcessingResult.PROCESSED;
   }
 
   private void storeChunks(

--- a/backend/src/main/java/io/opaa/indexing/IndexingConfiguration.java
+++ b/backend/src/main/java/io/opaa/indexing/IndexingConfiguration.java
@@ -29,6 +29,11 @@ public class IndexingConfiguration {
   }
 
   @Bean
+  ChecksumService checksumService() {
+    return new ChecksumService();
+  }
+
+  @Bean
   IndexingJobService indexingJobService(IndexingJobRepository indexingJobRepository) {
     return new IndexingJobService(indexingJobRepository);
   }
@@ -38,9 +43,10 @@ public class IndexingConfiguration {
       DocumentService documentService,
       ChunkingService chunkingService,
       DocumentRepository documentRepository,
-      VectorStore vectorStore) {
+      VectorStore vectorStore,
+      ChecksumService checksumService) {
     return new FileProcessingService(
-        documentService, chunkingService, documentRepository, vectorStore);
+        documentService, chunkingService, documentRepository, vectorStore, checksumService);
   }
 
   @Bean

--- a/backend/src/main/java/io/opaa/indexing/IndexingJob.java
+++ b/backend/src/main/java/io/opaa/indexing/IndexingJob.java
@@ -28,6 +28,9 @@ public class IndexingJob {
   @Column(name = "documents_total")
   private int documentsTotal;
 
+  @Column(name = "documents_skipped")
+  private int documentsSkipped;
+
   @Column(name = "started_at", nullable = false, updatable = false)
   private Instant startedAt;
 
@@ -79,6 +82,14 @@ public class IndexingJob {
 
   public void setDocumentsTotal(int documentsTotal) {
     this.documentsTotal = documentsTotal;
+  }
+
+  public int getDocumentsSkipped() {
+    return documentsSkipped;
+  }
+
+  public void setDocumentsSkipped(int documentsSkipped) {
+    this.documentsSkipped = documentsSkipped;
   }
 
   public Instant getStartedAt() {

--- a/backend/src/main/java/io/opaa/indexing/IndexingJobService.java
+++ b/backend/src/main/java/io/opaa/indexing/IndexingJobService.java
@@ -21,7 +21,8 @@ public class IndexingJobService {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void completeJob(UUID jobId, int documentsProcessed, int documentsFailed) {
+  public void completeJob(
+      UUID jobId, int documentsProcessed, int documentsFailed, int documentsSkipped) {
     var job =
         indexingJobRepository
             .findById(jobId)
@@ -29,6 +30,7 @@ public class IndexingJobService {
     job.setStatus(JobStatus.COMPLETED);
     job.setDocumentsProcessed(documentsProcessed);
     job.setDocumentsFailed(documentsFailed);
+    job.setDocumentsSkipped(documentsSkipped);
     job.setCompletedAt(Instant.now());
     indexingJobRepository.save(job);
   }
@@ -56,13 +58,15 @@ public class IndexingJobService {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void updateProgress(UUID jobId, int documentsProcessed, int documentsFailed) {
+  public void updateProgress(
+      UUID jobId, int documentsProcessed, int documentsFailed, int documentsSkipped) {
     var job =
         indexingJobRepository
             .findById(jobId)
             .orElseThrow(() -> new IllegalArgumentException("Job not found: " + jobId));
     job.setDocumentsProcessed(documentsProcessed);
     job.setDocumentsFailed(documentsFailed);
+    job.setDocumentsSkipped(documentsSkipped);
     indexingJobRepository.save(job);
   }
 

--- a/backend/src/main/resources/db/changelog/changes/005-add-checksum-and-skipped-columns.yaml
+++ b/backend/src/main/resources/db/changelog/changes/005-add-checksum-and-skipped-columns.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-add-checksum-to-documents
+      author: opaa
+      comment: "Add SHA-256 checksum column to documents for skip-unchanged detection"
+      changes:
+        - addColumn:
+            tableName: documents
+            columns:
+              - column:
+                  name: checksum
+                  type: varchar(64)
+      rollback:
+        - dropColumn:
+            tableName: documents
+            columnName: checksum
+
+  - changeSet:
+      id: 007-add-documents-skipped-to-indexing-jobs
+      author: opaa
+      comment: "Add documents_skipped column to indexing_jobs for tracking skipped unchanged documents"
+      changes:
+        - addColumn:
+            tableName: indexing_jobs
+            columns:
+              - column:
+                  name: documents_skipped
+                  type: int
+                  defaultValueNumeric: 0
+      rollback:
+        - dropColumn:
+            tableName: indexing_jobs
+            columnName: documents_skipped

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/changes/003-create-indexing-jobs-table.yaml
   - include:
       file: db/changelog/changes/004-add-documents-total-column.yaml
+  - include:
+      file: db/changelog/changes/005-add-checksum-and-skipped-columns.yaml

--- a/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
@@ -1,5 +1,6 @@
 package io.opaa.api;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,6 +12,7 @@ import io.opaa.indexing.IndexingAlreadyRunningException;
 import io.opaa.indexing.IndexingJob;
 import io.opaa.indexing.IndexingJobService;
 import io.opaa.indexing.JobStatus;
+import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +39,8 @@ class IndexingControllerTest {
         .andExpect(status().isAccepted())
         .andExpect(jsonPath("$.status").value("RUNNING"))
         .andExpect(jsonPath("$.documentCount").value(0))
-        .andExpect(jsonPath("$.totalDocuments").value(0));
+        .andExpect(jsonPath("$.totalDocuments").value(0))
+        .andExpect(jsonPath("$.documentsSkipped").value(0));
   }
 
   @Test
@@ -49,6 +52,7 @@ class IndexingControllerTest {
         .perform(post("/api/v1/indexing/trigger"))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.status").value("RUNNING"))
+        .andExpect(jsonPath("$.documentsSkipped").value(0))
         .andExpect(jsonPath("$.message").value("An indexing job is already running"));
   }
 
@@ -61,6 +65,7 @@ class IndexingControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("IDLE"))
         .andExpect(jsonPath("$.totalDocuments").value(0))
+        .andExpect(jsonPath("$.documentsSkipped").value(0))
         .andExpect(jsonPath("$.message").value("No indexing job found"));
   }
 
@@ -72,6 +77,27 @@ class IndexingControllerTest {
     mockMvc
         .perform(get("/api/v1/indexing/status"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.status").value("RUNNING"));
+        .andExpect(jsonPath("$.status").value("RUNNING"))
+        .andExpect(jsonPath("$.documentsSkipped").value(0));
+  }
+
+  @Test
+  void getStatusReturnsCompletedJobWithSkippedCount() throws Exception {
+    var job = new IndexingJob(JobStatus.RUNNING);
+    job.setStatus(JobStatus.COMPLETED);
+    job.setDocumentsProcessed(10);
+    job.setDocumentsFailed(1);
+    job.setDocumentsSkipped(5);
+    job.setDocumentsTotal(16);
+    job.setCompletedAt(Instant.now());
+    when(indexingJobService.getLatestJob()).thenReturn(Optional.of(job));
+
+    mockMvc
+        .perform(get("/api/v1/indexing/status"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("COMPLETED"))
+        .andExpect(jsonPath("$.documentCount").value(10))
+        .andExpect(jsonPath("$.documentsSkipped").value(5))
+        .andExpect(jsonPath("$.message").value(containsString("5 skipped")));
   }
 }

--- a/backend/src/test/java/io/opaa/api/MockIndexingControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/MockIndexingControllerTest.java
@@ -25,6 +25,7 @@ class MockIndexingControllerTest {
         .andExpect(jsonPath("$.status").value("COMPLETED"))
         .andExpect(jsonPath("$.documentCount").value(42))
         .andExpect(jsonPath("$.totalDocuments").value(42))
+        .andExpect(jsonPath("$.documentsSkipped").value(0))
         .andExpect(jsonPath("$.chunkCount").doesNotExist())
         .andExpect(jsonPath("$.message").value("Indexing completed successfully"))
         .andExpect(jsonPath("$.timestamp").exists());
@@ -37,6 +38,7 @@ class MockIndexingControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("COMPLETED"))
         .andExpect(jsonPath("$.documentCount").value(42))
-        .andExpect(jsonPath("$.totalDocuments").value(42));
+        .andExpect(jsonPath("$.totalDocuments").value(42))
+        .andExpect(jsonPath("$.documentsSkipped").value(0));
   }
 }

--- a/backend/src/test/java/io/opaa/indexing/ChecksumServiceTest.java
+++ b/backend/src/test/java/io/opaa/indexing/ChecksumServiceTest.java
@@ -1,0 +1,68 @@
+package io.opaa.indexing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ChecksumServiceTest {
+
+  private final ChecksumService checksumService = new ChecksumService();
+
+  @Test
+  void computesCorrectSha256ForKnownContent(@TempDir Path tempDir) throws IOException {
+    Path file = tempDir.resolve("test.txt");
+    Files.writeString(file, "hello world");
+
+    String checksum = checksumService.computeSha256(file);
+
+    // Known SHA-256 of "hello world"
+    assertThat(checksum)
+        .isEqualTo("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+  }
+
+  @Test
+  void sameContentProducesSameChecksum(@TempDir Path tempDir) throws IOException {
+    Path file1 = tempDir.resolve("file1.txt");
+    Path file2 = tempDir.resolve("file2.txt");
+    Files.writeString(file1, "identical content");
+    Files.writeString(file2, "identical content");
+
+    assertThat(checksumService.computeSha256(file1))
+        .isEqualTo(checksumService.computeSha256(file2));
+  }
+
+  @Test
+  void differentContentProducesDifferentChecksum(@TempDir Path tempDir) throws IOException {
+    Path file1 = tempDir.resolve("file1.txt");
+    Path file2 = tempDir.resolve("file2.txt");
+    Files.writeString(file1, "content A");
+    Files.writeString(file2, "content B");
+
+    assertThat(checksumService.computeSha256(file1))
+        .isNotEqualTo(checksumService.computeSha256(file2));
+  }
+
+  @Test
+  void throwsIOExceptionForNonExistentFile(@TempDir Path tempDir) {
+    Path nonExistent = tempDir.resolve("does-not-exist.txt");
+
+    assertThatThrownBy(() -> checksumService.computeSha256(nonExistent))
+        .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void returnsHexStringOf64Characters(@TempDir Path tempDir) throws IOException {
+    Path file = tempDir.resolve("test.txt");
+    Files.writeString(file, "any content");
+
+    String checksum = checksumService.computeSha256(file);
+
+    assertThat(checksum).hasSize(64);
+    assertThat(checksum).matches("[0-9a-f]{64}");
+  }
+}

--- a/backend/src/test/java/io/opaa/indexing/DocumentIndexingIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/indexing/DocumentIndexingIntegrationTest.java
@@ -101,12 +101,14 @@ class DocumentIndexingIntegrationTest {
     assertThat(completedJob.getDocumentsProcessed()).isEqualTo(2);
     assertThat(completedJob.getDocumentsTotal()).isEqualTo(2);
     assertThat(completedJob.getDocumentsFailed()).isZero();
+    assertThat(completedJob.getDocumentsSkipped()).isZero();
 
     List<Document> documents = documentRepository.findAll();
     assertThat(documents).hasSize(2);
     assertThat(documents).allMatch(d -> d.getStatus() == DocumentStatus.INDEXED);
     assertThat(documents).allMatch(d -> d.getIndexedAt() != null);
     assertThat(documents).allMatch(d -> d.getChunkCount() > 0);
+    assertThat(documents).allMatch(d -> d.getChecksum() != null && d.getChecksum().length() == 64);
 
     // Verify chunks with embeddings were stored in vector_store
     List<org.springframework.ai.document.Document> results =
@@ -177,6 +179,7 @@ class DocumentIndexingIntegrationTest {
 
     var completedFirstJob = indexingJobRepository.findById(firstJob.getId()).orElseThrow();
     assertThat(completedFirstJob.getDocumentsProcessed()).isEqualTo(1);
+    assertThat(completedFirstJob.getDocumentsSkipped()).isZero();
 
     // Remember initial state
     List<org.springframework.ai.document.Document> initialResults =
@@ -185,6 +188,7 @@ class DocumentIndexingIntegrationTest {
     assertThat(initialResults).isNotEmpty();
     Document initialDoc = documentRepository.findAll().getFirst();
     assertThat(initialDoc.getStatus()).isEqualTo(DocumentStatus.INDEXED);
+    assertThat(initialDoc.getChecksum()).isNotNull();
 
     // Update file and re-index
     Files.writeString(sharedTempDir.resolve("doc.txt"), "Updated content with more text.");
@@ -193,12 +197,14 @@ class DocumentIndexingIntegrationTest {
 
     var completedSecondJob = indexingJobRepository.findById(secondJob.getId()).orElseThrow();
     assertThat(completedSecondJob.getDocumentsProcessed()).isEqualTo(1);
+    assertThat(completedSecondJob.getDocumentsSkipped()).isZero();
     assertThat(documentRepository.count()).isEqualTo(1);
 
     // Verify the document content was actually re-indexed
     Document reindexedDoc = documentRepository.findAll().getFirst();
     assertThat(reindexedDoc.getStatus()).isEqualTo(DocumentStatus.INDEXED);
     assertThat(reindexedDoc.getIndexedAt()).isNotNull();
+    assertThat(reindexedDoc.getChecksum()).isNotEqualTo(initialDoc.getChecksum());
 
     // Verify chunk text was updated via similarity search
     List<org.springframework.ai.document.Document> newResults =
@@ -210,6 +216,33 @@ class DocumentIndexingIntegrationTest {
             .map(org.springframework.ai.document.Document::getText)
             .reduce("", String::concat);
     assertThat(allChunkText).contains("Updated");
+  }
+
+  @Test
+  void skipsUnchangedDocumentsOnReindex() throws IOException {
+    Files.writeString(sharedTempDir.resolve("doc.txt"), "Same content.");
+
+    IndexingJob firstJob = documentIndexingService.triggerIndexing();
+    awaitJobCompletion(firstJob);
+
+    var completedFirstJob = indexingJobRepository.findById(firstJob.getId()).orElseThrow();
+    assertThat(completedFirstJob.getDocumentsProcessed()).isEqualTo(1);
+    assertThat(completedFirstJob.getDocumentsSkipped()).isZero();
+
+    // Re-index without changing the file
+    IndexingJob secondJob = documentIndexingService.triggerIndexing();
+    awaitJobCompletion(secondJob);
+
+    var completedSecondJob = indexingJobRepository.findById(secondJob.getId()).orElseThrow();
+    assertThat(completedSecondJob.getDocumentsProcessed()).isZero();
+    assertThat(completedSecondJob.getDocumentsSkipped()).isEqualTo(1);
+
+    // Document record should still be there, unchanged
+    assertThat(documentRepository.count()).isEqualTo(1);
+    Document doc = documentRepository.findAll().getFirst();
+    assertThat(doc.getStatus()).isEqualTo(DocumentStatus.INDEXED);
+    assertThat(doc.getChecksum()).isNotNull();
+    assertThat(doc.getChecksum()).hasSize(64);
   }
 
   private void awaitJobCompletion(IndexingJob job) {

--- a/backend/src/test/java/io/opaa/indexing/FileProcessingServiceTest.java
+++ b/backend/src/test/java/io/opaa/indexing/FileProcessingServiceTest.java
@@ -1,0 +1,179 @@
+package io.opaa.indexing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.vectorstore.VectorStore;
+
+@ExtendWith(MockitoExtension.class)
+class FileProcessingServiceTest {
+
+  @Mock private DocumentService documentService;
+  @Mock private ChunkingService chunkingService;
+  @Mock private DocumentRepository documentRepository;
+  @Mock private VectorStore vectorStore;
+  @Mock private ChecksumService checksumService;
+
+  @TempDir Path tempDir;
+
+  private FileProcessingService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new FileProcessingService(
+            documentService, chunkingService, documentRepository, vectorStore, checksumService);
+  }
+
+  @Test
+  void firstRunProcessesDocument() throws IOException {
+    Path file = tempDir.resolve("new-doc.txt");
+    Files.writeString(file, "some content");
+
+    when(checksumService.computeSha256(file)).thenReturn("abc123");
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.empty());
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("new-doc.txt"), eq(parsed))).thenReturn(chunks);
+
+    FileProcessingResult result = service.processFile(file);
+
+    assertThat(result).isEqualTo(FileProcessingResult.PROCESSED);
+    verify(documentService).parseDocument(file);
+    verify(chunkingService).chunkDocuments(eq("new-doc.txt"), eq(parsed));
+    verify(vectorStore).add(any());
+
+    // Verify checksum was saved (save is called twice: initial PENDING + final INDEXED)
+    ArgumentCaptor<Document> docCaptor = ArgumentCaptor.forClass(Document.class);
+    verify(documentRepository, org.mockito.Mockito.times(2)).save(docCaptor.capture());
+    Document lastSaved = docCaptor.getAllValues().getLast();
+    assertThat(lastSaved.getChecksum()).isEqualTo("abc123");
+    assertThat(lastSaved.getStatus()).isEqualTo(DocumentStatus.INDEXED);
+  }
+
+  @Test
+  void skipsUnchangedDocumentWithSameChecksumAndIndexedStatus() throws IOException {
+    Path file = tempDir.resolve("unchanged.txt");
+    Files.writeString(file, "same content");
+
+    when(checksumService.computeSha256(file)).thenReturn("matching-checksum");
+
+    Document existingDoc =
+        new Document("unchanged.txt", file.toAbsolutePath().toString(), null, 0L);
+    existingDoc.setChecksum("matching-checksum");
+    existingDoc.setStatus(DocumentStatus.INDEXED);
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.of(existingDoc));
+
+    FileProcessingResult result = service.processFile(file);
+
+    assertThat(result).isEqualTo(FileProcessingResult.SKIPPED);
+    verify(documentService, never()).parseDocument(any());
+    verify(chunkingService, never()).chunkDocuments(anyString(), any());
+    verify(vectorStore, never()).add(any());
+    verify(vectorStore, never()).delete(anyString());
+  }
+
+  @Test
+  void reindexesDocumentWithChangedChecksum() throws IOException {
+    Path file = tempDir.resolve("changed.txt");
+    Files.writeString(file, "new content");
+
+    when(checksumService.computeSha256(file)).thenReturn("new-checksum");
+
+    Document existingDoc = new Document("changed.txt", file.toAbsolutePath().toString(), null, 10L);
+    existingDoc.setChecksum("old-checksum");
+    existingDoc.setStatus(DocumentStatus.INDEXED);
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.of(existingDoc));
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("changed.txt"), eq(parsed))).thenReturn(chunks);
+
+    FileProcessingResult result = service.processFile(file);
+
+    assertThat(result).isEqualTo(FileProcessingResult.PROCESSED);
+    verify(vectorStore).delete("document_id == '" + existingDoc.getId().toString() + "'");
+    verify(documentRepository).delete(existingDoc);
+    verify(documentService).parseDocument(file);
+  }
+
+  @Test
+  void reindexesDocumentWithNullChecksum() throws IOException {
+    Path file = tempDir.resolve("legacy.txt");
+    Files.writeString(file, "legacy content");
+
+    when(checksumService.computeSha256(file)).thenReturn("computed-checksum");
+
+    Document existingDoc = new Document("legacy.txt", file.toAbsolutePath().toString(), null, 10L);
+    existingDoc.setStatus(DocumentStatus.INDEXED);
+    // checksum is null (legacy document without checksum)
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.of(existingDoc));
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("legacy.txt"), eq(parsed))).thenReturn(chunks);
+
+    FileProcessingResult result = service.processFile(file);
+
+    assertThat(result).isEqualTo(FileProcessingResult.PROCESSED);
+    verify(vectorStore).delete("document_id == '" + existingDoc.getId().toString() + "'");
+    verify(documentRepository).delete(existingDoc);
+  }
+
+  @Test
+  void reindexesDocumentWithFailedStatusEvenIfChecksumMatches() throws IOException {
+    Path file = tempDir.resolve("failed.txt");
+    Files.writeString(file, "failed content");
+
+    when(checksumService.computeSha256(file)).thenReturn("same-checksum");
+
+    Document existingDoc = new Document("failed.txt", file.toAbsolutePath().toString(), null, 10L);
+    existingDoc.setChecksum("same-checksum");
+    existingDoc.setStatus(DocumentStatus.FAILED);
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.of(existingDoc));
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("failed.txt"), eq(parsed))).thenReturn(chunks);
+
+    FileProcessingResult result = service.processFile(file);
+
+    assertThat(result).isEqualTo(FileProcessingResult.PROCESSED);
+    verify(documentService).parseDocument(file);
+  }
+}

--- a/backend/src/test/java/io/opaa/indexing/IndexingJobServiceTest.java
+++ b/backend/src/test/java/io/opaa/indexing/IndexingJobServiceTest.java
@@ -42,11 +42,12 @@ class IndexingJobServiceTest {
     when(indexingJobRepository.findById(jobId)).thenReturn(Optional.of(job));
     when(indexingJobRepository.save(any(IndexingJob.class))).thenReturn(job);
 
-    service.completeJob(jobId, 10, 2);
+    service.completeJob(jobId, 10, 2, 5);
 
     assertThat(job.getStatus()).isEqualTo(JobStatus.COMPLETED);
     assertThat(job.getDocumentsProcessed()).isEqualTo(10);
     assertThat(job.getDocumentsFailed()).isEqualTo(2);
+    assertThat(job.getDocumentsSkipped()).isEqualTo(5);
     assertThat(job.getCompletedAt()).isNotNull();
   }
 
@@ -69,7 +70,7 @@ class IndexingJobServiceTest {
     UUID jobId = UUID.randomUUID();
     when(indexingJobRepository.findById(jobId)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.completeJob(jobId, 0, 0))
+    assertThatThrownBy(() -> service.completeJob(jobId, 0, 0, 0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -92,10 +93,11 @@ class IndexingJobServiceTest {
     when(indexingJobRepository.findById(jobId)).thenReturn(Optional.of(job));
     when(indexingJobRepository.save(any(IndexingJob.class))).thenReturn(job);
 
-    service.updateProgress(jobId, 5, 1);
+    service.updateProgress(jobId, 5, 1, 3);
 
     assertThat(job.getDocumentsProcessed()).isEqualTo(5);
     assertThat(job.getDocumentsFailed()).isEqualTo(1);
+    assertThat(job.getDocumentsSkipped()).isEqualTo(3);
     assertThat(job.getStatus()).isEqualTo(JobStatus.RUNNING);
     assertThat(job.getCompletedAt()).isNull();
   }

--- a/frontend/src/components/admin/AdminDrawer.test.tsx
+++ b/frontend/src/components/admin/AdminDrawer.test.tsx
@@ -11,6 +11,7 @@ describe('AdminDrawer', () => {
       status: 'IDLE',
       documentCount: 0,
       totalDocuments: 0,
+      documentsSkipped: 0,
       message: null,
       timestamp: null,
       isPolling: false,
@@ -64,13 +65,14 @@ describe('AdminDrawer', () => {
       status: 'RUNNING',
       totalDocuments: 42,
       documentCount: 10,
+      documentsSkipped: 0,
     })
     renderWithProviders(<AdminDrawer />)
 
     const progressbar = screen.getByRole('progressbar')
     expect(progressbar).toBeInTheDocument()
     expect(progressbar).toHaveAttribute('aria-valuenow', '24')
-    expect(screen.getByText(/10 of 42 documents indexed/i)).toBeInTheDocument()
+    expect(screen.getByText(/10 of 42 documents processed/i)).toBeInTheDocument()
   })
 
   it('shows last indexing info when completed', () => {
@@ -78,12 +80,39 @@ describe('AdminDrawer', () => {
       status: 'COMPLETED',
       documentCount: 42,
       totalDocuments: 42,
+      documentsSkipped: 0,
       timestamp: '2025-01-15T10:30:00Z',
     })
     renderWithProviders(<AdminDrawer />)
 
     expect(screen.getByText(/completed/i)).toBeInTheDocument()
-    expect(screen.getByText(/documents: 42/i)).toBeInTheDocument()
+    expect(screen.getByText(/documents: 42 processed/i)).toBeInTheDocument()
+  })
+
+  it('shows skipped count when documents were skipped', () => {
+    useIndexingStore.setState({
+      status: 'COMPLETED',
+      documentCount: 32,
+      totalDocuments: 42,
+      documentsSkipped: 10,
+      timestamp: '2025-01-15T10:30:00Z',
+    })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.getByText(/10 skipped/i)).toBeInTheDocument()
+  })
+
+  it('does not show skipped text when zero skipped', () => {
+    useIndexingStore.setState({
+      status: 'COMPLETED',
+      documentCount: 42,
+      totalDocuments: 42,
+      documentsSkipped: 0,
+      timestamp: '2025-01-15T10:30:00Z',
+    })
+    renderWithProviders(<AdminDrawer />)
+
+    expect(screen.queryByText(/skipped/i)).not.toBeInTheDocument()
   })
 
   it('does not render content when drawer is closed', () => {

--- a/frontend/src/components/admin/AdminDrawer.tsx
+++ b/frontend/src/components/admin/AdminDrawer.tsx
@@ -17,12 +17,13 @@ export default function AdminDrawer() {
   const status = useIndexingStore((s) => s.status)
   const documentCount = useIndexingStore((s) => s.documentCount)
   const totalDocuments = useIndexingStore((s) => s.totalDocuments)
+  const documentsSkipped = useIndexingStore((s) => s.documentsSkipped)
   const timestamp = useIndexingStore((s) => s.timestamp)
   const trigger = useIndexingStore((s) => s.triggerIndexing)
 
   const isRunning = status === 'RUNNING'
   const progressPercent =
-    totalDocuments > 0 ? Math.round((documentCount / totalDocuments) * 100) : 0
+    totalDocuments > 0 ? Math.round(((documentCount + documentsSkipped) / totalDocuments) * 100) : 0
 
   return (
     <Drawer
@@ -75,7 +76,7 @@ export default function AdminDrawer() {
               />
               <Typography variant="body2" color="text.secondary">
                 {totalDocuments > 0
-                  ? `${documentCount} of ${totalDocuments} documents indexed`
+                  ? `${documentCount + documentsSkipped} of ${totalDocuments} documents processed`
                   : 'Discovering documents...'}
               </Typography>
             </Box>
@@ -87,7 +88,8 @@ export default function AdminDrawer() {
                 Last indexing: {status === 'COMPLETED' ? 'Completed' : 'Failed'}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Documents: {documentCount}
+                Documents: {documentCount} processed
+                {documentsSkipped > 0 && ` (${documentsSkipped} skipped)`}
               </Typography>
               {timestamp && (
                 <Typography variant="caption" color="text.secondary">

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -8,15 +8,17 @@ export const mockIndexingIdle: IndexingStatusResponse = {
   status: 'IDLE',
   documentCount: 0,
   totalDocuments: 0,
+  documentsSkipped: 0,
   message: null,
   timestamp: '2025-01-15T10:00:00Z',
 }
 
 export const mockIndexingCompleted: IndexingStatusResponse = {
   status: 'COMPLETED',
-  documentCount: 42,
+  documentCount: 37,
   totalDocuments: 42,
-  message: 'Indexing completed successfully',
+  documentsSkipped: 5,
+  message: 'Indexing completed: 37 processed, 5 skipped, 0 failed',
   timestamp: '2025-01-15T10:30:00Z',
 }
 

--- a/frontend/src/mocks/handlers.test.ts
+++ b/frontend/src/mocks/handlers.test.ts
@@ -42,7 +42,8 @@ describe('MSW Handlers', () => {
       }
 
       expect(data.status).toBe('COMPLETED')
-      expect(data.documentCount).toBe(42)
+      expect(data.documentCount).toBe(37)
+      expect(data.documentsSkipped).toBe(5)
     })
   })
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -25,6 +25,7 @@ function getRunningStatus(step: number): IndexingStatusResponse {
     status: 'RUNNING',
     documentCount: Math.round(TOTAL_DOCUMENTS * progress),
     totalDocuments: TOTAL_DOCUMENTS,
+    documentsSkipped: 0,
     message: `Indexing in progress... ${Math.round(TOTAL_DOCUMENTS * progress)} documents processed`,
     timestamp: new Date().toISOString(),
   }
@@ -43,6 +44,7 @@ export const handlers = [
         status: 'RUNNING',
         documentCount: 0,
         totalDocuments: 0,
+        documentsSkipped: 0,
         message: 'Indexing started',
         timestamp: new Date().toISOString(),
       } satisfies IndexingStatusResponse,

--- a/frontend/src/stores/indexingStore.test.ts
+++ b/frontend/src/stores/indexingStore.test.ts
@@ -7,6 +7,7 @@ describe('indexingStore', () => {
       status: 'IDLE',
       documentCount: 0,
       totalDocuments: 0,
+      documentsSkipped: 0,
       message: null,
       timestamp: null,
       isPolling: false,
@@ -23,6 +24,7 @@ describe('indexingStore', () => {
     const state = useIndexingStore.getState()
     expect(state.status).toBe('IDLE')
     expect(state.totalDocuments).toBe(0)
+    expect(state.documentsSkipped).toBe(0)
     expect(state.isPolling).toBe(false)
     expect(state.drawerOpen).toBe(false)
   })

--- a/frontend/src/stores/indexingStore.ts
+++ b/frontend/src/stores/indexingStore.ts
@@ -16,6 +16,7 @@ interface IndexingState {
   status: IndexingStatus
   documentCount: number
   totalDocuments: number
+  documentsSkipped: number
   message: string | null
   timestamp: string | null
   isPolling: boolean
@@ -36,6 +37,7 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
   status: 'IDLE',
   documentCount: 0,
   totalDocuments: 0,
+  documentsSkipped: 0,
   message: null,
   timestamp: null,
   isPolling: false,
@@ -49,6 +51,7 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
         status: response.status,
         documentCount: response.documentCount,
         totalDocuments: response.totalDocuments,
+        documentsSkipped: response.documentsSkipped,
         message: response.message,
         timestamp: response.timestamp,
       })
@@ -78,6 +81,7 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
           status: response.status,
           documentCount: response.documentCount,
           totalDocuments: response.totalDocuments,
+          documentsSkipped: response.documentsSkipped,
           message: response.message,
           timestamp: response.timestamp,
         })
@@ -89,7 +93,7 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
               open: true,
               message:
                 response.status === 'COMPLETED'
-                  ? `Indexing completed: ${response.documentCount} documents processed`
+                  ? `Indexing completed: ${response.documentCount} processed, ${response.documentsSkipped} skipped`
                   : (response.message ?? 'Indexing failed'),
               severity: response.status === 'COMPLETED' ? 'success' : 'error',
             },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8,6 +8,7 @@ export interface IndexingStatusResponse {
   status: IndexingStatus
   documentCount: number
   totalDocuments: number
+  documentsSkipped: number
   message: string | null
   timestamp: string
 }


### PR DESCRIPTION
## Summary
- Compute SHA-256 checksum before parsing each file during indexing
- Skip documents whose checksum matches the stored value and are already in INDEXED status
- Track and display skipped document count in both backend API and frontend UI

## Changes

### Backend
- **ChecksumService**: SHA-256 computation via `DigestInputStream`
- **FileProcessingResult** enum: `PROCESSED` / `SKIPPED`
- **Document** entity: new `checksum` column (VARCHAR 64)
- **IndexingJob** entity: new `documents_skipped` counter
- **FileProcessingService**: compare checksums, skip unchanged files
- **AsyncIndexingExecutor**: track skipped count during async execution
- **IndexingJobService**: persist `documentsSkipped`
- **IndexingStatusResponse**: include `documentsSkipped` field
- **Liquibase migration**: `005-add-checksum-and-skipped-columns.yaml`

### Frontend
- API types and Zustand store updated with `documentsSkipped`
- AdminDrawer progress bar includes skipped documents
- Completed state shows "X processed (Y skipped)"
- MSW mocks and fixtures updated

### Tests
- 5 unit tests for `ChecksumService`
- 5 unit tests for `FileProcessingService`
- Updated `IndexingJobServiceTest`, `IndexingControllerTest`, `MockIndexingControllerTest`
- New integration test: `skipsUnchangedDocumentsOnReindex`
- All frontend tests updated for skipped state

## Test plan
- [x] Backend build passes (73 tests, 13 skipped — Docker/API key dependent)
- [x] Frontend tests pass (85 tests)
- [x] Frontend lint and build pass
- [x] Backend spotless formatting applied

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)