### PR TITLE
fix: add conversationId input validation

### DIFF
--- a/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
@@ -41,6 +41,12 @@ public class GlobalExceptionHandler {
                 Instant.now()));
   }
 
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+    return ResponseEntity.badRequest()
+        .body(new ErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST.value(), Instant.now()));
+  }
+
   @ExceptionHandler(TransientAiException.class)
   public ResponseEntity<ErrorResponse> handleTransientAiException(TransientAiException ex) {
     log.warn("Transient AI service error: {}", ex.getMessage());

--- a/backend/src/main/java/io/opaa/api/MockQueryController.java
+++ b/backend/src/main/java/io/opaa/api/MockQueryController.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MockQueryController {
 
   private static final Instant MOCK_INDEXED_AT = Instant.parse("2025-01-15T10:30:00Z");
+  private static final Pattern VALID_CONVERSATION_ID = Pattern.compile("^[a-zA-Z0-9-]{1,50}$");
 
   private record MockAnswer(String answer, List<SourceReference> sources, QueryMetadata metadata) {}
 
@@ -55,13 +57,20 @@ public class MockQueryController {
                   new SourceReference("security-checklist.md", 0.65, 1, MOCK_INDEXED_AT, false)),
               new QueryMetadata("gpt-4o", 1584, 2341)));
 
+  private static String validateConversationId(String conversationId) {
+    if (conversationId == null || conversationId.isBlank()) {
+      return UUID.randomUUID().toString();
+    }
+    if (!VALID_CONVERSATION_ID.matcher(conversationId).matches()) {
+      throw new IllegalArgumentException("Invalid conversationId format");
+    }
+    return conversationId;
+  }
+
   @PostMapping("/query")
   public QueryResponse query(@Valid @RequestBody QueryRequest request) {
     MockAnswer mock = MOCK_ANSWERS.get(ThreadLocalRandom.current().nextInt(MOCK_ANSWERS.size()));
-    String conversationId =
-        request.conversationId() != null && !request.conversationId().isBlank()
-            ? request.conversationId()
-            : UUID.randomUUID().toString();
+    String conversationId = validateConversationId(request.conversationId());
     return new QueryResponse(mock.answer(), mock.sources(), mock.metadata(), conversationId);
   }
 }

--- a/backend/src/main/java/io/opaa/query/QueryService.java
+++ b/backend/src/main/java/io/opaa/query/QueryService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ public class QueryService {
 
   private static final int DEFAULT_TOP_K = 5;
   private static final double DEFAULT_SIMILARITY_THRESHOLD = 0.3;
+  private static final Pattern VALID_CONVERSATION_ID = Pattern.compile("^[a-zA-Z0-9-]{1,50}$");
 
   private final VectorStore vectorStore;
   private final AnswerGenerationService answerGenerationService;
@@ -52,10 +54,7 @@ public class QueryService {
   public QueryResponse query(String question, String conversationId) {
     long startTime = System.currentTimeMillis();
 
-    String effectiveConversationId =
-        conversationId != null && !conversationId.isBlank()
-            ? conversationId
-            : UUID.randomUUID().toString();
+    String effectiveConversationId = validateConversationId(conversationId);
 
     String searchQuery = buildSearchQuery(question, effectiveConversationId);
 
@@ -177,6 +176,16 @@ public class QueryService {
       return response.getMetadata().getUsage().getTotalTokens();
     }
     return 0;
+  }
+
+  String validateConversationId(String conversationId) {
+    if (conversationId == null || conversationId.isBlank()) {
+      return UUID.randomUUID().toString();
+    }
+    if (!VALID_CONVERSATION_ID.matcher(conversationId).matches()) {
+      throw new IllegalArgumentException("Invalid conversationId format");
+    }
+    return conversationId;
   }
 
   String buildSearchQuery(String question, String conversationId) {

--- a/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.opaa.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -130,5 +131,12 @@ class QueryIntegrationTest {
 
     assertThat(response.answer()).contains("don't have enough context");
     assertThat(response.sources()).isEmpty();
+  }
+
+  @Test
+  void queryRejectsInvalidConversationId() {
+    assertThatThrownBy(() -> queryService.query("Test question", "<script>alert(1)</script>"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid conversationId format");
   }
 }

--- a/backend/src/test/java/io/opaa/query/QueryServiceTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryServiceTest.java
@@ -1,6 +1,7 @@
 package io.opaa.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -327,6 +328,40 @@ class QueryServiceTest {
     ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
     verify(vectorStore).similaritySearch(captor.capture());
     assertThat(captor.getValue().getQuery()).isEqualTo("First question");
+  }
+
+  @Test
+  void validateConversationIdRejectsToolLongId() {
+    String tooLong = "a".repeat(51);
+    assertThatThrownBy(() -> queryService.validateConversationId(tooLong))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid conversationId format");
+  }
+
+  @Test
+  void validateConversationIdRejectsSpecialCharacters() {
+    assertThatThrownBy(() -> queryService.validateConversationId("id with spaces"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> queryService.validateConversationId("id;DROP TABLE"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> queryService.validateConversationId("<script>alert(1)</script>"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> queryService.validateConversationId("id/path/../traversal"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void validateConversationIdAcceptsValidFormats() {
+    assertThat(queryService.validateConversationId("abc-123")).isEqualTo("abc-123");
+    assertThat(queryService.validateConversationId("A")).isEqualTo("A");
+    assertThat(queryService.validateConversationId("a".repeat(50))).hasSize(50);
+  }
+
+  @Test
+  void validateConversationIdGeneratesUuidForNullOrBlank() {
+    assertThat(queryService.validateConversationId(null)).isNotBlank();
+    assertThat(queryService.validateConversationId("")).isNotBlank();
+    assertThat(queryService.validateConversationId("   ")).isNotBlank();
   }
 
   private Usage createUsage(int promptTokens, int completionTokens) {


### PR DESCRIPTION
## Summary
- Validate `conversationId` with regex `^[a-zA-Z0-9-]{1,50}$` in `QueryService` and `MockQueryController`
- Return 400 Bad Request for invalid formats via `GlobalExceptionHandler`
- Unit tests for too-long IDs, special characters (XSS, SQL injection, path traversal), valid formats, and null/blank handling
- Integration test for rejection of invalid conversation IDs

Closes #64

## Test plan
- [x] Unit tests: too long IDs rejected
- [x] Unit tests: special characters rejected (spaces, SQL injection, XSS, path traversal)
- [x] Unit tests: valid alphanumeric + hyphen IDs accepted
- [x] Unit tests: null/blank generates UUID
- [x] Integration test: invalid conversationId returns error
- [x] Backend build passes (`./gradlew build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)