### PR TITLE
fix: replace CORS wildcard headers with explicit whitelist

### DIFF
--- a/backend/src/main/java/io/opaa/api/CorsConfig.java
+++ b/backend/src/main/java/io/opaa/api/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
             .addMapping("/api/**")
             .allowedOrigins(allowedOrigins.split(","))
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-            .allowedHeaders("*");
+            .allowedHeaders("Content-Type", "Authorization", "X-Requested-With");
       }
     };
   }


### PR DESCRIPTION
## Summary
- Replace `allowedHeaders("*")` in `CorsConfig.java` with an explicit whitelist: `Content-Type`, `Authorization`, `X-Requested-With`
- Reduces attack surface for CORS-bypass and request smuggling attacks
- Backend build and all tests pass with the restricted headers

Closes #61

## Test plan
- [x] `./gradlew spotlessCheck` passes
- [x] `./gradlew build` passes (includes all tests)
- [ ] Verify frontend still works correctly with restricted CORS headers

> [!NOTE]
> This PR was authored with the help of an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)