### PR TITLE
feat(frontend): enhance ErrorBoundary with error details

### DIFF
--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,87 @@
+import type React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ErrorBoundary from './ErrorBoundary'
+
+function ThrowingComponent({ message }: { message: string }): React.ReactNode {
+  throw new Error(message)
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>App content</div>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('App content')).toBeInTheDocument()
+  })
+
+  it('renders error screen when a child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="Test crash" />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(
+      screen.getByText('An unexpected error occurred. Please try reloading the page.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show Details' })).toBeInTheDocument()
+  })
+
+  it('shows error details when "Show Details" is clicked', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="Something broke" />
+      </ErrorBoundary>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Show Details' }))
+
+    expect(screen.getByText('Something broke')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Hide Details' })).toBeInTheDocument()
+  })
+
+  it('hides error details when "Hide Details" is clicked', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="Another error" />
+      </ErrorBoundary>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Show Details' }))
+    expect(screen.getByRole('button', { name: 'Hide Details' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Hide Details' }))
+    expect(screen.getByRole('button', { name: 'Show Details' })).toBeInTheDocument()
+  })
+
+  it('logs the error to console', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="Console test" />
+      </ErrorBoundary>,
+    )
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'ErrorBoundary caught:',
+      expect.any(Error),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    )
+  })
+})

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,8 @@ import { Component, type ErrorInfo, type ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
+import Collapse from '@mui/material/Collapse'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 
 interface Props {
   children: ReactNode
@@ -9,16 +11,18 @@ interface Props {
 
 interface State {
   hasError: boolean
+  error: Error | null
+  showDetails: boolean
 }
 
 export default class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, error: null, showDetails: false }
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true }
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error, showDetails: false }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -27,6 +31,8 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      const { error, showDetails } = this.state
+
       return (
         <Box
           sx={{
@@ -39,13 +45,54 @@ export default class ErrorBoundary extends Component<Props, State> {
             p: 4,
           }}
         >
+          <ErrorOutlineIcon sx={{ fontSize: 64 }} color="error" />
           <Typography variant="h5">Something went wrong</Typography>
-          <Typography variant="body1" color="text.secondary">
+          <Typography variant="body1" color="text.secondary" textAlign="center">
             An unexpected error occurred. Please try reloading the page.
           </Typography>
-          <Button variant="contained" onClick={() => window.location.reload()}>
-            Reload
-          </Button>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <Button variant="contained" onClick={() => window.location.reload()}>
+              Reload
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => this.setState((prev) => ({ showDetails: !prev.showDetails }))}
+            >
+              {showDetails ? 'Hide Details' : 'Show Details'}
+            </Button>
+          </Box>
+          <Collapse in={showDetails}>
+            <Box
+              sx={{
+                mt: 2,
+                p: 2,
+                maxWidth: 600,
+                width: '100%',
+                bgcolor: 'grey.100',
+                borderRadius: 1,
+                overflow: 'auto',
+              }}
+            >
+              <Typography variant="subtitle2" color="error" gutterBottom>
+                {error?.message}
+              </Typography>
+              {error?.stack && (
+                <Typography
+                  variant="body2"
+                  component="pre"
+                  sx={{
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    fontSize: '0.75rem',
+                    color: 'text.secondary',
+                    m: 0,
+                  }}
+                >
+                  {error.stack}
+                </Typography>
+              )}
+            </Box>
+          </Collapse>
         </Box>
       )
     }


### PR DESCRIPTION
## Summary
- Enhanced the existing `ErrorBoundary` component with a collapsible error details section showing error message and stack trace
- Added an error icon for visual clarity on the error screen
- Added 5 tests covering rendering, detail toggling, and console logging

Closes #70

## Test plan
- [x] ErrorBoundary renders children when no error occurs
- [x] Error screen shows user-friendly message with icon
- [x] "Show Details" / "Hide Details" toggle works
- [x] Error message and stack trace are displayed in details
- [x] Errors are logged to console
- [x] Frontend lint, format, tests, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)