### PR TITLE
fix(chat): add ChatMemory lifecycle management with Caffeine cache

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.ai:spring-ai-starter-vector-store-pgvector")
     implementation("org.springframework.ai:spring-ai-tika-document-reader")
+    implementation(libs.caffeine)
     runtimeOnly("org.postgresql:postgresql")
     testRuntimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -2,9 +2,11 @@
 spring-ai = "1.1.2"
 spotless = "8.2.1"
 awaitility = "4.3.0"
+caffeine = "3.2.0"
 
 [libraries]
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/backend/src/main/java/io/opaa/query/CaffeineChatMemoryRepository.java
+++ b/backend/src/main/java/io/opaa/query/CaffeineChatMemoryRepository.java
@@ -1,0 +1,80 @@
+package io.opaa.query;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.Message;
+
+/**
+ * A {@link ChatMemoryRepository} backed by a Caffeine cache with LRU eviction and TTL. Limits the
+ * number of concurrent conversations to prevent unbounded memory growth.
+ */
+public class CaffeineChatMemoryRepository implements ChatMemoryRepository {
+
+  private static final Logger log = LoggerFactory.getLogger(CaffeineChatMemoryRepository.class);
+
+  private final Cache<String, List<Message>> cache;
+
+  /**
+   * Creates a new repository with the given limits.
+   *
+   * @param maxConversations maximum number of conversations to keep (LRU eviction)
+   * @param ttlMinutes time-to-live in minutes after last access before a conversation is evicted
+   */
+  public CaffeineChatMemoryRepository(int maxConversations, int ttlMinutes) {
+    this(maxConversations, ttlMinutes, null);
+  }
+
+  CaffeineChatMemoryRepository(int maxConversations, int ttlMinutes, Executor executor) {
+    Caffeine<Object, Object> builder =
+        Caffeine.newBuilder()
+            .maximumSize(maxConversations)
+            .expireAfterAccess(ttlMinutes, TimeUnit.MINUTES)
+            .evictionListener(
+                (key, value, cause) ->
+                    log.debug("Evicted conversation '{}' due to {}", key, cause));
+
+    if (executor != null) {
+      builder.executor(executor);
+    }
+
+    this.cache = builder.build();
+
+    log.info(
+        "ChatMemory repository initialized: maxConversations={}, ttlMinutes={}",
+        maxConversations,
+        ttlMinutes);
+  }
+
+  @Override
+  public List<String> findConversationIds() {
+    return List.copyOf(cache.asMap().keySet());
+  }
+
+  @Override
+  public List<Message> findByConversationId(String conversationId) {
+    List<Message> messages = cache.getIfPresent(conversationId);
+    return messages != null ? List.copyOf(messages) : List.of();
+  }
+
+  @Override
+  public void saveAll(String conversationId, List<Message> messages) {
+    cache.put(conversationId, new ArrayList<>(messages));
+  }
+
+  @Override
+  public void deleteByConversationId(String conversationId) {
+    cache.invalidate(conversationId);
+  }
+
+  /** Forces pending evictions to run synchronously. Intended for testing. */
+  void cleanUp() {
+    cache.cleanUp();
+  }
+}

--- a/backend/src/main/java/io/opaa/query/QueryConfiguration.java
+++ b/backend/src/main/java/io/opaa/query/QueryConfiguration.java
@@ -3,6 +3,7 @@ package io.opaa.query;
 import io.opaa.indexing.DocumentRepository;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.context.annotation.Bean;
@@ -13,9 +14,21 @@ import org.springframework.context.annotation.Profile;
 @Profile("!mock")
 public class QueryConfiguration {
 
+  static final int MAX_CONVERSATIONS = 50;
+  static final int TTL_MINUTES = 60;
+  static final int MAX_MESSAGES_PER_CONVERSATION = 20;
+
   @Bean
-  ChatMemory chatMemory() {
-    return MessageWindowChatMemory.builder().build();
+  ChatMemoryRepository chatMemoryRepository() {
+    return new CaffeineChatMemoryRepository(MAX_CONVERSATIONS, TTL_MINUTES);
+  }
+
+  @Bean
+  ChatMemory chatMemory(ChatMemoryRepository chatMemoryRepository) {
+    return MessageWindowChatMemory.builder()
+        .chatMemoryRepository(chatMemoryRepository)
+        .maxMessages(MAX_MESSAGES_PER_CONVERSATION)
+        .build();
   }
 
   @Bean

--- a/backend/src/test/java/io/opaa/query/CaffeineChatMemoryRepositoryTest.java
+++ b/backend/src/test/java/io/opaa/query/CaffeineChatMemoryRepositoryTest.java
@@ -1,0 +1,117 @@
+package io.opaa.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+class CaffeineChatMemoryRepositoryTest {
+
+  private CaffeineChatMemoryRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new CaffeineChatMemoryRepository(50, 60);
+  }
+
+  @Test
+  void saveAndFindMessages() {
+    List<Message> messages = List.of(new UserMessage("Hello"), new AssistantMessage("Hi there"));
+
+    repository.saveAll("conv-1", messages);
+
+    List<Message> result = repository.findByConversationId("conv-1");
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getText()).isEqualTo("Hello");
+    assertThat(result.get(1).getText()).isEqualTo("Hi there");
+  }
+
+  @Test
+  void findByConversationIdReturnsEmptyListForUnknownId() {
+    List<Message> result = repository.findByConversationId("nonexistent");
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void findConversationIdsReturnsAllActiveIds() {
+    repository.saveAll("conv-1", List.of(new UserMessage("Q1")));
+    repository.saveAll("conv-2", List.of(new UserMessage("Q2")));
+    repository.saveAll("conv-3", List.of(new UserMessage("Q3")));
+
+    List<String> ids = repository.findConversationIds();
+    assertThat(ids).containsExactlyInAnyOrder("conv-1", "conv-2", "conv-3");
+  }
+
+  @Test
+  void findConversationIdsReturnsEmptyListWhenEmpty() {
+    assertThat(repository.findConversationIds()).isEmpty();
+  }
+
+  @Test
+  void deleteByConversationIdRemovesConversation() {
+    repository.saveAll("conv-1", List.of(new UserMessage("Q1")));
+    repository.saveAll("conv-2", List.of(new UserMessage("Q2")));
+
+    repository.deleteByConversationId("conv-1");
+
+    assertThat(repository.findByConversationId("conv-1")).isEmpty();
+    assertThat(repository.findByConversationId("conv-2")).hasSize(1);
+    assertThat(repository.findConversationIds()).containsExactly("conv-2");
+  }
+
+  @Test
+  void deleteByConversationIdDoesNothingForUnknownId() {
+    repository.saveAll("conv-1", List.of(new UserMessage("Q1")));
+
+    repository.deleteByConversationId("nonexistent");
+
+    assertThat(repository.findByConversationId("conv-1")).hasSize(1);
+  }
+
+  @Test
+  void saveAllOverwritesExistingConversation() {
+    repository.saveAll("conv-1", List.of(new UserMessage("Old question")));
+    repository.saveAll(
+        "conv-1", List.of(new UserMessage("New question"), new AssistantMessage("New answer")));
+
+    List<Message> result = repository.findByConversationId("conv-1");
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getText()).isEqualTo("New question");
+  }
+
+  @Test
+  void lruEvictionRemovesOldestConversations() {
+    // Use synchronous executor so eviction happens immediately
+    var smallRepository = new CaffeineChatMemoryRepository(3, 60, Runnable::run);
+
+    smallRepository.saveAll("conv-1", List.of(new UserMessage("Q1")));
+    smallRepository.saveAll("conv-2", List.of(new UserMessage("Q2")));
+    smallRepository.saveAll("conv-3", List.of(new UserMessage("Q3")));
+
+    // Access conv-1 to make it recently used
+    smallRepository.findByConversationId("conv-1");
+
+    // Add a 4th conversation, which should trigger eviction of conv-2 (least recently used)
+    smallRepository.saveAll("conv-4", List.of(new UserMessage("Q4")));
+    smallRepository.cleanUp();
+
+    List<String> ids = smallRepository.findConversationIds();
+    assertThat(ids).hasSize(3);
+    // conv-4 (newest) and conv-1 (recently accessed) should survive
+    assertThat(ids).contains("conv-4", "conv-1");
+  }
+
+  @Test
+  void findByConversationIdReturnsDefensiveCopy() {
+    repository.saveAll("conv-1", List.of(new UserMessage("Q1")));
+
+    List<Message> result = repository.findByConversationId("conv-1");
+
+    // Returned list should be unmodifiable (defensive copy)
+    assertThat(result).isUnmodifiable();
+  }
+}


### PR DESCRIPTION
## Summary
- Replace unbounded `InMemoryChatMemoryRepository` with `CaffeineChatMemoryRepository` backed by Caffeine cache to prevent memory leaks from unlimited conversation growth
- Configure LRU eviction (max 50 sessions), TTL (60 min inactivity), and message window (max 20 messages per session)
- Add 8 unit tests covering CRUD, LRU eviction, defensive copies, and edge cases

Closes #69

## Test plan
- [x] All 109 backend tests pass (`./gradlew build`)
- [x] Spotless formatting applied (`./gradlew spotlessApply`)
- [ ] Verify eviction behavior under load (manual or future load test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>