### PR TITLE
refactor(query): extract source merge lambda to named method

### DIFF
--- a/backend/src/main/java/io/opaa/query/QueryService.java
+++ b/backend/src/main/java/io/opaa/query/QueryService.java
@@ -161,23 +161,33 @@ public class QueryService {
             toMap(
                 SourceReference::fileName,
                 source -> source,
-                (a, b) -> {
-                  boolean eitherCited = a.cited() || b.cited();
-                  SourceReference winner = a.relevanceScore() >= b.relevanceScore() ? a : b;
-                  if (eitherCited && !winner.cited()) {
-                    return new SourceReference(
-                        winner.fileName(),
-                        winner.relevanceScore(),
-                        winner.matchCount(),
-                        winner.indexedAt(),
-                        true);
-                  }
-                  return winner;
-                },
+                QueryService::mergeSourceReferences,
                 LinkedHashMap::new))
         .values()
         .stream()
         .toList();
+  }
+
+  /**
+   * Merges duplicate source references for the same file, keeping the one with the highest
+   * relevance score while preserving citation status. If either reference was cited in the answer,
+   * the merged result is marked as cited — because any chunk from that document being cited means
+   * the document as a whole contributed to the answer.
+   */
+  static SourceReference mergeSourceReferences(SourceReference a, SourceReference b) {
+    SourceReference preferred = a.relevanceScore() >= b.relevanceScore() ? a : b;
+    boolean shouldBeCited = a.cited() || b.cited();
+
+    if (shouldBeCited && !preferred.cited()) {
+      return new SourceReference(
+          preferred.fileName(),
+          preferred.relevanceScore(),
+          preferred.matchCount(),
+          preferred.indexedAt(),
+          true);
+    }
+
+    return preferred;
   }
 
   private String extractAnswer(ChatResponse response) {

--- a/backend/src/test/java/io/opaa/query/QueryServiceTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryServiceTest.java
@@ -9,12 +9,15 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opaa.api.dto.QueryResponse;
+import io.opaa.api.dto.SourceReference;
 import io.opaa.indexing.DocumentRepository;
 import io.opaa.observability.QueryMetrics;
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -376,6 +379,89 @@ class QueryServiceTest {
     assertThat(queryService.validateConversationId(null)).isNotBlank();
     assertThat(queryService.validateConversationId("")).isNotBlank();
     assertThat(queryService.validateConversationId("   ")).isNotBlank();
+  }
+
+  @Nested
+  class MergeSourceReferences {
+
+    private static final Instant INDEXED_AT = Instant.parse("2025-01-01T00:00:00Z");
+
+    @Test
+    void keepsHigherRelevanceScore() {
+      var high = new SourceReference("file.pdf", 0.9, 1, INDEXED_AT, false);
+      var low = new SourceReference("file.pdf", 0.5, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(high, low);
+
+      assertThat(result.relevanceScore()).isEqualTo(0.9);
+    }
+
+    @Test
+    void keepsHigherScoreRegardlessOfOrder() {
+      var low = new SourceReference("file.pdf", 0.3, 1, INDEXED_AT, false);
+      var high = new SourceReference("file.pdf", 0.8, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(low, high);
+
+      assertThat(result.relevanceScore()).isEqualTo(0.8);
+    }
+
+    @Test
+    void prefersFirstWhenScoresAreEqual() {
+      var first = new SourceReference("file.pdf", 0.7, 2, INDEXED_AT, true);
+      var second = new SourceReference("file.pdf", 0.7, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(first, second);
+
+      assertThat(result).isEqualTo(first);
+    }
+
+    @Test
+    void preservesCitedWhenHigherScoreIsCited() {
+      var cited = new SourceReference("file.pdf", 0.9, 1, INDEXED_AT, true);
+      var uncited = new SourceReference("file.pdf", 0.5, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(cited, uncited);
+
+      assertThat(result.cited()).isTrue();
+      assertThat(result.relevanceScore()).isEqualTo(0.9);
+    }
+
+    @Test
+    void forcesCitedWhenLowerScoreIsCitedButHigherWins() {
+      var citedLow = new SourceReference("file.pdf", 0.3, 1, INDEXED_AT, true);
+      var uncitedHigh = new SourceReference("file.pdf", 0.9, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(citedLow, uncitedHigh);
+
+      assertThat(result.cited()).isTrue();
+      assertThat(result.relevanceScore()).isEqualTo(0.9);
+      assertThat(result.fileName()).isEqualTo("file.pdf");
+    }
+
+    @Test
+    void returnsFalseWhenNeitherIsCited() {
+      var a = new SourceReference("file.pdf", 0.8, 1, INDEXED_AT, false);
+      var b = new SourceReference("file.pdf", 0.6, 1, INDEXED_AT, false);
+
+      var result = QueryService.mergeSourceReferences(a, b);
+
+      assertThat(result.cited()).isFalse();
+    }
+
+    @Test
+    void preservesMetadataFromPreferredSource() {
+      var indexedEarly = Instant.parse("2024-01-01T00:00:00Z");
+      var indexedLate = Instant.parse("2025-06-01T00:00:00Z");
+      var high = new SourceReference("report.pdf", 0.95, 3, indexedLate, false);
+      var low = new SourceReference("report.pdf", 0.4, 1, indexedEarly, true);
+
+      var result = QueryService.mergeSourceReferences(high, low);
+
+      assertThat(result.matchCount()).isEqualTo(3);
+      assertThat(result.indexedAt()).isEqualTo(indexedLate);
+      assertThat(result.cited()).isTrue();
+    }
   }
 
   private Usage createUsage(int promptTokens, int completionTokens) {


### PR DESCRIPTION
## Summary
- Extract complex inline lambda in `QueryService.mapSources()` to a named `mergeSourceReferences()` static method with Javadoc
- Add 7 dedicated unit tests covering all merge scenarios (higher score wins, citation preservation, equal scores, metadata preservation)

## Test plan
- [x] All existing tests pass (no behavior change)
- [x] New `MergeSourceReferences` nested test class covers:
  - Higher relevance score wins
  - Order independence (higher score wins regardless of argument position)
  - First reference preferred when scores are equal
  - Citation preserved when higher score is already cited
  - Citation forced when lower-scored reference was cited but higher wins
  - No citation when neither is cited
  - Metadata from preferred source preserved

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)