### PR TITLE
refactor(security): make ErrorSanitizer a plain class instead of Spring bean

### DIFF
--- a/backend/src/main/java/io/opaa/api/ErrorSanitizer.java
+++ b/backend/src/main/java/io/opaa/api/ErrorSanitizer.java
@@ -2,9 +2,8 @@ package io.opaa.api;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.springframework.stereotype.Component;
 
-@Component
+/** Stateless utility that strips sensitive data (API keys, file paths, URL params) from strings. */
 public class ErrorSanitizer {
 
   private static final Pattern API_KEY_PATTERN =

--- a/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
@@ -18,11 +18,9 @@ public class GlobalExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-  private final ErrorSanitizer errorSanitizer;
-
-  public GlobalExceptionHandler(ErrorSanitizer errorSanitizer) {
-    this.errorSanitizer = errorSanitizer;
-  }
+  // Instantiated directly to keep it out of the Spring context and avoid
+  // forcing every @WebMvcTest to import the bean.
+  private final ErrorSanitizer errorSanitizer = new ErrorSanitizer();
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleValidationException(

--- a/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
@@ -10,8 +10,7 @@ import org.springframework.ai.retry.TransientAiException;
 
 class GlobalExceptionHandlerTest {
 
-  private final ErrorSanitizer sanitizer = new ErrorSanitizer();
-  private final GlobalExceptionHandler handler = new GlobalExceptionHandler(sanitizer);
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
   @Test
   void handleGenericExceptionReturnsInternalServerError() {

--- a/backend/src/test/java/io/opaa/api/HealthControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/HealthControllerTest.java
@@ -7,11 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(HealthController.class)
-@Import(ErrorSanitizer.class)
 class HealthControllerTest {
 
   @Autowired private MockMvc mockMvc;

--- a/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
@@ -17,13 +17,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(IndexingController.class)
-@Import(ErrorSanitizer.class)
 @ActiveProfiles("test")
 class IndexingControllerTest {
 

--- a/backend/src/test/java/io/opaa/api/MockIndexingControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/MockIndexingControllerTest.java
@@ -8,12 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(MockIndexingController.class)
-@Import(ErrorSanitizer.class)
 @ActiveProfiles("mock")
 class MockIndexingControllerTest {
 

--- a/backend/src/test/java/io/opaa/api/MockQueryControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/MockQueryControllerTest.java
@@ -7,13 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(MockQueryController.class)
-@Import(ErrorSanitizer.class)
 @ActiveProfiles("mock")
 class MockQueryControllerTest {
 

--- a/backend/src/test/java/io/opaa/api/QueryControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/QueryControllerTest.java
@@ -18,14 +18,12 @@ import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.ai.retry.TransientAiException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(QueryController.class)
-@Import(ErrorSanitizer.class)
 @ActiveProfiles("test")
 class QueryControllerTest {
 


### PR DESCRIPTION
## Summary
- Remove `@Component` from `ErrorSanitizer`, making it a plain utility class
- Instantiate it directly in `GlobalExceptionHandler` instead of via constructor injection
- Remove `@Import(ErrorSanitizer.class)` from all 5 `@WebMvcTest` classes that previously needed it

Follow-up to #89 — avoids polluting the Spring context with a stateless utility and keeps `@WebMvcTest` classes clean.

Closes #71

## Test plan
- [x] All backend tests pass (`./gradlew build`)
- [x] No `@WebMvcTest` needs `@Import(ErrorSanitizer.class)` anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)