### PR TITLE
docs: add architecture discussion documents

### DIFF
--- a/docs/discussions/discussion-embeddings.md
+++ b/docs/discussions/discussion-embeddings.md
@@ -1,0 +1,296 @@
+# Discussion: Embedding-Modelle für Enterprise-RAG
+
+**Thema:** Übersicht gängiger Embedding-Modelle, ihre Stärken/Schwächen, und praktische Anwendung im Enterprise-Kontext (On-Prem mit Ollama vs. Cloud-APIs)
+
+**Fokus:** Lokale Embeddings (Ollama), OpenAI Alternativen, Multi-Language Support (EN/DE), verschiedene Dokumenttypen (PDF, PPT, Code, Text)
+
+---
+
+## 1. Embedding-Modelle in Ollama (lokal verfügbar)
+
+### Top-Modelle für lokale Nutzung
+
+#### 1. **nomic-embed-text**
+- **Dimension:** 768
+- **Größe:** ~274 MB
+- **Kontext:** bis ~8.192 Tokens
+- **Stärken:** Allround-Performance, lange Texte, lokal effizient, bessere als ältere OpenAI-Modelle (ada-002)
+- **Schwächen:** Nicht SOTA, Englisch dominiert, kein spezialisiertes Retrieval-Fine-Tuning
+- **Einsatz:** Standard für lokale RAG-Apps
+
+#### 2. **nomic-embed-text-v2 (Neue Generation mit Mixture-of-Experts)**
+- **Dimension:** 768
+- **Besonderheit:** Multilingual (~100 Sprachen), trainiert auf >1.6 B Textpaaren, Matryoshka Embeddings (komprimierbar)
+- **Stärken:** Sehr starke Multilingualität, gute Retrieval-Scores, moderne Architektur
+- **Schwächen:** Größer und langsamer, teilweise noch experimentell
+- **Einsatz:** **Beste Wahl für internationale Daten (DE/EN)**
+
+#### 3. **mxbai-embed-large**
+- **Dimension:** 1024
+- **Parameter:** ~334M
+- **Größe:** ~670 MB
+- **Stärken:** Sehr hohe Qualität, SOTA für BERT-ähnliche Modelle, gute Generalisierung
+- **Schwächen:** Deutlich langsamer, mehr RAM/VRAM
+- **⚠️ Limitierung:** 512 Token Kontext-Limit (nicht konfigurierbar, ist normal für BERT-basierte Modelle)
+- **Einsatz:** High-Quality Offline Search
+
+#### 4. **all-MiniLM (leichtgewichtig)**
+- **Dimension:** 384
+- **Größe:** ~45 MB
+- **Stärken:** Extrem schnell, minimaler Speicherbedarf, gut für Edge-Devices
+- **Schwächen:** Niedrigere semantische Qualität
+- **Einsatz:** Realtime/Embedded/Mobile
+
+#### 5. **BGE-Modelle (BAAI General Embeddings)**
+- **Varianten:** small (384), base (768), large (1024), M3 (multilingual)
+- **Stärken:** Sehr gute Retrieval-Scores, gute Open-Source-Community, Cross-Encoder-Pairing möglich
+- **Schwächen:** Oft langsamer als MiniLM
+- **Einsatz:** Popular in Open-Source-RAG-Systemen
+
+#### 6. **Jina Embeddings v3**
+- **Dimension:** 1024 (skalierbar)
+- **Kontext:** bis ~8.192 Tokens
+- **Stärken:** SOTA multilingual, flexible Dimension, sehr stark bei Retrieval & Clustering
+- **Schwächen:** Lokal schwerer zu betreiben
+- **Einsatz:** High-Performance Retrieval
+
+#### 7. **E5 / mE5 (Microsoft)**
+- **Varianten:** base (768), large (1024)
+- **Besonderheit:** Instruction-tuned für Retrieval
+- **Stärken:** Sehr gut für Query-Document Retrieval, multilingual, robust
+- **Einsatz:** Spezialisiert auf Retrieval-Aufgaben
+
+---
+
+## 2. Cloud-basierte Embedding-Modelle
+
+### OpenAI
+
+#### text-embedding-3-large
+- **Dimension:** 3072
+- **Qualität:** State-of-the-Art
+- **Stärken:** Sehr präzise Semantik, stark bei komplexen Queries, gute Multilingualität
+- **Schwächen:** API-Kosten, Cloud-only, große Vektoren → hoher Speicherbedarf
+- **Einsatz:** Enterprise-RAG / Production Cloud
+
+#### text-embedding-3-small
+- **Dimension:** 1536
+- **Stärken:** Gute Qualität pro Kosten, viel schneller als large
+- **Schwächen:** Weniger präzise
+- **Einsatz:** Standard für viele Apps
+
+### Weitere Alternativen
+- **Cohere Embeddings:** ~1024 Dimension, sehr gute Qualität, production-ready, kostenpflichtig
+- **Jina Cloud API:** SOTA multilingual, flexibel
+- **BGE Cloud:** Kostengünstiger
+
+---
+
+## 3. Dimension & Qualität: Wichtige Erkenntnisse
+
+### ❌ Mythos: "Größere Dimension = bessere Qualität"
+
+**Realität:**
+- 768 Dimension (z.B. nomic v2) reicht für die meisten Enterprise-RAG-Systeme vollständig aus
+- Ein gut trainiertes 768-Dim-Modell kann besser sein als schwaches 1536-Dim-Modell
+- Trainingsdaten schlagen rohe Dimension
+
+**Vorteile kleinerer Dimensionen:**
+- 4× weniger RAM (768 vs. 3072)
+- 4× schnellere Vektorsuche
+- Geringere Vector-DB Kosten
+- Für Enterprise-Scale kritisch
+
+**Wann mehr Dimension sinnvoll:**
+- Sehr große Datenbanken
+- Feine semantische Unterschiede wichtig
+- Komplexes Clustering
+
+---
+
+## 4. Multilingualität (DE/EN)
+
+### Problem
+Viele Modelle sind primär auf Englisch trainiert → schlechtere deutsche Qualität, semantische Drift, schlechte Cross-Language-Suche
+
+### Beste multilingual Modelle (lokal)
+- ✅ **nomic-embed-text-v2** (empfohlen)
+- ✅ **BGE-M3**
+- ✅ **E5-multilingual**
+- ✅ **Jina v3**
+
+**Fähigkeit:** Deutsche Frage kann englisches Dokument finden (und umgekehrt)
+
+---
+
+## 5. Dokumenttypen & Chunking-Strategie
+
+### ❌ KRITISCHER FEHLER: Ein einziger Chunk-Size für alle Formate
+
+Dokumenttypen haben unterschiedliche semantische Dichten und erfordern unterschiedliche Ansätze.
+
+### Empfohlene Chunk-Größen pro Typ
+
+| Dokumenttyp | Chunk-Größe | Besonderheiten |
+|---|---|---|
+| **Fließtext (PDF, DOCX)** | 300–800 Tokens (10–20% Overlap) | Semantische Grenzen bevorzugen (Absätze, Kapitel) |
+| **Präsentationen (PPT)** | 1 Folie = 1 Chunk | ⚠️ Kontext anreichern (Titel + Notizen)! |
+| **Source Code** | Pro Funktion/Klasse (100–300 Tokens) | Strukturgrenzen beachten |
+| **Tabellen/Struktur** | Pro Tabelle oder Abschnitt | Row-wise Chunking selten sinnvoll |
+| **E-Mails** | Pro Thread | Mit Konversations-Kontext |
+
+### ✅ Darf man unterschiedliche Größen mischen?
+**Ja — absolut normal und Best Practice.**
+
+Vector-DBs speichern nur Vektor + Metadaten + Text. Chunkgröße ist egal.
+
+**⚠️ Aber:** Große Chunks haben höhere Trefferchance (mehr Keywords) → Score-Normalisierung, Reranking oder Hybrid Search einsetzen.
+
+### Context Enrichment (sehr wirkungsvoll)
+Jeden Chunk mit Metadaten anreichern:
+```
+Titel: Sicherheitsrichtlinie 2024
+Kapitel: Zugriffskontrolle
+Dokumenttyp: PDF
+Text: [Chunk-Inhalt]
+```
+
+---
+
+## 6. Query-Embedding & Modellkompatibilität
+
+### ⚠️ Query-Embedding MUSS kompatibel sein
+
+**Regel:** Query-Vektor muss im selben Vektorraum wie Dokumente liegen.
+
+- ✅ Dasselbe Modell für Query + Dokumente = funktioniert
+- ❌ Unterschiedliche Modelle = Cosine Similarity sinnlos, Retrieval bricht
+
+### Modellwechsel später: Was dann?
+
+#### Option 1: Re-Embedding (empfohlen für Production)
+- Alle Dokumente durch neues Modell neu laufen lassen
+- Vorteil: Beste Qualität, konsistenter Vektorraum
+- Nachteil: Teuer bei großen Datenmengen
+
+#### Option 2: Parallelbetrieb (Übergangslösung)
+```
+Index_A → altes Modell
+Index_B → neues Modell
+Query → beide → Ergebnisse mergen
+
+Dann schrittweise alte Dokumente re-embedden
+```
+
+#### Option 3: Mixed Embeddings (⚠️ nicht empfohlen)
+- Nur wenn klar getrennt per Namespace/Filter
+- Niemals gemeinsam durchsuchen
+
+---
+
+## 7. Technische Begriffe
+
+### SOTA (State Of The Art)
+- Aktuell bestes bekanntes Verfahren auf Benchmark-Tests
+- Gemessen z.B. auf MTEB (Massive Text Embedding Benchmark)
+- ❌ SOTA ≠ bestes Modell für Produktion (kann langsamer, speicherhungriger sein)
+
+### BERT (Bidirectional Encoder Representations from Transformers)
+**Entwickelt von Google (2018)**
+
+- Bidirektionales Kontextverständnis
+- Encoder-only Transformer
+- Sehr gut für Klassifikation & Retrieval
+- Fast alle modernen Embedding-Modelle sind BERT-Varianten
+
+**BERT vs. GPT:**
+| Eigenschaft | BERT | GPT |
+|---|---|---|
+| Embedding | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| Text generieren | ❌ | ⭐⭐⭐⭐⭐ |
+| Retrieval | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| Encoder | ✔ | ❌ |
+| Decoder | ❌ | ✔ |
+
+---
+
+## 8. Enterprise-RAG Empfehlung (PDF/PPT/Code/DE+EN)
+
+### 🥇 Lokal (Ollama) — Best Overall
+**→ `nomic-embed-text-v2`**
+- ✔ Multilingual
+- ✔ Lange Kontexte
+- ✔ Gute Allround-Qualität
+- ✔ Effizient
+
+### 🥈 Wenn max. Qualität lokal nötig
+**→ `mxbai-embed-large`** (mit aggressivem Chunking bei 512-Token-Limit)
+
+### 🥇 Wenn Cloud erlaubt
+**→ `text-embedding-3-large`**
+- Sehr stark bei gemischten Daten, Code + Text, Multilingualität
+
+---
+
+## 9. Qualität: Was wirklich zählt
+
+### ❌ Der größte Fehler: Modellwahl überschätzen
+
+**Ranking der Einflussfaktoren:**
+1. 🔥 **Chunking-Strategie** (kritisch!)
+2. **Metadaten + Dokumentbereinigung**
+3. **Reranking** (Top-k Kandidaten mit Cross-Encoder bewerten)
+4. **Query-Rewriting**
+5. **Vector-DB-Setup**
+6. **Modellwahl** (überraschend weniger wichtig)
+
+**Faustregel:** Ein mittelmäßiges Modell + gutes Pipeline-Design schlägt oft SOTA-Modelle allein.
+
+---
+
+## 10. Konkrete Architektur für euren Use-Case
+
+### Schritt 1: Dokumenttyp-spezifisches Chunking
+```
+PDF Text:      600 Tokens
+PPT:           1 Folie + Kontext
+Code:          Pro Funktion/Klasse
+Wiki:          Pro Abschnitt
+Emails:        Pro Thread
+```
+
+### Schritt 2: Einheitliches Embedding-Modell
+- Lokal: `nomic-embed-text-v2`
+- Cloud: `text-embedding-3-large`
+
+### Schritt 3: Metadaten speichern
+- Dokumenttyp
+- Sprache
+- Autor
+- Datum
+- Zugriffsrechte (ACL)
+- Quelle
+- Abschnitt
+
+### Schritt 4: Retrieval-Pipeline
+1. **Vector Search** (Embedding-basiert)
+2. **Reranking** (Cross-Encoder)
+3. **Hybrid Search** (BM25 + Embeddings kombinieren)
+4. **Metadaten-Filter** (Datum, Zugriffsrechte, etc.)
+
+---
+
+## 11. Offene Fragen für weitere Architekturdiskussion
+
+- Wie viele Dokumente / GB Daten sind vorhanden?
+- Muss alles lokal laufen (On-Prem)?
+- Welche Vector-DB eignet sich (Postgres pgvector, Milvus, Weaviate, Pinecone)?
+- Wie sieht die ACL/Berechtigung aus?
+- Wird Code-Suche ein Schwerpunkt?
+- Wie häufig Embeddings neutrainieren (Model Updates)?
+
+---
+
+**Status:** Diskussionsergebnis aus ChatGPT-Konversation
+**Sprachen:** DE / EN
+**Kontext:** Enterprise-RAG-Systeme mit heterogenen Dokumenttypen

--- a/docs/discussions/discussion-rag-evaluation.md
+++ b/docs/discussions/discussion-rag-evaluation.md
@@ -1,0 +1,338 @@
+# Discussion: RAG-Qualität messen und vergleichen
+
+**Thema:** Wie misst man die Qualität eines RAG-Systems? Welche Metriken, Frameworks, Benchmarks und Best Practices gibt es?
+
+**Kontext:** Aufbauend auf den Diskussionen zu [Embedding-Modellen](discussion-embeddings.md) und [Retrieval-Pipelines](discussion-retrieval-document-pipelines.md). Ziel ist es, Aussagen wie *"Modell X mit Embedding Y liefert N% bessere Antworten als Modell Z mit Embedding W"* fundiert treffen zu können.
+
+**Bezug zum Projekt:** OPAA nutzt Spring AI 1.1.2, pgvector, Ollama/OpenAI
+
+---
+
+## 1. RAG-Evaluation: Die drei Ebenen
+
+Ein RAG-System hat zwei Hauptkomponenten, die separat und zusammen gemessen werden sollten:
+
+```
+Query → [Retrieval] → relevante Chunks → [Generation] → Antwort
+         ↑                                   ↑
+   Retrieval-Metriken               Generations-Metriken
+         └───────────── End-to-End ──────────┘
+```
+
+---
+
+## 2. Metriken im Detail
+
+### 2.1 Retrieval-Metriken (Wie gut findet die Suche relevante Dokumente?)
+
+| Metrik | Was sie misst | Berechnung |
+|---|---|---|
+| **Hit Rate @k** | Ist mindestens ein relevantes Dokument in den Top-k? | Binär: 1 wenn ja, 0 wenn nein. Durchschnitt über alle Queries. |
+| **MRR (Mean Reciprocal Rank)** | Wie hoch ist das erste relevante Ergebnis gerankt? | Durchschnitt von 1/Position des ersten relevanten Treffers |
+| **Precision @k** | Welcher Anteil der Top-k Ergebnisse ist relevant? | Relevante in Top-k / k |
+| **Recall @k** | Welcher Anteil aller relevanten Dokumente ist in Top-k? | Relevante in Top-k / Alle relevanten |
+| **NDCG @k** | Qualität der gesamten Ranking-Liste | Gewichtete Summe (höhere Positionen zählen mehr), normalisiert gegen ideales Ranking |
+| **Context Precision (RAGAS)** | Sind relevante Chunks höher gerankt als irrelevante? | Positionsgewichteter Mean Average Precision |
+| **Context Recall (RAGAS)** | Sind alle nötigen Informationen im abgerufenen Kontext? | LLM prüft, ob jeder Satz der Ground-Truth-Antwort im Kontext zuordenbar ist |
+
+**Praxis-Empfehlung:** Hit Rate für schnelles Debugging, MRR + Recall beim Retriever-Tuning, NDCG + Hit Rate für Systemvergleiche.
+
+### 2.2 Generations-Metriken (Wie gut ist die generierte Antwort?)
+
+| Metrik | Was sie misst | Berechnung |
+|---|---|---|
+| **Faithfulness** | Ist die Antwort faktisch im Kontext verankert? | Antwort wird in Einzelaussagen zerlegt, jede wird gegen Kontext geprüft. Score = gestützte / alle Aussagen |
+| **Answer Relevancy** | Beantwortet die Antwort die Frage? | Aus der Antwort werden hypothetische Fragen generiert → Cosine Similarity mit Originalfrage |
+| **Hallucination Rate** | Enthält die Antwort nicht-gestützte Behauptungen? | 1 - Faithfulness |
+| **Answer Correctness** | Ist die Antwort faktisch korrekt? (braucht Ground Truth) | F1 über extrahierte Fakten + semantische Ähnlichkeit zur Referenzantwort |
+
+### 2.3 End-to-End-Metriken
+
+| Metrik | Was sie misst |
+|---|---|
+| **Answer Similarity** | Semantische Ähnlichkeit zwischen generierter und erwarteter Antwort |
+| **Latency (P50, P95, P99)** | Antwortzeit von Query bis Response |
+| **Token Efficiency** | Verhältnis nützlicher Kontext-Tokens zu total abgerufenen Tokens |
+| **Cost per Query** | Token-Verbrauch und API-Kosten pro Anfrage |
+
+---
+
+## 3. Evaluation-Frameworks
+
+### 3.1 Java / Spring AI (nativ verfügbar!)
+
+Spring AI 1.1.x hat **zwei eingebaute Evaluatoren**, die sofort nutzbar sind:
+
+#### RelevancyEvaluator
+- Prüft, ob die KI-Antwort relevant zur Frage ist (bezogen auf den abgerufenen Kontext)
+- Gibt `isPass()` true/false zurück
+- Nutzt ein LLM zur Bewertung
+
+#### FactCheckingEvaluator
+- Prüft faktische Korrektheit der Antwort gegen den abgerufenen Kontext
+- Erkennt Halluzinationen
+- Gibt ebenfalls pass/fail zurück
+
+**Evaluierungs-Modell-Tipp:** `bespoke-minicheck` (Bespoke Labs) ist speziell für Fact-Checking trainiert, sehr effizient (nur yes/no Output), und top-gerankt auf dem LLM-AggreFact Leaderboard.
+
+**Vorteil:** Native Java, integriert direkt in JUnit-Tests und CI/CD.
+
+### 3.2 Python-Frameworks (umfangreichere Metriken)
+
+Alle großen RAG-Evaluation-Frameworks sind Python-basiert:
+
+#### RAGAS (de-facto Standard)
+- Open-Source, referenz-frei (braucht keine Ground Truth für viele Metriken)
+- LLM-as-a-Judge Ansatz
+- Metriken: Faithfulness, Answer Relevancy, Context Precision, Context Recall
+- Paper: arXiv:2309.15217
+
+#### DeepEval
+- pytest-artig mit pass/fail Thresholds
+- Integriert RAGAS-Metriken
+- G-Eval: Eigene Bewertungskriterien mit Chain-of-Thought
+- Gut für CI/CD-Integration
+
+#### TruLens
+- "RAG Triad": Context Relevance + Groundedness + Answer Relevance
+- OpenTelemetry-basiertes Tracing
+- Gut für qualitative Analyse
+
+#### LangSmith
+- Kommerziell (LangChain)
+- Offline- und Online-Evaluation
+- Pairwise-Vergleiche
+- REST API für Java-Integration
+
+#### Weitere
+- **Giskard:** Fokus auf Safety/Halluzinations-Tests
+- **Langfuse:** Open-Source Observability mit RAGAS-Integration
+- **Phoenix (Arize):** LLM-Observability mit OpenTelemetry
+
+### 3.3 Java-Integration: Hybrid-Ansatz
+
+Da alle umfassenden Frameworks Python-basiert sind:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ CI/CD Pipeline                                      │
+│                                                     │
+│  JUnit Tests                Python Sidecar (Docker) │
+│  ┌─────────────────┐       ┌─────────────────────┐  │
+│  │ Spring AI        │       │ RAGAS / DeepEval    │  │
+│  │ RelevancyEval    │       │ - Faithfulness      │  │
+│  │ FactCheckingEval │       │ - Answer Relevancy  │  │
+│  │ Hit Rate, MRR    │       │ - Context Precision │  │
+│  └────────┬────────┘       │ - Context Recall    │  │
+│           │                └────────┬────────────┘  │
+│           └──────────┬─────────────┘                │
+│                      ▼                              │
+│              Shared Golden Dataset (JSON)            │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Benchmark-Datensätze
+
+### 4.1 Standardisierte Retrieval-Benchmarks
+
+| Benchmark | Beschreibung | Sprachen | Primärmetrik |
+|---|---|---|---|
+| **MTEB** | 58 Datasets, 8 Aufgabentypen, DER Standard für Embedding-Vergleiche | primär EN | diverse |
+| **BEIR** | 18 Datasets für Zero-Shot Retrieval (Subset von MTEB) | EN | NDCG@10 |
+| **MS MARCO** | 1M+ Bing-Fragen mit menschlich annotierten Antworten | EN | MRR@10 |
+| **Natural Questions** | Echte Google-Suchanfragen mit Wikipedia-Antworten | EN | EM/F1 |
+| **HotpotQA** | Multi-Hop-Fragen (Infos aus mehreren Dokumenten kombinieren) | EN | EM/F1 |
+
+### 4.2 End-to-End RAG-Benchmarks
+
+| Benchmark | Beschreibung | Besonderheit |
+|---|---|---|
+| **RAGBench** | 100k+ Beispiele, 5 Domänen, annotiert für Halluzination/Faithfulness | arXiv:2407.11005 |
+| **Open RAG Benchmark (Vectara)** | 1000 arXiv-PDFs, 3045 Q&A-Paare, Text + Tabellen + Bilder | Multimodal, PDF-fokussiert |
+| **MultiHop-RAG** | Multi-Hop Reasoning über mehrere Dokumente | Komplexe Retrieval-Szenarien |
+
+### 4.3 Deutsche / mehrsprachige Benchmarks
+
+| Benchmark | Sprachen | Beschreibung |
+|---|---|---|
+| **MEMERAG** | 5 Sprachen (inkl. DE) | Multilingual RAG Meta-Evaluation, basiert auf MIRACL |
+| **MIRAGE-Bench** | 18 Sprachen (inkl. DE) | 11.195 Evaluation-Paare, menschlich generierte Fragen |
+| **XRAG** | 5 Sprachen (inkl. DE) | Cross-lingual RAG (Query-Sprache ≠ Dokument-Sprache) |
+
+**Realität:** Deutsche RAG-Benchmarks sind noch begrenzt. Für domänenspezifische Evaluation muss ein eigener Golden Dataset erstellt werden.
+
+---
+
+## 5. Golden Dataset aufbauen (eigene Testdaten)
+
+### Was ist ein Golden Dataset?
+
+Eine kuratierte, versionierte Sammlung von **(Frage, erwartete relevante Dokumente, erwartete Antwort)** — die Ground Truth für euer System.
+
+### Schritt-für-Schritt
+
+#### 1. Synthetische Daten generieren ("Silver Dataset")
+- LLM generiert Frage-Antwort-Paare aus euren echten Dokumenten
+- RAGAS bietet einen `TestsetGenerator` dafür
+- Schnell skalierbar (hunderte Paare in Minuten)
+
+#### 2. Experten-Review ("Silver → Gold")
+- Fachexperten prüfen und korrigieren die generierten Paare
+- Inter-Annotator Agreement messen (Cohen's Kappa)
+- Falsche, uneindeutige oder triviale Fragen aussortieren
+
+#### 3. Struktur pro Testfall
+
+```json
+{
+  "id": "q-042",
+  "query": "Welche Chunking-Strategie wird für PowerPoint empfohlen?",
+  "expected_documents": ["discussion-retrieval-document-pipelines.md"],
+  "expected_answer_contains": ["pro Folie", "Kontext anreichern", "Folientitel"],
+  "category": "architecture",
+  "difficulty": "medium",
+  "language": "de",
+  "type": "factual"
+}
+```
+
+#### 4. Diversität sicherstellen
+- Verschiedene Fragetypen: faktisch, vergleichend, Multi-Hop
+- Verschiedene Dokumenttypen abdecken
+- Verschiedene Schwierigkeitsgrade
+- Edge Cases (leere Dokumente, sehr kurze Chunks, gemischtsprachig)
+
+#### 5. Empfohlene Größe
+- **Start:** 50–100 hochwertige Testfälle
+- **Umfassend:** 200–500
+- **Qualität > Quantität** — 50 saubere Paare sind besser als 500 unsaubere
+
+#### 6. Versionierung
+- Golden Dataset wie Code behandeln: Git, Reviews, Changelog
+- Aktualisieren wenn sich der Dokumentenkorpus ändert
+
+---
+
+## 6. LLM-as-a-Judge: Best Practices
+
+### Grundprinzip
+Ein LLM bewertet die Ausgabe eines anderen LLM anhand definierter Kriterien.
+
+### Empfehlungen für zuverlässige Bewertungen
+
+1. **Strukturierte Rubrics:** Explizite Bewertungskriterien (1–5 Skala oder binär) mit klaren Beschreibungen pro Stufe
+2. **Kalibrierung:** Pilot-Runde, in der Mensch und LLM dieselben Samples bewerten → Alignment messen (Cohen's Kappa)
+3. **Mehrere Judge-Modelle:** 2–3 verschiedene LLMs bewerten, Mehrheitsentscheid oder Durchschnitt
+4. **Position Bias vermeiden:** LLMs bevorzugen oft die erste/letzte Option bei Paarvergleichen → Reihenfolge randomisieren
+5. **Chain-of-Thought:** Judge soll seine Bewertung begründen → interpretierbar und auditierbar
+
+---
+
+## 7. Konfigurationen statistisch sauber vergleichen
+
+### Das Ziel
+> "Konfiguration A (Modell X + Embedding Y) liefert signifikant bessere Antworten als Konfiguration B"
+
+### Methode: Gepaarter Vergleich
+
+#### Schritt 1: Metriken definieren
+- 2–3 Primärmetriken auswählen (z.B. Faithfulness + Answer Relevancy + Hit Rate@5)
+- Ggf. Gewichtung für Composite Score
+
+#### Schritt 2: Gepaarte Evaluation
+- **Beide** Konfigurationen auf **denselben** Golden Dataset laufen lassen
+- Pro Query: (Score_A, Score_B) → Paarung eliminiert Dataset-Varianz
+
+#### Schritt 3: Mehrere Durchläufe
+- Bei Randomisierung (LLM Temperature, Sampling): Jeden Lauf mehrfach wiederholen
+- Verteilung statt Einzelwert
+
+#### Schritt 4: Statistische Signifikanz
+
+**Empfohlen: Paired Bootstrap Test**
+1. Gepaarte Multi-Seed-Evaluation durchführen
+2. BCa (Bias-corrected and accelerated) Bootstrap-Konfidenzintervalle auf Score-Deltas berechnen
+3. Sign-Flip Permutationstest auf Per-Seed-Deltas
+4. Verbesserung nur behaupten wenn: Konfidenzintervall komplett über 0 UND p < 0.05
+
+**Einfachere Alternative:** Wilcoxon Signed-Rank Test (nicht-parametrisch, funktioniert gut bei kleinen Samples)
+
+#### Reporting-Template
+
+```
+Konfiguration A: Ollama/nomic-v2 + TokenSplitter(1000), top_k=5
+Konfiguration B: Ollama/nomic-v2 + ParagraphPdfReader + TokenSplitter(600), top_k=5
+
+Golden Dataset: 100 Queries, 3 Dokumentkategorien, DE + EN
+
+Ergebnisse (Mean ± 95% CI):
+  Faithfulness:     A: 0.82 ± 0.04   B: 0.89 ± 0.03   Δ: +0.07 (p=0.008)
+  Answer Relevancy: A: 0.79 ± 0.05   B: 0.84 ± 0.04   Δ: +0.05 (p=0.021)
+  Hit Rate@5:       A: 0.85 ± 0.04   B: 0.91 ± 0.03   Δ: +0.06 (p=0.014)
+
+Fazit: Konfiguration B zeigt signifikante Verbesserung über alle Metriken
+       (alle p < 0.05, Paired Bootstrap Test).
+```
+
+### Was man NICHT tun sollte
+- Einzelne Aggregatzahl ohne Konfidenzintervall berichten
+- Verbesserung auf Basis eines einzigen Laufs behaupten
+- Verschiedene Golden Datasets für A und B verwenden
+
+---
+
+## 8. Empfohlener Ansatz für OPAA
+
+### Phase 1: Sofort (Spring AI nativ)
+
+- `RelevancyEvaluator` + `FactCheckingEvaluator` in Integrationstests einbauen
+- Hit Rate und MRR direkt über pgvector-Queries messen
+- 50 Testfälle als Golden Dataset erstellen (JSON, im Repo versioniert)
+
+### Phase 2: Kurzfristig (Retrieval-Metriken)
+
+- Retrieval-Metriken (Hit Rate, MRR, Precision@k) als JUnit-Tests
+- Golden Dataset auf 100–200 Testfälle erweitern
+- A/B-Vergleiche bei Pipeline-Änderungen (z.B. `ParagraphPdfReader` vs. `TikaReader`)
+
+### Phase 3: Mittelfristig (umfassende Evaluation)
+
+- Python-Sidecar (Docker) mit RAGAS für Faithfulness, Context Precision/Recall
+- Shared Golden Dataset zwischen Java und Python (JSON)
+- Automatisierte Vergleiche in CI/CD bei Modell- oder Pipeline-Änderungen
+
+### Phase 4: Langfristig
+
+- Eigener deutscher Benchmark aus Domänendaten
+- Online-Evaluation auf Produktionsdaten (Langfuse oder Phoenix)
+- Regelmäßige Recalibration der LLM-as-Judge gegen menschliche Bewertungen
+
+---
+
+## 9. Zusammenfassung der Kernerkenntnisse
+
+| Erkenntnis | Detail |
+|---|---|
+| Spring AI hat eingebaute Evaluatoren | `RelevancyEvaluator` + `FactCheckingEvaluator` — sofort nutzbar in JUnit |
+| Umfassende Frameworks sind Python-only | RAGAS, DeepEval, TruLens — Integration über Docker-Sidecar möglich |
+| Golden Dataset ist der Schlüssel | 50–100 kuratierte Testfälle, versioniert wie Code |
+| Retrieval und Generation separat messen | Unterschiedliche Metriken für unterschiedliche Probleme |
+| Statistische Signifikanz ist Pflicht | Gepaarter Bootstrap-Test oder Wilcoxon, nie Einzelwerte vergleichen |
+| Deutsche Benchmarks sind begrenzt | MEMERAG und MIRAGE-Bench existieren, aber eigener Golden Dataset ist nötig |
+| `bespoke-minicheck` als Evaluierungs-LLM | Effizienter und genauer als GPT-4o für Fact-Checking |
+
+---
+
+## 10. Referenzen
+
+- RAGAS: https://docs.ragas.io/
+- DeepEval: https://deepeval.com/
+- TruLens: https://www.trulens.org/
+- Spring AI Evaluation: https://docs.spring.io/spring-ai/reference/api/testing.html
+- RAGBench: arXiv:2407.11005
+- MEMERAG: arXiv:2502.17163
+- MIRAGE-Bench: https://mirage-bench.github.io/
+- Paired Bootstrap Protocol: arXiv:2511.19794
+- BES4RAG Framework: ACL Anthology 2025

--- a/docs/discussions/discussion-retrieval-document-pipelines.md
+++ b/docs/discussions/discussion-retrieval-document-pipelines.md
@@ -1,0 +1,221 @@
+# Discussion: Retrieval-Pipelines pro Dokumenttyp
+
+**Thema:** Dokumenttyp-spezifische Parsing- und Chunking-Strategien für Enterprise-RAG mit Spring AI
+
+**Kontext:** Aufbauend auf der [Embedding-Diskussion](discussion-embeddings.md). OPAA nutzt aktuell `TikaDocumentReader` + `TokenTextSplitter` (1000 Tokens) einheitlich für alle Formate. Diese Diskussion behandelt, warum und wie das differenziert werden sollte.
+
+**Bezug zum Code:** `DocumentService`, `ChunkingService`, `FileProcessingService` im Package `io.opaa.indexing`
+
+---
+
+## 1. Aktueller Stand: Ein Reader, ein Splitter für alles
+
+```
+Alle Dateien → TikaDocumentReader → TokenTextSplitter(1000) → VectorStore
+```
+
+**Probleme:**
+- Tika gibt für PPTX alle Folien als einen Textblock zurück (Foliengrenzen verloren)
+- PDF-Kapitelstruktur geht verloren (nur Rohtext)
+- Markdown-Heading-Struktur wird ignoriert
+- Source Code wird mitten in Funktionen geschnitten
+- Einheitlich 1000 Tokens ist für manche Typen zu viel, für andere zu wenig
+
+---
+
+## 2. Spring AI bietet spezialisierte Reader (ungenutzt)
+
+Spring AI 1.1.x hat **7 DocumentReader-Implementierungen** — OPAA nutzt aktuell nur eine davon.
+
+### Sofort nutzbare Reader (nur Dependency hinzufügen)
+
+| Reader | Artifact | Vorteil gegenüber Tika |
+|---|---|---|
+| `ParagraphPdfDocumentReader` | `spring-ai-pdf-document-reader` | Nutzt PDF-Katalog/TOC → kapitel-aware Splitting |
+| `PagePdfDocumentReader` | `spring-ai-pdf-document-reader` | 1 Seite = 1 Document (saubere Seitengrenzen) |
+| `MarkdownDocumentReader` | `spring-ai-markdown-document-reader` | Splittet nach Headers/Paragraphen |
+| `JsoupDocumentReader` | `spring-ai-jsoup-document-reader` | HTML mit CSS-Selektoren, besser als Tika für HTML |
+| `JsonReader` | core (bereits vorhanden) | JSONPath-Support |
+| `TextReader` | core (bereits vorhanden) | Einfacher Plain-Text-Reader |
+
+### Nicht verfügbar (eigene Implementierung nötig)
+
+| Format | Grund | Lösung |
+|---|---|---|
+| **PPTX pro Folie** | Kein Framework bietet das | Eigener Reader via Apache POI (`XMLSlideShow`) |
+| **Source Code pro Funktion** | Kein Framework bietet das | Eigener Reader mit Regex oder Tree-Sitter |
+| **E-Mail granular** | Tika parst E-Mails, aber Body+Attachments als Block | Ggf. eigener Reader für separate Attachment-Behandlung |
+
+---
+
+## 3. Tika bleibt — als Fallback
+
+Apache Tika ist nicht obsolet. Es bleibt der beste universelle Parser für:
+
+- **E-Mails** (.eml, .msg, .mbox) — parst Headers, Body, Attachments nativ
+- **Office-Formate** (.docx, .xlsx) — solide Textextraktion
+- **Unbekannte/neue Formate** — 1000+ Formate ohne Codeänderung
+- **Alle Formate ohne spezialisierten Reader** — generischer Fallback
+
+**Fazit:** Tika = Sicherheitsnetz. Spezialisierte Reader = Qualität.
+
+---
+
+## 4. Empfohlene Pipeline-Architektur
+
+### Konzept: Reader + Splitter pro Dateityp
+
+```
+┌─────────────┬──────────────────────────┬─────────────────────┬─────────────┐
+│ Dateityp    │ Reader                   │ Splitter            │ Chunk-Size  │
+├─────────────┼──────────────────────────┼─────────────────────┼─────────────┤
+│ .pdf        │ ParagraphPdfDocReader     │ TokenTextSplitter   │ 600 Tokens  │
+│ .md         │ MarkdownDocumentReader    │ (kein Split nötig)  │ per Header  │
+│ .pptx       │ PptxSlideReader (eigener) │ (kein Split nötig)  │ per Folie   │
+│ .html       │ JsoupDocumentReader       │ TokenTextSplitter   │ 500 Tokens  │
+│ .java/.py   │ CodeReader (eigener)      │ (kein Split nötig)  │ per Funktion│
+│ .eml/.msg   │ TikaDocumentReader        │ TokenTextSplitter   │ 400 Tokens  │
+│ .docx/.txt  │ TikaDocumentReader        │ TokenTextSplitter   │ 800 Tokens  │
+│ (Fallback)  │ TikaDocumentReader        │ TokenTextSplitter   │ 800 Tokens  │
+└─────────────┴──────────────────────────┴─────────────────────┴─────────────┘
+```
+
+### Umsetzungsskizze im Code
+
+**DocumentService** — Reader-Auswahl nach Extension:
+
+```java
+// Konzeptionell
+DocumentReader resolveReader(Resource resource, String extension) {
+    return switch (extension) {
+        case ".pdf"  -> new ParagraphPdfDocumentReader(resource);
+        case ".md"   -> new MarkdownDocumentReader(resource);
+        case ".html" -> new JsoupDocumentReader(resource);
+        case ".pptx" -> new PptxSlideDocumentReader(resource); // eigener
+        default      -> new TikaDocumentReader(resource);       // Fallback
+    };
+}
+```
+
+**ChunkingService** — Splitter-Konfiguration nach Dateityp:
+
+```java
+// Konzeptionell
+TokenTextSplitter resolveSplitter(String extension) {
+    int chunkSize = switch (extension) {
+        case ".pdf"  -> 600;
+        case ".html" -> 500;
+        case ".eml", ".msg" -> 400;
+        default -> 800;
+    };
+    return new TokenTextSplitter(chunkSize, 350, 5, 10000, true);
+}
+```
+
+---
+
+## 5. Schwäche von Spring AI: Nur ein Splitter
+
+Spring AI bietet **nur `TokenTextSplitter`**. Es gibt keinen Paragraph-, Sentence- oder Recursive-Splitter.
+
+### Vergleich mit LangChain4j
+
+| Splitter | Spring AI | LangChain4j |
+|---|---|---|
+| Token-basiert | `TokenTextSplitter` | (ähnlich) |
+| Paragraph-basiert | - | `DocumentByParagraphSplitter` |
+| Satz-basiert | - | `DocumentBySentenceSplitter` |
+| Regex-basiert | - | `DocumentByRegexSplitter` |
+| Rekursiv (hierarchisch) | - | `DocumentSplitters.recursive()` |
+
+**Empfehlung:** Nicht zu LangChain4j wechseln — stattdessen bei Bedarf eigene `DocumentTransformer`-Implementierungen bauen (Spring AI Interface ist einfach). Für den Start reicht der `TokenTextSplitter` mit typspezifischer Konfiguration.
+
+---
+
+## 6. Weitere Formate: E-Mails, Wiki, Zukunft
+
+### E-Mails (.eml, .msg)
+
+- **Parser:** `TikaDocumentReader` (unterstützt E-Mail-Formate nativ)
+- **Tika extrahiert:** Headers (From, To, Subject, Date), Body, Attachment-Text
+- **Verbesserung:** Eigener Reader, der Subject+Sender als Metadaten speichert und Attachments separat chunked
+
+### Wiki-Seiten (Confluence, MediaWiki)
+
+- **Kein Framework bietet native Wiki-Reader**
+- **Praxis:** Export als HTML → `JsoupDocumentReader`
+- **Oder:** Confluence REST API → HTML → JsoupDocumentReader
+
+### Weitere Office-Formate (.xlsx, .csv)
+
+- **Tabellen:** Tika extrahiert den Text, aber Tabellenstruktur geht verloren
+- **Besser:** Apache POI direkt für strukturiertes Row/Column-Parsing
+- **CSV:** `JsonReader` mit Vorverarbeitung oder eigener Reader
+
+---
+
+## 7. Community-Option: Docling (IBM)
+
+**Artifact:** `io.arconia:arconia-ai-docling-document-reader`
+
+Open-Source-Projekt von IBM für layout-aware Dokumentenparsing:
+- ~97.9% Accuracy bei komplexen Tabellen
+- Erkennt Dokumentstruktur (Überschriften, Absätze, Tabellen, Bilder)
+- Spring AI Integration via Arconia (Community, seit Dezember 2025)
+
+**Einschätzung:** Interessant für komplexe PDFs mit Tabellen/Grafiken. Für den Start nicht nötig — `ParagraphPdfDocumentReader` reicht. Als Option im Hinterkopf behalten.
+
+---
+
+## 8. Entscheidung: Eine Pipeline pro Dokumenttyp
+
+### Warum?
+
+- Verschiedene Formate haben **unterschiedliche semantische Dichten**
+- Ein Universal-Ansatz erzeugt entweder zu große oder zu kleine Chunks
+- Strukturinformationen (Kapitel, Folien, Funktionen) gehen sonst verloren
+- Neue Formate können sauber hinzugefügt werden, ohne bestehende zu beeinflussen
+
+### Architektur-Prinzip
+
+```
+DocumentPipeline (Interface)
+  ├── PdfPipeline         → ParagraphPdfReader + TokenSplitter(600)
+  ├── MarkdownPipeline    → MarkdownReader (header-based, kein extra Split)
+  ├── PptxPipeline        → PptxSlideReader (eigener, pro Folie)
+  ├── HtmlPipeline        → JsoupReader + TokenSplitter(500)
+  ├── CodePipeline        → CodeReader (eigener, pro Funktion)
+  └── DefaultPipeline     → TikaReader + TokenSplitter(800)  ← Fallback
+```
+
+Jede Pipeline definiert:
+1. **Welcher Reader** parst das Dokument
+2. **Welcher Splitter** (falls nötig) chunked den Output
+3. **Welche Metadaten** angereichert werden (Kapitel, Foliennummer, Funktionsname, ...)
+4. **Welche Chunk-Größe** verwendet wird
+
+### Erweiterbarkeit
+
+Neue Formate hinzufügen = neue Pipeline-Klasse + Extension registrieren. Kein bestehender Code wird geändert (Open-Closed Principle).
+
+---
+
+## 9. Nächste Schritte
+
+1. **Quick Win:** `ParagraphPdfDocumentReader` und `MarkdownDocumentReader` als Dependencies hinzufügen und in `DocumentService` einbauen
+2. **Pipeline-Abstraktion:** `DocumentPipeline`-Interface + Registry im `ChunkingService`/`DocumentService`
+3. **Eigene Reader:** `PptxSlideDocumentReader` (Apache POI)
+4. **Später:** Code-Reader, E-Mail-Reader, Docling evaluieren
+
+---
+
+## 10. Zusammenfassung der Kernerkenntnisse
+
+| Erkenntnis | Detail |
+|---|---|
+| Spring AI hat mehr Reader als wir nutzen | `ParagraphPdfReader`, `MarkdownReader`, `JsoupReader` sofort einsetzbar |
+| Tika bleibt als Fallback | Universell, 1000+ Formate, besonders gut für E-Mails |
+| Pipeline pro Dokumenttyp ist der richtige Ansatz | Unterschiedliche Reader, Splitter und Chunk-Sizes pro Format |
+| Spring AI Splitter-Auswahl ist begrenzt | Nur `TokenTextSplitter`, aber für den Start ausreichend |
+| PPTX und Code brauchen eigene Reader | ~100-200 Zeilen pro Reader, POI ist schon als Dependency da |
+| Docling als Zukunftsoption | Layout-aware PDF-Parsing, Community-Integration vorhanden |


### PR DESCRIPTION
## Summary
- Add `discussion-embeddings.md`: Diskussion zu Embedding-Strategien
- Add `discussion-rag-evaluation.md`: Diskussion zu RAG-Evaluierungsmethoden
- Add `discussion-retrieval-document-pipelines.md`: Diskussion zu Retrieval-Pipelines

## Test plan
- [x] Dateien im Repository sichtbar
- [x] Keine Code-Änderungen, daher kein funktionaler Testbedarf

🤖 Generated with [Claude Code](https://claude.com/claude-code)