### PR TITLE
fix: safeguard Axios error response type assertion

### DIFF
--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,4 +1,6 @@
+import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
+import { server } from '../mocks/server'
 import { getHealth, sendQuery } from './api'
 
 describe('api service', () => {
@@ -15,6 +17,44 @@ describe('api service', () => {
       expect(result.answer).toBeDefined()
       expect(result.sources.length).toBeGreaterThanOrEqual(1)
       expect(result.metadata.model).toBe('gpt-4o')
+    })
+  })
+
+  describe('normalizeError', () => {
+    it('throws error message from valid ErrorResponse JSON', async () => {
+      server.use(
+        http.get('/api/health', () => {
+          return HttpResponse.json(
+            { error: 'Service unavailable', status: 503, timestamp: new Date().toISOString() },
+            { status: 503 },
+          )
+        }),
+      )
+
+      await expect(getHealth()).rejects.toThrow('Service unavailable')
+    })
+
+    it('falls back to HTTP status when response is not JSON ErrorResponse', async () => {
+      server.use(
+        http.get('/api/health', () => {
+          return new HttpResponse('<html>Bad Gateway</html>', {
+            status: 502,
+            headers: { 'Content-Type': 'text/html' },
+          })
+        }),
+      )
+
+      await expect(getHealth()).rejects.toThrow(/HTTP 502/)
+    })
+
+    it('falls back to error message on network error', async () => {
+      server.use(
+        http.get('/api/health', () => {
+          return HttpResponse.error()
+        }),
+      )
+
+      await expect(getHealth()).rejects.toThrow()
     })
   })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosError } from 'axios'
 import type {
-  ErrorResponse,
   HealthResponse,
   IndexingStatusResponse,
   QueryRequest,
   QueryResponse,
 } from '../types/api'
+import { isErrorResponse } from '../types/api'
 
 const client = axios.create({
   baseURL: '/api',
@@ -13,8 +13,17 @@ const client = axios.create({
 
 function normalizeError(err: unknown): never {
   if (err instanceof AxiosError) {
-    const data = err.response?.data as ErrorResponse | undefined
-    throw new Error(data?.error ?? err.message)
+    const data = err.response?.data
+
+    if (isErrorResponse(data)) {
+      throw new Error(data.error)
+    }
+
+    if (err.response?.status) {
+      throw new Error(`HTTP ${err.response.status}: ${err.message}`)
+    }
+
+    throw new Error(err.message)
   }
   throw err
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -44,3 +44,12 @@ export interface ErrorResponse {
   status: number
   timestamp: string
 }
+
+export function isErrorResponse(data: unknown): data is ErrorResponse {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'error' in data &&
+    typeof (data as Record<string, unknown>).error === 'string'
+  )
+}


### PR DESCRIPTION
## Summary

- Add `isErrorResponse` type guard to safely validate `err.response.data` before property access
- Rewrite `normalizeError` with graceful fallback chain (JSON error → HTTP status → network error)
- Add 3 tests covering valid ErrorResponse, HTML/non-JSON response, and network error scenarios

## Related Issues

Closes #75

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Claude Opus 4.6)
- [ ] This PR was co-authored by human + AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)