### PR TITLE
Add branch protection rules for main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+repository:
+  name: opaa
+  description: Open Project AI Assistant
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI / backend
+          - CI / backend-integration
+          - CI / frontend
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+      required_conversation_resolution: true
+      enforce_admins: false
+      restrict_pushes:
+        push_allowance: []  # Nobody can push directly to main


### PR DESCRIPTION
## Summary
Add GitHub branch protection configuration via `.github/settings.yml` to enforce CI checks and code review requirements for the main branch.

## Changes
- Require all CI jobs (backend, backend-integration, frontend) to pass before merging
- Require 1 approval on pull requests
- Dismiss stale reviews automatically
- Require conversation resolution before merging
- Prevent direct pushes to main branch

## Installation
Install the [probot/settings](https://github.com/apps/settings) GitHub App on this repository to apply these protection rules automatically.

Closes #102

🤖 Generated with Claude Code