### PR TITLE
fix: store CLA signatures on unprotected branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/criew/opaa/blob/main/CLA.md
-          branch: main
+          branch: cla-signatures
           allowlist: criew,*[bot]
           create-file-commit-message: "chore: initialize CLA signatures file"
           signed-commit-message: "chore: add $contributorName to CLA signatories"


### PR DESCRIPTION
## Summary

- Change CLA signature storage from `main` to dedicated `cla-signatures` branch
- Fixes: CLA bot cannot commit to `main` due to branch protection rules

## Related Issues

Closes the CLA bot error: `Could not create file: Changes must be made through a pull request`

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [ ] This PR was authored by an AI agent (specify: _______)
- [x] This PR was co-authored by human + AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)