### PR TITLE
feat(workspace): membership API and personal workspace auto-creation

### DIFF
--- a/backend/src/main/java/io/opaa/api/WorkspaceController.java
+++ b/backend/src/main/java/io/opaa/api/WorkspaceController.java
@@ -1,8 +1,12 @@
 package io.opaa.api;
 
+import io.opaa.api.dto.WorkspaceAddMemberRequest;
 import io.opaa.api.dto.WorkspaceListResponse;
+import io.opaa.api.dto.WorkspaceMemberResponse;
 import io.opaa.api.dto.WorkspaceRequest;
 import io.opaa.api.dto.WorkspaceResponse;
+import io.opaa.api.dto.WorkspaceRoleUpdateRequest;
+import io.opaa.api.dto.WorkspaceTransferOwnershipRequest;
 import io.opaa.auth.SystemRole;
 import io.opaa.auth.User;
 import io.opaa.auth.UserService;
@@ -81,6 +85,54 @@ public class WorkspaceController {
     User currentUser = currentUser(jwt);
     workspaceService.deleteWorkspace(
         workspaceId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{workspaceId}/members")
+  public List<WorkspaceMemberResponse> listMembers(
+      @PathVariable UUID workspaceId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return workspaceService.listMembers(workspaceId, currentUser.getId());
+  }
+
+  @PostMapping("/{workspaceId}/members")
+  public ResponseEntity<WorkspaceMemberResponse> addMember(
+      @PathVariable UUID workspaceId,
+      @Valid @RequestBody WorkspaceAddMemberRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    WorkspaceMemberResponse response =
+        workspaceService.addMember(
+            workspaceId, request.userId(), request.role(), currentUser.getId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @DeleteMapping("/{workspaceId}/members/{userId}")
+  public ResponseEntity<Void> removeMember(
+      @PathVariable UUID workspaceId, @PathVariable UUID userId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    workspaceService.removeMember(workspaceId, userId, currentUser.getId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @PutMapping("/{workspaceId}/members/{userId}/role")
+  public WorkspaceMemberResponse updateMemberRole(
+      @PathVariable UUID workspaceId,
+      @PathVariable UUID userId,
+      @Valid @RequestBody WorkspaceRoleUpdateRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return workspaceService.updateMemberRole(
+        workspaceId, userId, request.role(), currentUser.getId());
+  }
+
+  @PostMapping("/{workspaceId}/transfer-ownership")
+  public ResponseEntity<Void> transferOwnership(
+      @PathVariable UUID workspaceId,
+      @Valid @RequestBody WorkspaceTransferOwnershipRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    workspaceService.transferOwnership(workspaceId, request.userId(), currentUser.getId());
     return ResponseEntity.noContent().build();
   }
 

--- a/backend/src/main/java/io/opaa/api/dto/WorkspaceAddMemberRequest.java
+++ b/backend/src/main/java/io/opaa/api/dto/WorkspaceAddMemberRequest.java
@@ -1,0 +1,7 @@
+package io.opaa.api.dto;
+
+import io.opaa.workspace.WorkspaceRole;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record WorkspaceAddMemberRequest(@NotNull UUID userId, WorkspaceRole role) {}

--- a/backend/src/main/java/io/opaa/api/dto/WorkspaceRoleUpdateRequest.java
+++ b/backend/src/main/java/io/opaa/api/dto/WorkspaceRoleUpdateRequest.java
@@ -1,0 +1,6 @@
+package io.opaa.api.dto;
+
+import io.opaa.workspace.WorkspaceRole;
+import jakarta.validation.constraints.NotNull;
+
+public record WorkspaceRoleUpdateRequest(@NotNull WorkspaceRole role) {}

--- a/backend/src/main/java/io/opaa/api/dto/WorkspaceTransferOwnershipRequest.java
+++ b/backend/src/main/java/io/opaa/api/dto/WorkspaceTransferOwnershipRequest.java
@@ -1,0 +1,6 @@
+package io.opaa.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record WorkspaceTransferOwnershipRequest(@NotNull UUID userId) {}

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -1,5 +1,10 @@
 package io.opaa.auth;
 
+import io.opaa.workspace.Workspace;
+import io.opaa.workspace.WorkspaceMembership;
+import io.opaa.workspace.WorkspaceRepository;
+import io.opaa.workspace.WorkspaceRole;
+import io.opaa.workspace.WorkspaceType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -14,37 +19,49 @@ import org.springframework.transaction.annotation.Transactional;
 @EnableConfigurationProperties(AuthProperties.class)
 public class UserService {
 
+  private static final String PERSONAL_WORKSPACE_NAME = "My Documents";
+  private static final String PERSONAL_WORKSPACE_DESCRIPTION = "Private personal workspace";
+
   private final UserRepository userRepository;
+  private final WorkspaceRepository workspaceRepository;
   private final AuthProperties authProperties;
 
-  public UserService(UserRepository userRepository, AuthProperties authProperties) {
+  public UserService(
+      UserRepository userRepository,
+      WorkspaceRepository workspaceRepository,
+      AuthProperties authProperties) {
     this.userRepository = userRepository;
+    this.workspaceRepository = workspaceRepository;
     this.authProperties = authProperties;
   }
 
   @Transactional
   public User findOrCreateUser(String subject, String issuer, String email, String displayName) {
-    return userRepository
-        .findBySubjectAndIssuer(subject, issuer)
-        .map(
-            existing -> {
-              existing.setLastLoginAt(Instant.now());
-              if (email != null) {
-                existing.setEmail(email);
-              }
-              if (displayName != null) {
-                existing.setDisplayName(displayName);
-              }
-              return userRepository.save(existing);
-            })
-        .orElseGet(
-            () -> {
-              User newUser = new User(subject, issuer, email, displayName);
-              if (isInitialAdmin(email)) {
-                newUser.setSystemRole(SystemRole.SYSTEM_ADMIN);
-              }
-              return userRepository.save(newUser);
-            });
+    User user =
+        userRepository
+            .findBySubjectAndIssuer(subject, issuer)
+            .map(
+                existing -> {
+                  existing.setLastLoginAt(Instant.now());
+                  if (email != null) {
+                    existing.setEmail(email);
+                  }
+                  if (displayName != null) {
+                    existing.setDisplayName(displayName);
+                  }
+                  return userRepository.save(existing);
+                })
+            .orElseGet(
+                () -> {
+                  User newUser = new User(subject, issuer, email, displayName);
+                  if (isInitialAdmin(email)) {
+                    newUser.setSystemRole(SystemRole.SYSTEM_ADMIN);
+                  }
+                  return userRepository.save(newUser);
+                });
+
+    ensurePersonalWorkspace(user);
+    return user;
   }
 
   public Optional<User> findBySubjectAndIssuer(String subject, String issuer) {
@@ -74,5 +91,20 @@ public class UserService {
     return initialAdminEmail != null
         && !initialAdminEmail.isBlank()
         && initialAdminEmail.equalsIgnoreCase(email);
+  }
+
+  private void ensurePersonalWorkspace(User user) {
+    if (workspaceRepository.existsByOwnerIdAndType(user.getId(), WorkspaceType.PERSONAL)) {
+      return;
+    }
+
+    Workspace personalWorkspace =
+        new Workspace(
+            PERSONAL_WORKSPACE_NAME,
+            PERSONAL_WORKSPACE_DESCRIPTION,
+            WorkspaceType.PERSONAL,
+            user.getId());
+    personalWorkspace.addMembership(new WorkspaceMembership(user.getId(), WorkspaceRole.OWNER));
+    workspaceRepository.save(personalWorkspace);
   }
 }

--- a/backend/src/main/java/io/opaa/workspace/WorkspaceMembership.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceMembership.java
@@ -66,6 +66,10 @@ public class WorkspaceMembership {
     return role;
   }
 
+  public void setRole(WorkspaceRole role) {
+    this.role = role;
+  }
+
   public Instant getCreatedAt() {
     return createdAt;
   }

--- a/backend/src/main/java/io/opaa/workspace/WorkspaceRepository.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceRepository.java
@@ -22,4 +22,6 @@ public interface WorkspaceRepository extends JpaRepository<Workspace, UUID> {
   Optional<Workspace> findByIdWithMemberships(@Param("workspaceId") UUID workspaceId);
 
   boolean existsByNameIgnoreCase(String name);
+
+  boolean existsByOwnerIdAndType(UUID ownerId, WorkspaceType type);
 }

--- a/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
@@ -79,6 +79,123 @@ public class WorkspaceService {
     return toWorkspaceResponse(workspace, currentUserId);
   }
 
+  public List<WorkspaceMemberResponse> listMembers(UUID workspaceId, UUID currentUserId) {
+    Workspace workspace = loadWorkspace(workspaceId);
+    requireMembership(workspace, currentUserId);
+
+    return workspaceMembershipRepository.findByWorkspaceId(workspaceId).stream()
+        .map(m -> new WorkspaceMemberResponse(m.getUserId(), m.getRole(), m.getCreatedAt()))
+        .toList();
+  }
+
+  @Transactional
+  public WorkspaceMemberResponse addMember(
+      UUID workspaceId, UUID memberUserId, WorkspaceRole requestedRole, UUID currentUserId) {
+    Workspace workspace = loadWorkspace(workspaceId);
+    WorkspaceMembership actor = requireManager(workspace, currentUserId);
+    rejectPersonalWorkspaceMemberChanges(workspace);
+
+    if (userMembership(workspace, memberUserId) != null) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "User is already a workspace member");
+    }
+
+    WorkspaceRole roleToAssign = requestedRole == null ? WorkspaceRole.VIEWER : requestedRole;
+    if (roleToAssign == WorkspaceRole.OWNER) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Use transfer ownership endpoint to assign OWNER role");
+    }
+    ensureCanManageRole(actor.getRole(), roleToAssign);
+
+    WorkspaceMembership membership = new WorkspaceMembership(memberUserId, roleToAssign);
+    workspace.addMembership(membership);
+    workspaceRepository.save(workspace);
+
+    return new WorkspaceMemberResponse(
+        membership.getUserId(), membership.getRole(), membership.getCreatedAt());
+  }
+
+  @Transactional
+  public WorkspaceMemberResponse updateMemberRole(
+      UUID workspaceId, UUID memberUserId, WorkspaceRole newRole, UUID currentUserId) {
+    Workspace workspace = loadWorkspace(workspaceId);
+    WorkspaceMembership actor = requireManager(workspace, currentUserId);
+    if (newRole == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "role is required");
+    }
+
+    WorkspaceMembership target = userMembership(workspace, memberUserId);
+    if (target == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace member not found");
+    }
+    if (target.getRole() == WorkspaceRole.OWNER) {
+      if (actor.getRole() != WorkspaceRole.OWNER) {
+        throw new ResponseStatusException(
+            HttpStatus.FORBIDDEN, "Only owners can manage owner role assignments");
+      }
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Owner role changes require ownership transfer");
+    }
+    if (newRole == WorkspaceRole.OWNER) {
+      if (actor.getRole() != WorkspaceRole.OWNER) {
+        throw new ResponseStatusException(
+            HttpStatus.FORBIDDEN, "Only owners can promote members to OWNER");
+      }
+      actor.setRole(WorkspaceRole.ADMIN);
+      target.setRole(WorkspaceRole.OWNER);
+      workspaceRepository.save(workspace);
+      return new WorkspaceMemberResponse(
+          target.getUserId(), target.getRole(), target.getCreatedAt());
+    }
+
+    ensureCanManageRole(actor.getRole(), target.getRole());
+    ensureCanManageRole(actor.getRole(), newRole);
+    target.setRole(newRole);
+    workspaceRepository.save(workspace);
+    return new WorkspaceMemberResponse(target.getUserId(), target.getRole(), target.getCreatedAt());
+  }
+
+  @Transactional
+  public void removeMember(UUID workspaceId, UUID memberUserId, UUID currentUserId) {
+    Workspace workspace = loadWorkspace(workspaceId);
+    WorkspaceMembership actor = requireManager(workspace, currentUserId);
+
+    WorkspaceMembership target = userMembership(workspace, memberUserId);
+    if (target == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace member not found");
+    }
+    if (target.getRole() == WorkspaceRole.OWNER) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Workspace owner cannot be removed");
+    }
+
+    ensureCanManageRole(actor.getRole(), target.getRole());
+    workspace.removeMembership(target);
+    workspaceRepository.save(workspace);
+  }
+
+  @Transactional
+  public void transferOwnership(UUID workspaceId, UUID newOwnerUserId, UUID currentUserId) {
+    Workspace workspace = loadWorkspace(workspaceId);
+    WorkspaceMembership actor = userMembership(workspace, currentUserId);
+    if (actor == null || actor.getRole() != WorkspaceRole.OWNER) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Only workspace owners can transfer ownership");
+    }
+
+    WorkspaceMembership newOwnerMembership = userMembership(workspace, newOwnerUserId);
+    if (newOwnerMembership == null) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Target user is not a workspace member");
+    }
+    if (newOwnerMembership.getRole() == WorkspaceRole.OWNER) {
+      return;
+    }
+
+    actor.setRole(WorkspaceRole.ADMIN);
+    newOwnerMembership.setRole(WorkspaceRole.OWNER);
+    workspaceRepository.save(workspace);
+  }
+
   @Transactional
   public WorkspaceResponse updateWorkspace(
       UUID workspaceId, WorkspaceRequest request, UUID currentUserId) {
@@ -109,11 +226,7 @@ public class WorkspaceService {
 
   @Transactional
   public void deleteWorkspace(UUID workspaceId, UUID currentUserId, boolean systemAdmin) {
-    Workspace workspace =
-        workspaceRepository
-            .findByIdWithMemberships(workspaceId)
-            .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace not found"));
+    Workspace workspace = loadWorkspace(workspaceId);
 
     if (workspace.isPersonal()) {
       throw new ResponseStatusException(
@@ -128,6 +241,60 @@ public class WorkspaceService {
     }
 
     workspaceRepository.delete(workspace);
+  }
+
+  private Workspace loadWorkspace(UUID workspaceId) {
+    return workspaceRepository
+        .findByIdWithMemberships(workspaceId)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace not found"));
+  }
+
+  private WorkspaceMembership requireMembership(Workspace workspace, UUID userId) {
+    WorkspaceMembership membership = userMembership(workspace, userId);
+    if (membership == null) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "You are not a member of this workspace");
+    }
+    return membership;
+  }
+
+  private WorkspaceMembership requireManager(Workspace workspace, UUID userId) {
+    WorkspaceMembership membership = requireMembership(workspace, userId);
+    if (membership.getRole() != WorkspaceRole.ADMIN
+        && membership.getRole() != WorkspaceRole.OWNER) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Only admins or owners can manage workspace members");
+    }
+    return membership;
+  }
+
+  private void rejectPersonalWorkspaceMemberChanges(Workspace workspace) {
+    if (workspace.isPersonal()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Members cannot be added to personal workspaces");
+    }
+  }
+
+  private void ensureCanManageRole(WorkspaceRole actorRole, WorkspaceRole targetRole) {
+    if (actorRole == WorkspaceRole.OWNER) {
+      return;
+    }
+    if (actorRole == WorkspaceRole.ADMIN
+        && roleRank(targetRole) <= roleRank(WorkspaceRole.EDITOR)) {
+      return;
+    }
+    throw new ResponseStatusException(
+        HttpStatus.FORBIDDEN, "Insufficient role permissions for this member change");
+  }
+
+  private int roleRank(WorkspaceRole role) {
+    return switch (role) {
+      case VIEWER -> 1;
+      case EDITOR -> 2;
+      case ADMIN -> 3;
+      case OWNER -> 4;
+    };
   }
 
   private void appendInitialMemberships(

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -3,8 +3,13 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opaa.workspace.Workspace;
+import io.opaa.workspace.WorkspaceRepository;
+import io.opaa.workspace.WorkspaceType;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -18,6 +23,8 @@ class UserServiceTest {
 
   @Mock private UserRepository userRepository;
 
+  @Mock private WorkspaceRepository workspaceRepository;
+
   @Mock private AuthProperties authProperties;
 
   @InjectMocks private UserService userService;
@@ -26,12 +33,16 @@ class UserServiceTest {
   void findOrCreateUserCreatesNewUser() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
     when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn(null);
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "test@example.com", "Test");
 
     assertThat(user.getSubject()).isEqualTo("sub1");
     assertThat(user.getSystemRole()).isEqualTo(SystemRole.USER);
+    verify(workspaceRepository).save(any(Workspace.class));
   }
 
   @Test
@@ -40,17 +51,23 @@ class UserServiceTest {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1"))
         .thenReturn(Optional.of(existing));
     when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(existing.getId(), WorkspaceType.PERSONAL))
+        .thenReturn(true);
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "new@example.com", "New Name");
 
     assertThat(user.getEmail()).isEqualTo("new@example.com");
     assertThat(user.getDisplayName()).isEqualTo("New Name");
+    verify(workspaceRepository, never()).save(any(Workspace.class));
   }
 
   @Test
   void findOrCreateUserGrantsSystemAdminToInitialAdmin() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
     when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "admin@example.com", "Admin");
@@ -62,6 +79,9 @@ class UserServiceTest {
   void findOrCreateUserDoesNotGrantAdminForNonMatchingEmail() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
     when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "other@example.com", "Other");
@@ -88,5 +108,19 @@ class UserServiceTest {
 
     assertThatThrownBy(() -> userService.updateRole(userId, SystemRole.SYSTEM_ADMIN))
         .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void findOrCreateUserDoesNotCreateDuplicatePersonalWorkspace() {
+    User existing = new User("sub1", "issuer1", "old@example.com", "Old Name");
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1"))
+        .thenReturn(Optional.of(existing));
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(existing.getId(), WorkspaceType.PERSONAL))
+        .thenReturn(true);
+
+    userService.findOrCreateUser("sub1", "issuer1", "old@example.com", "Old Name");
+
+    verify(workspaceRepository, never()).save(any(Workspace.class));
   }
 }

--- a/backend/src/test/java/io/opaa/workspace/WorkspaceServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/workspace/WorkspaceServiceIntegrationTest.java
@@ -170,4 +170,168 @@ class WorkspaceServiceIntegrationTest {
                 assertThat(((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.CONFLICT));
   }
+
+  @Test
+  void adminCanAddViewerAndEditor() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    UUID viewer = UUID.randomUUID();
+    UUID editor = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    workspaceService.addMember(saved.getId(), viewer, WorkspaceRole.VIEWER, admin);
+    workspaceService.addMember(saved.getId(), editor, WorkspaceRole.EDITOR, admin);
+
+    Workspace reloaded = workspaceRepository.findByIdWithMemberships(saved.getId()).orElseThrow();
+    assertThat(reloaded.getMemberships()).hasSize(4);
+    assertThat(reloaded.getMemberships())
+        .filteredOn(member -> member.getUserId().equals(viewer))
+        .extracting(WorkspaceMembership::getRole)
+        .containsExactly(WorkspaceRole.VIEWER);
+    assertThat(reloaded.getMemberships())
+        .filteredOn(member -> member.getUserId().equals(editor))
+        .extracting(WorkspaceMembership::getRole)
+        .containsExactly(WorkspaceRole.EDITOR);
+  }
+
+  @Test
+  void adminCannotAddAdminMember() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    assertThatThrownBy(
+            () ->
+                workspaceService.addMember(
+                    saved.getId(), UUID.randomUUID(), WorkspaceRole.ADMIN, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void cannotAddMembersToPersonalWorkspace() {
+    UUID owner = UUID.randomUUID();
+    Workspace personal = new Workspace("My Documents", "Private", WorkspaceType.PERSONAL, owner);
+    personal.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    Workspace saved = workspaceRepository.save(personal);
+
+    assertThatThrownBy(
+            () ->
+                workspaceService.addMember(
+                    saved.getId(), UUID.randomUUID(), WorkspaceRole.VIEWER, owner))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void adminCannotRemoveOwner() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    assertThatThrownBy(() -> workspaceService.removeMember(saved.getId(), owner, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void ownerCanTransferOwnership() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    workspaceService.transferOwnership(saved.getId(), admin, owner);
+
+    Workspace reloaded = workspaceRepository.findByIdWithMemberships(saved.getId()).orElseThrow();
+    assertThat(reloaded.getMemberships())
+        .filteredOn(member -> member.getUserId().equals(owner))
+        .extracting(WorkspaceMembership::getRole)
+        .containsExactly(WorkspaceRole.ADMIN);
+    assertThat(reloaded.getMemberships())
+        .filteredOn(member -> member.getUserId().equals(admin))
+        .extracting(WorkspaceMembership::getRole)
+        .containsExactly(WorkspaceRole.OWNER);
+  }
+
+  @Test
+  void roleChangesAreImmediatelyEffective() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    UUID editor = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    workspace.addMembership(new WorkspaceMembership(editor, WorkspaceRole.EDITOR));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    workspaceService.updateMemberRole(saved.getId(), editor, WorkspaceRole.VIEWER, admin);
+    WorkspaceResponse details = workspaceService.getWorkspace(saved.getId(), editor, false);
+
+    assertThat(details.userRole()).isEqualTo(WorkspaceRole.VIEWER);
+  }
+
+  @Test
+  void viewerCannotChangeRoles() {
+    UUID owner = UUID.randomUUID();
+    UUID viewer = UUID.randomUUID();
+    UUID target = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(viewer, WorkspaceRole.VIEWER));
+    workspace.addMembership(new WorkspaceMembership(target, WorkspaceRole.EDITOR));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    assertThatThrownBy(
+            () ->
+                workspaceService.updateMemberRole(
+                    saved.getId(), target, WorkspaceRole.VIEWER, viewer))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void adminCannotPromoteMemberToOwner() {
+    UUID owner = UUID.randomUUID();
+    UUID admin = UUID.randomUUID();
+    UUID editor = UUID.randomUUID();
+    Workspace workspace = new Workspace("Team", "Team docs", WorkspaceType.SHARED, owner);
+    workspace.addMembership(new WorkspaceMembership(owner, WorkspaceRole.OWNER));
+    workspace.addMembership(new WorkspaceMembership(admin, WorkspaceRole.ADMIN));
+    workspace.addMembership(new WorkspaceMembership(editor, WorkspaceRole.EDITOR));
+    Workspace saved = workspaceRepository.save(workspace);
+
+    assertThatThrownBy(
+            () ->
+                workspaceService.updateMemberRole(
+                    saved.getId(), editor, WorkspaceRole.OWNER, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
 }


### PR DESCRIPTION
## Summary

- implement workspace membership management API (list/add/remove/update role/transfer ownership)
- enforce role hierarchy and permission checks (`VIEWER < EDITOR < ADMIN < OWNER`)
- reject member additions to personal workspaces and block owner removal
- auto-create a personal workspace (`My Documents`) on first login/user provisioning
- ensure idempotency: repeated login does not create duplicate personal workspaces
- add/extend integration and unit tests for the new workspace and user provisioning behavior

## Related Issues

Closes #113
Closes #114

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Codex / GPT-5)
- [ ] This PR was co-authored by human + AI agent
