### PR TITLE
fix(workspace): restore listMembers to use loaded memberships

### DIFF
--- a/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
@@ -79,7 +79,7 @@ public class WorkspaceService {
     Workspace workspace = loadWorkspace(workspaceId);
     requireMembership(workspace, currentUserId);
 
-    return workspaceMembershipRepository.findByWorkspaceId(workspaceId).stream()
+    return workspace.getMemberships().stream()
         .map(m -> new WorkspaceMemberResponse(m.getUserId(), m.getRole(), m.getCreatedAt()))
         .toList();
   }


### PR DESCRIPTION
## Summary

- `listMembers()` in `WorkspaceService` was using `workspaceMembershipRepository.findByWorkspaceId()`, which no longer exists — the field was removed when fixing the N+1 query in PR #131 review
- This broke the `main` branch build after PR #140 (which introduced `listMembers`) and PR #146 (which brought the N+1 fix) were both merged

## Fix

Use `workspace.getMemberships()` (already JOIN-fetched via `findByIdWithMemberships`) instead of a separate repository query — consistent with `toWorkspaceResponse()`.

## Related Issues

- PR #131 review fix (removed `workspaceMembershipRepository`)
- PR #140 (`listMembers` introduced)
- PR #146 (N+1 fix merged to main)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally (`./gradlew test`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Claude Sonnet 4.6)
- [ ] This PR was co-authored by human + AI agent