### PR TITLE
feat(ui): add workspace creation dialog for system admins

### DIFF
--- a/frontend/src/components/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/components/CreateWorkspaceDialog.test.tsx
@@ -1,0 +1,83 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '../test/test-utils'
+import CreateWorkspaceDialog from './CreateWorkspaceDialog'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+
+vi.mock('../services/api', () => ({
+  getWorkspaces: vi.fn(async () => []),
+  getWorkspace: vi.fn(async () => ({})),
+  getWorkspaceDocuments: vi.fn(async () => []),
+  createWorkspace: vi.fn(async () => ({
+    id: 'ws-new',
+    name: 'Test',
+    description: '',
+    type: 'SHARED',
+    ownerId: 'u1',
+    memberCount: 1,
+    userRole: 'OWNER',
+    roleCounts: { VIEWER: 0, EDITOR: 0, ADMIN: 0, OWNER: 1 },
+    members: [{ userId: 'u1', role: 'OWNER', createdAt: '2026-03-01T10:00:00Z' }],
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  })),
+}))
+
+describe('CreateWorkspaceDialog', () => {
+  const onClose = vi.fn()
+  const onCreated = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({
+      workspaces: [],
+      selectedWorkspaceId: null,
+      selectedWorkspace: null,
+      selectedWorkspaceDocuments: [],
+      chatFilterWorkspaceIds: [],
+      isLoadingList: false,
+      isLoadingDetails: false,
+      error: null,
+    })
+  })
+
+  it('renders name and description fields', () => {
+    renderWithProviders(
+      <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
+    )
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('disables create button when name is empty', () => {
+    renderWithProviders(
+      <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
+    )
+    expect(screen.getByRole('button', { name: /create/i })).toBeDisabled()
+  })
+
+  it('calls onCreated with workspace id after submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
+    )
+
+    await user.type(screen.getByLabelText(/name/i), 'My New Workspace')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith('ws-new')
+    })
+  })
+
+  it('calls onClose when cancel is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/CreateWorkspaceDialog.tsx
+++ b/frontend/src/components/CreateWorkspaceDialog.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import Alert from '@mui/material/Alert'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import TextField from '@mui/material/TextField'
+
+interface CreateWorkspaceDialogProps {
+  open: boolean
+  onClose: () => void
+  onCreated: (workspaceId: string) => void
+}
+
+export default function CreateWorkspaceDialog({
+  open,
+  onClose,
+  onCreated,
+}: CreateWorkspaceDialogProps) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  function handleClose() {
+    if (submitting) return
+    setName('')
+    setDescription('')
+    setError(null)
+    onClose()
+  }
+
+  async function handleCreate() {
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError('Name is required')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      const { useWorkspaceStore } = await import('../stores/workspaceStore')
+      const workspaceId = await useWorkspaceStore
+        .getState()
+        .createNewWorkspace(trimmedName, description.trim())
+      setName('')
+      setDescription('')
+      onCreated(workspaceId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create workspace')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Create Workspace</DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <TextField
+          autoFocus
+          label="Name"
+          fullWidth
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          inputProps={{ maxLength: 255 }}
+          sx={{ mt: 1 }}
+        />
+        <TextField
+          label="Description"
+          fullWidth
+          multiline
+          minRows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          inputProps={{ maxLength: 2000 }}
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button onClick={handleCreate} variant="contained" disabled={submitting || !name.trim()}>
+          {submitting ? 'Creating...' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -21,6 +21,7 @@ import PersonIcon from '@mui/icons-material/Person'
 import SettingsIcon from '@mui/icons-material/Settings'
 import WorkspacesIcon from '@mui/icons-material/Workspaces'
 import { NavLink, useLocation, useNavigate } from 'react-router-dom'
+import CreateWorkspaceDialog from '../components/CreateWorkspaceDialog'
 import { useChatStore } from '../stores/chatStore'
 import { useAuthStore } from '../stores/authStore'
 import { useWorkspaceStore } from '../stores/workspaceStore'
@@ -42,6 +43,8 @@ export default function Sidebar() {
   const loadWorkspaces = useWorkspaceStore((s) => s.loadWorkspaces)
   const [workspacesOpen, setWorkspacesOpen] = useState(true)
   const [chatsOpen, setChatsOpen] = useState(true)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const isSystemAdmin = user?.systemRole === 'SYSTEM_ADMIN'
 
   useEffect(() => {
     if (workspaces.length === 0) {
@@ -82,17 +85,28 @@ export default function Sidebar() {
           <Typography variant="overline" color="text.secondary" sx={{ letterSpacing: 1 }}>
             Workspaces
           </Typography>
-          <IconButton
-            size="small"
-            onClick={() => setWorkspacesOpen((open) => !open)}
-            aria-label="toggle workspaces"
-          >
-            {workspacesOpen ? (
-              <ExpandLessIcon fontSize="small" />
-            ) : (
-              <ExpandMoreIcon fontSize="small" />
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {isSystemAdmin && (
+              <IconButton
+                size="small"
+                onClick={() => setCreateDialogOpen(true)}
+                aria-label="create workspace"
+              >
+                <AddIcon fontSize="small" />
+              </IconButton>
             )}
-          </IconButton>
+            <IconButton
+              size="small"
+              onClick={() => setWorkspacesOpen((open) => !open)}
+              aria-label="toggle workspaces"
+            >
+              {workspacesOpen ? (
+                <ExpandLessIcon fontSize="small" />
+              ) : (
+                <ExpandMoreIcon fontSize="small" />
+              )}
+            </IconButton>
+          </Box>
         </Box>
         {workspacesOpen &&
           (isLoadingWorkspaces ? (
@@ -225,6 +239,15 @@ export default function Sidebar() {
           OPAA v0.1.0
         </Typography>
       </Box>
+
+      <CreateWorkspaceDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onCreated={(workspaceId) => {
+          setCreateDialogOpen(false)
+          navigate(`/workspaces/${workspaceId}`)
+        }}
+      />
     </Box>
   )
 }

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -214,7 +214,7 @@ export const mockUser: AuthUser = {
   id: 'mock-user-id',
   email: 'admin@opaa.local',
   displayName: 'Admin',
-  systemRole: 'USER',
+  systemRole: 'SYSTEM_ADMIN',
 }
 
 export const mockWorkspaces: WorkspaceListResponse[] = [

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -117,6 +117,38 @@ export const handlers = [
     })
   }),
 
+  http.post('/api/v1/workspaces', async ({ request }) => {
+    const body = (await request.json()) as { name: string; description?: string }
+    if (!body.name || body.name.trim() === '') {
+      return HttpResponse.json({ error: 'Workspace name is required' }, { status: 400 })
+    }
+    if (mockWorkspaces.some((ws) => ws.name.toLowerCase() === body.name.trim().toLowerCase())) {
+      return HttpResponse.json({ error: 'Workspace name already exists' }, { status: 409 })
+    }
+    const id = `ws-${crypto.randomUUID().slice(0, 8)}`
+    const now = new Date().toISOString()
+    const listEntry: (typeof mockWorkspaces)[number] = {
+      id,
+      name: body.name.trim(),
+      description: body.description?.trim() ?? null,
+      type: 'SHARED',
+      memberCount: 1,
+      userRole: 'OWNER',
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockWorkspaces.push(listEntry)
+    const detail = {
+      ...listEntry,
+      ownerId: 'mock-user-id',
+      roleCounts: { VIEWER: 0, EDITOR: 0, ADMIN: 0, OWNER: 1 },
+      members: [{ userId: 'mock-user-id', role: 'OWNER' as const, createdAt: now }],
+    }
+    mockWorkspaceDetails[id] = detail
+    mockWorkspaceDocuments[id] = []
+    return HttpResponse.json(detail, { status: 201 })
+  }),
+
   http.get('/api/v1/workspaces', () => {
     return HttpResponse.json(mockWorkspaces)
   }),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -168,6 +168,23 @@ export async function updateWorkspaceDetails(
   }
 }
 
+export async function createWorkspace(
+  name: string,
+  description: string,
+): Promise<WorkspaceResponse> {
+  try {
+    const { data } = await client.post<WorkspaceResponse>('/v1/workspaces', {
+      name,
+      description,
+      ownerId: null,
+      initialMembers: [],
+    })
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
 export async function deleteWorkspace(workspaceId: string): Promise<void> {
   try {
     await client.delete(`/v1/workspaces/${workspaceId}`)

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -45,7 +45,7 @@ describe('authStore', () => {
       id: 'mock-user-id',
       email: 'admin@opaa.local',
       displayName: 'Admin',
-      systemRole: 'USER',
+      systemRole: 'SYSTEM_ADMIN',
     })
     expect(sessionStorage.getItem('opaa.basicAuth.session')).toBeTruthy()
   })

--- a/frontend/src/stores/workspaceStore.test.ts
+++ b/frontend/src/stores/workspaceStore.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { useWorkspaceStore } from './workspaceStore'
 
+const mockCreateWorkspace = vi.fn()
+
 vi.mock('../services/api', () => ({
   getWorkspaces: vi.fn(async () => [
     {
@@ -38,6 +40,7 @@ vi.mock('../services/api', () => ({
     updatedAt: '2026-03-01T10:00:00Z',
   })),
   getWorkspaceDocuments: vi.fn(async () => []),
+  createWorkspace: (...args: unknown[]) => mockCreateWorkspace(...args),
 }))
 
 describe('workspaceStore', () => {
@@ -66,5 +69,26 @@ describe('workspaceStore', () => {
       'ws-personal',
       'ws-shared',
     ])
+  })
+
+  it('creates a new workspace and selects it', async () => {
+    mockCreateWorkspace.mockResolvedValueOnce({
+      id: 'ws-new',
+      name: 'New Workspace',
+      description: 'desc',
+      type: 'SHARED',
+      ownerId: 'u1',
+      memberCount: 1,
+      userRole: 'OWNER',
+      roleCounts: { VIEWER: 0, EDITOR: 0, ADMIN: 0, OWNER: 1 },
+      members: [{ userId: 'u1', role: 'OWNER', createdAt: '2026-03-01T10:00:00Z' }],
+      createdAt: '2026-03-01T10:00:00Z',
+      updatedAt: '2026-03-01T10:00:00Z',
+    })
+
+    const id = await useWorkspaceStore.getState().createNewWorkspace('New Workspace', 'desc')
+    expect(id).toBe('ws-new')
+    expect(mockCreateWorkspace).toHaveBeenCalledWith('New Workspace', 'desc')
+    expect(useWorkspaceStore.getState().selectedWorkspaceId).toBe('ws-new')
   })
 })

--- a/frontend/src/stores/workspaceStore.ts
+++ b/frontend/src/stores/workspaceStore.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types/api'
 import {
   addWorkspaceMember,
+  createWorkspace,
   deleteWorkspace,
   getWorkspace,
   getWorkspaceDocuments,
@@ -35,6 +36,7 @@ interface WorkspaceState {
   transferOwnership: (workspaceId: string, userId: string) => Promise<void>
   updateDetails: (workspaceId: string, name: string, description: string) => Promise<void>
   deleteSelectedWorkspace: (workspaceId: string) => Promise<void>
+  createNewWorkspace: (name: string, description: string) => Promise<string>
 }
 
 function sortWorkspaces(list: WorkspaceListResponse[]): WorkspaceListResponse[] {
@@ -135,5 +137,12 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     } else {
       set({ selectedWorkspace: null, selectedWorkspaceDocuments: [], selectedWorkspaceId: null })
     }
+  },
+
+  createNewWorkspace: async (name, description) => {
+    const workspace = await createWorkspace(name, description)
+    await get().loadWorkspaces()
+    await get().selectWorkspace(workspace.id)
+    return workspace.id
   },
 }))


### PR DESCRIPTION
## Summary

- Add UI for creating new shared workspaces (SYSTEM_ADMIN only)
- "+" button in sidebar next to "Workspaces" header, opens a dialog with name and description fields
- Includes API function, Zustand store action, MSW mock handler, and tests

## Related Issues

Closes #122

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Claude Opus 4.6)
- [ ] This PR was co-authored by human + AI agent