### PR TITLE
feat(workspace): create configurable default workspace on first system admin login

### DIFF
--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -2,6 +2,7 @@ package io.opaa.auth;
 
 import io.opaa.workspace.Workspace;
 import io.opaa.workspace.WorkspaceMembership;
+import io.opaa.workspace.WorkspaceProperties;
 import io.opaa.workspace.WorkspaceRepository;
 import io.opaa.workspace.WorkspaceRole;
 import io.opaa.workspace.WorkspaceType;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Profile({"oidc", "basic"})
-@EnableConfigurationProperties(AuthProperties.class)
+@EnableConfigurationProperties({AuthProperties.class, WorkspaceProperties.class})
 public class UserService {
 
   private static final String PERSONAL_WORKSPACE_NAME = "My Documents";
@@ -25,14 +26,17 @@ public class UserService {
   private final UserRepository userRepository;
   private final WorkspaceRepository workspaceRepository;
   private final AuthProperties authProperties;
+  private final WorkspaceProperties workspaceProperties;
 
   public UserService(
       UserRepository userRepository,
       WorkspaceRepository workspaceRepository,
-      AuthProperties authProperties) {
+      AuthProperties authProperties,
+      WorkspaceProperties workspaceProperties) {
     this.userRepository = userRepository;
     this.workspaceRepository = workspaceRepository;
     this.authProperties = authProperties;
+    this.workspaceProperties = workspaceProperties;
   }
 
   @Transactional
@@ -61,6 +65,7 @@ public class UserService {
                 });
 
     ensurePersonalWorkspace(user);
+    ensureDefaultWorkspace(user);
     return user;
   }
 
@@ -91,6 +96,24 @@ public class UserService {
     return initialAdminEmail != null
         && !initialAdminEmail.isBlank()
         && initialAdminEmail.equalsIgnoreCase(email);
+  }
+
+  private void ensureDefaultWorkspace(User user) {
+    if (user.getSystemRole() != SystemRole.SYSTEM_ADMIN) {
+      return;
+    }
+    String defaultName = workspaceProperties.defaultWorkspace().name();
+    if (workspaceRepository.existsByNameIgnoreCase(defaultName)) {
+      return;
+    }
+    Workspace defaultWorkspace =
+        new Workspace(
+            defaultName,
+            workspaceProperties.defaultWorkspace().description(),
+            WorkspaceType.SHARED,
+            user.getId());
+    defaultWorkspace.addMembership(new WorkspaceMembership(user.getId(), WorkspaceRole.OWNER));
+    workspaceRepository.save(defaultWorkspace);
   }
 
   private void ensurePersonalWorkspace(User user) {

--- a/backend/src/main/java/io/opaa/workspace/WorkspaceProperties.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceProperties.java
@@ -1,0 +1,25 @@
+package io.opaa.workspace;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opaa.workspace")
+public record WorkspaceProperties(DefaultWorkspace defaultWorkspace) {
+
+  public WorkspaceProperties {
+    if (defaultWorkspace == null) {
+      defaultWorkspace = new DefaultWorkspace(null, null);
+    }
+  }
+
+  public record DefaultWorkspace(String name, String description) {
+
+    public DefaultWorkspace {
+      if (name == null || name.isBlank()) {
+        name = "Default";
+      }
+      if (description == null || description.isBlank()) {
+        description = "Default shared workspace";
+      }
+    }
+  }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -59,6 +59,10 @@ opaa:
   auth:
     mode: ${OPAA_AUTH_MODE:mock}
     initial-admin-email: ${OPAA_INITIAL_ADMIN_EMAIL:admin@opaa.local}
+  workspace:
+    default-workspace:
+      name: ${OPAA_WORKSPACE_DEFAULT_NAME:Default}
+      description: ${OPAA_WORKSPACE_DEFAULT_DESCRIPTION:Default shared workspace}
   http:
     force-http1: ${OPAA_HTTP_FORCE_HTTP1:false}
   query:

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -3,18 +3,21 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opaa.workspace.Workspace;
+import io.opaa.workspace.WorkspaceProperties;
 import io.opaa.workspace.WorkspaceRepository;
 import io.opaa.workspace.WorkspaceType;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -27,7 +30,17 @@ class UserServiceTest {
 
   @Mock private AuthProperties authProperties;
 
-  @InjectMocks private UserService userService;
+  private final WorkspaceProperties workspaceProperties =
+      new WorkspaceProperties(
+          new WorkspaceProperties.DefaultWorkspace("Default", "Default shared workspace"));
+
+  private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    userService =
+        new UserService(userRepository, workspaceRepository, authProperties, workspaceProperties);
+  }
 
   @Test
   void findOrCreateUserCreatesNewUser() {
@@ -67,6 +80,7 @@ class UserServiceTest {
     when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
         .thenReturn(false);
+    when(workspaceRepository.existsByNameIgnoreCase(anyString())).thenReturn(false);
     when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
 
@@ -122,5 +136,53 @@ class UserServiceTest {
     userService.findOrCreateUser("sub1", "issuer1", "old@example.com", "Old Name");
 
     verify(workspaceRepository, never()).save(any(Workspace.class));
+  }
+
+  @Test
+  void firstLoginOfSystemAdminCreatesDefaultWorkspace() {
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.existsByNameIgnoreCase("Default")).thenReturn(false);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
+
+    userService.findOrCreateUser("sub1", "issuer1", "admin@example.com", "Admin");
+
+    // Saves both personal workspace and default workspace
+    verify(workspaceRepository, times(2)).save(any(Workspace.class));
+  }
+
+  @Test
+  void defaultWorkspaceNotCreatedIfAlreadyExists() {
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.existsByNameIgnoreCase("Default")).thenReturn(true);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
+
+    userService.findOrCreateUser("sub1", "issuer1", "admin@example.com", "Admin");
+
+    // Only personal workspace is saved; default already exists
+    verify(workspaceRepository, times(1)).save(any(Workspace.class));
+  }
+
+  @Test
+  void regularUserLoginDoesNotCreateDefaultWorkspace() {
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(workspaceRepository.existsByOwnerIdAndType(any(UUID.class), any(WorkspaceType.class)))
+        .thenReturn(false);
+    when(workspaceRepository.save(any(Workspace.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
+
+    userService.findOrCreateUser("sub1", "issuer1", "user@example.com", "User");
+
+    // Only personal workspace is saved; no default workspace for regular users
+    verify(workspaceRepository, times(1)).save(any(Workspace.class));
+    verify(workspaceRepository, never()).existsByNameIgnoreCase(anyString());
   }
 }


### PR DESCRIPTION
## Summary

- Adds `WorkspaceProperties` configuration record (`opaa.workspace.default-workspace.name` / `opaa.workspace.default-workspace.description`) — defaults to `"Default"` / `"Default shared workspace"`, overridable via env vars `OPAA_WORKSPACE_DEFAULT_NAME` and `OPAA_WORKSPACE_DEFAULT_DESCRIPTION`
- On first login of a system admin, the default shared workspace is created automatically with the admin as OWNER
- Idempotent: skips creation if a workspace with the configured name already exists (case-insensitive)
- Required prerequisite for chunk metadata tagging with `workspace_ids` (part of #115)

## Related Issues

#115

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Claude Sonnet 4.6)
- [ ] This PR was co-authored by human + AI agent