### PR TITLE
Externalize docker-compose env vars into .env.docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,138 @@
-# AI Chat Provider (openai or ollama)
-OPAA_AI_CHAT_PROVIDER=openai
+# ============================================================
+# OPAA Environment Configuration
+# Copy this file to .env and adjust values as needed.
+# ============================================================
 
-# OpenAI
+# --- AI Providers ---
+# Chat model provider: "openai" or "ollama"
+OPAA_AI_CHAT_PROVIDER=openai
+# Embedding model provider: "openai" or "ollama"
+OPAA_AI_EMBEDDING_PROVIDER=openai
+
+# --- OpenAI (shared defaults) ---
+# API key used for both chat and embedding (unless overridden below)
 OPAA_OPENAI_API_KEY=sk-your-key-here
+# Base URL for the OpenAI-compatible API
+OPAA_OPENAI_BASE_URL=https://api.openai.com
+
+# --- OpenAI Chat (override shared defaults per-function) ---
+# Separate API key for chat (falls back to OPAA_OPENAI_API_KEY)
+OPAA_OPENAI_CHAT_API_KEY=
+# Separate base URL for chat (falls back to OPAA_OPENAI_BASE_URL)
+OPAA_OPENAI_CHAT_BASE_URL=
+# Chat model name
 OPAA_OPENAI_CHAT_MODEL=gpt-4o
+# Sampling temperature (0.0 = deterministic, 1.0 = creative)
 OPAA_OPENAI_CHAT_TEMPERATURE=0.7
+# Maximum tokens in chat response
 OPAA_OPENAI_CHAT_MAX_TOKENS=2000
+
+# --- OpenAI Embedding (override shared defaults per-function) ---
+# Separate API key for embeddings (falls back to OPAA_OPENAI_API_KEY)
+OPAA_OPENAI_EMBEDDING_API_KEY=
+# Separate base URL for embeddings (falls back to OPAA_OPENAI_BASE_URL)
+OPAA_OPENAI_EMBEDDING_BASE_URL=
+# Embedding model name
 OPAA_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
-# Ollama (optional, for local LLM usage)
-OPAA_OLLAMA_BASE_URL=http://localhost:11434
+# --- Ollama (for local LLM usage) ---
+# Ollama server URL
+OPAA_OLLAMA_BASE_URL=http://ollama:11434
+# Ollama chat model name
+OPAA_OLLAMA_CHAT_MODEL=phi3:mini
+# Ollama embedding model name
+OPAA_OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
-# Database
+# --- Database ---
+# JDBC connection URL for PostgreSQL
+OPAA_DB_URL=jdbc:postgresql://localhost:5432/opaa?prepareThreshold=0
+# Database username
 OPAA_DB_USERNAME=opaa
+# Database password
 OPAA_DB_PASSWORD=opaa
 
-# Documents (host path mapped into container)
-OPAA_DOCUMENTS_PATH_HOST=./documents
+# --- Server ---
+# Bind address (0.0.0.0 for all interfaces)
+OPAA_SERVER_ADDRESS=0.0.0.0
+# Allowed CORS origins (comma-separated)
+OPAA_CORS_ALLOWED_ORIGINS=http://localhost:5173
+# Force HTTP/1.1 (needed for vLLM/Uvicorn-based servers)
+OPAA_HTTP_FORCE_HTTP1=false
+
+# --- Documents & Indexing ---
+# Host path mounted into the container (Docker Compose only)
+OPAA_INDEXING_DOCUMENT_PATH_HOST=./documents
+# Document path inside the application / container
+OPAA_INDEXING_DOCUMENT_PATH=./documents
+# Characters per text chunk for embedding
+OPAA_INDEXING_CHUNK_SIZE=1000
+# Number of chunks per embedding batch
+OPAA_INDEXING_BATCH_SIZE=50
+# Retry attempts on embedding failures
+OPAA_INDEXING_RETRY_ATTEMPTS=3
+# Minimum threads in the indexing pool
+OPAA_INDEXING_THREAD_POOL_CORE_SIZE=2
+# Maximum threads in the indexing pool
+OPAA_INDEXING_THREAD_POOL_MAX_SIZE=4
+# Queue capacity before new indexing tasks are rejected
+OPAA_INDEXING_THREAD_POOL_QUEUE_CAPACITY=20
+
+# --- Query ---
+# Number of most similar documents to retrieve
+OPAA_QUERY_TOP_K=5
+# Minimum cosine similarity to include a result (0.0–1.0)
+OPAA_QUERY_SIMILARITY_THRESHOLD=0.3
+
+# --- pgvector ---
+# Vector dimensions (must match the embedding model output)
+OPAA_PGVECTOR_DIMENSIONS=1536
+# Distance function: cosine_distance, euclidean_distance, negative_inner_product
+OPAA_PGVECTOR_DISTANCE_TYPE=cosine_distance
+
+# --- Rate Limiting ---
+# Enable or disable rate limiting globally
+OPAA_RATE_LIMIT_ENABLED=true
+# Max query requests per user within the time window
+OPAA_RATE_LIMIT_QUERY_MAX_REQUESTS=10
+# Time window for per-user query rate limit (seconds)
+OPAA_RATE_LIMIT_QUERY_WINDOW_SECONDS=60
+# Max query requests across all users within the time window
+OPAA_RATE_LIMIT_QUERY_GLOBAL_MAX_REQUESTS=100
+# Max indexing requests per user within the time window
+OPAA_RATE_LIMIT_INDEXING_MAX_REQUESTS=1
+# Time window for per-user indexing rate limit (seconds)
+OPAA_RATE_LIMIT_INDEXING_WINDOW_SECONDS=60
+# Max indexing requests across all users within the time window
+OPAA_RATE_LIMIT_INDEXING_GLOBAL_MAX_REQUESTS=5
+
+# --- Authentication ---
+# Auth mode: "mock", "basic", or "oidc"
+OPAA_AUTH_MODE=mock
+# Username for basic auth
+OPAA_AUTH_BASIC_USERNAME=admin
+# Password for basic auth
+OPAA_AUTH_BASIC_PASSWORD=admin
+# JWT signing secret (min 256 bit — change in production!)
+OPAA_AUTH_BASIC_SECRET=change-me-to-a-256-bit-secret-key-in-production!!
+# JWT token expiration in seconds
+OPAA_AUTH_BASIC_TOKEN_EXPIRATION=3600
+# JWT issuer claim
+OPAA_AUTH_BASIC_ISSUER=opaa-basic
+# Email for the initial admin user (auto-created on first start)
+OPAA_INITIAL_ADMIN_EMAIL=
+
+# --- OIDC (used with oidc profile) ---
+# JWK Set URI for token verification (container-internal URL)
+OPAA_OIDC_JWK_SET_URI=http://keycloak:8180/realms/opaa/protocol/openid-connect/certs
+# OIDC issuer URI for token validation
+OPAA_OIDC_ISSUER_URI=http://localhost:8180/realms/opaa
+# OIDC authority URL (used by the frontend)
+OPAA_OIDC_AUTHORITY=http://localhost:8180/realms/opaa
+# OIDC client ID for the frontend
+OPAA_OIDC_CLIENT_ID=opaa-frontend
+
+# --- Docker Compose ports ---
+# Backend host port (mapped to container port 8080)
+OPAA_BACKEND_PORT=8081
+# Frontend host port (mapped to container port 80)
+OPAA_FRONTEND_PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg18
     container_name: opaa-postgres
+    env_file: .env.docker
     environment:
       POSTGRES_DB: opaa
       POSTGRES_USER: ${OPAA_DB_USERNAME:-opaa}
@@ -14,7 +15,7 @@ services:
     volumes:
       - opaa-postgres-data:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U opaa -d opaa"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-opaa} -d ${POSTGRES_DB:-opaa}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -22,51 +23,21 @@ services:
   backend:
     build: ./backend
     container_name: opaa-backend
-    environment:
-      SPRING_PROFILES_ACTIVE: docker
-      OPAA_DB_USERNAME: ${OPAA_DB_USERNAME:-opaa}
-      OPAA_DB_PASSWORD: ${OPAA_DB_PASSWORD:-opaa}
-      OPAA_AI_CHAT_PROVIDER: ${OPAA_AI_CHAT_PROVIDER:-openai}
-      OPAA_AI_EMBEDDING_PROVIDER: ${OPAA_AI_EMBEDDING_PROVIDER:-openai}
-      OPAA_OPENAI_API_KEY: ${OPAA_OPENAI_API_KEY:-}
-      OPAA_OPENAI_BASE_URL: ${OPAA_OPENAI_BASE_URL:-https://api.openai.com}
-      OPAA_OPENAI_CHAT_API_KEY: ${OPAA_OPENAI_CHAT_API_KEY:-}
-      OPAA_OPENAI_CHAT_BASE_URL: ${OPAA_OPENAI_CHAT_BASE_URL:-}
-      OPAA_OPENAI_CHAT_MODEL: ${OPAA_OPENAI_CHAT_MODEL:-gpt-4o}
-      OPAA_OPENAI_CHAT_TEMPERATURE: ${OPAA_OPENAI_CHAT_TEMPERATURE:-0.7}
-      OPAA_OPENAI_CHAT_MAX_TOKENS: ${OPAA_OPENAI_CHAT_MAX_TOKENS:-2000}
-      OPAA_OPENAI_EMBEDDING_API_KEY: ${OPAA_OPENAI_EMBEDDING_API_KEY:-}
-      OPAA_OPENAI_EMBEDDING_BASE_URL: ${OPAA_OPENAI_EMBEDDING_BASE_URL:-}
-      OPAA_OPENAI_EMBEDDING_MODEL: ${OPAA_OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
-      OPAA_OLLAMA_BASE_URL: ${OPAA_OLLAMA_BASE_URL:-http://ollama:11434}
-      OPAA_OLLAMA_CHAT_MODEL: ${OPAA_OLLAMA_CHAT_MODEL:-phi3:mini}
-      OPAA_OLLAMA_EMBEDDING_MODEL: ${OPAA_OLLAMA_EMBEDDING_MODEL:-nomic-embed-text}
-      OPAA_HTTP_FORCE_HTTP1: ${OPAA_HTTP_FORCE_HTTP1:-false}
-      OPAA_SERVER_ADDRESS: ${OPAA_SERVER_ADDRESS:-0.0.0.0}
-      OPAA_DOCUMENTS_PATH: ${OPAA_DOCUMENTS_PATH:-/app/documents}
-      OPAA_CORS_ALLOWED_ORIGINS: ${OPAA_CORS_ALLOWED_ORIGINS:-http://localhost:5173}
-      OPAA_PGVECTOR_DIMENSIONS: ${OPAA_PGVECTOR_DIMENSIONS:-1536}
-      OPAA_AUTH_MODE: ${OPAA_AUTH_MODE:-mock}
-      OPAA_OIDC_JWK_SET_URI: ${OPAA_OIDC_JWK_SET_URI:-http://keycloak:8180/realms/opaa/protocol/openid-connect/certs}
-      OPAA_OIDC_ISSUER_URI: ${OPAA_OIDC_ISSUER_URI:-http://localhost:8180/realms/opaa}
-      OPAA_OIDC_AUTHORITY: ${OPAA_OIDC_AUTHORITY:-http://localhost:8180/realms/opaa}
-      OPAA_OIDC_CLIENT_ID: ${OPAA_OIDC_CLIENT_ID:-opaa-frontend}
-      OPAA_AUTH_BASIC_USERNAME: ${OPAA_AUTH_BASIC_USERNAME:-admin}
-      OPAA_AUTH_BASIC_PASSWORD: ${OPAA_AUTH_BASIC_PASSWORD:-admin}
-      OPAA_AUTH_BASIC_SECRET: ${OPAA_AUTH_BASIC_SECRET:-change-me-to-a-256-bit-secret-key-in-production!!}
-      OPAA_INITIAL_ADMIN_EMAIL: ${OPAA_INITIAL_ADMIN_EMAIL:-}
+    env_file: .env.docker
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
       - "${OPAA_BACKEND_PORT:-8081}:8080"
     volumes:
-      - ${OPAA_DOCUMENTS_PATH_HOST:-./documents}:/app/documents
+      - ${OPAA_INDEXING_DOCUMENT_PATH_HOST:-./documents}:/app/documents
     depends_on:
       postgres:
         condition: service_healthy
 
   frontend:
-    build: ./frontend
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
     container_name: opaa-frontend
     ports:
       - "${OPAA_FRONTEND_PORT:-3000}:80"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,48 +4,90 @@
 
 ```bash
 # 1. Configure environment
-cp .env.example .env
-# Edit .env and set your OPAA_OPENAI_API_KEY
+cp .env.example .env.docker
+# Edit .env.docker and set your OPAA_OPENAI_API_KEY
 
 # 2. Start all services
 docker compose up --build
 
 # 3. Open the application
-# Frontend: http://localhost
-# Backend API: http://localhost:8080/api
+# Frontend: http://localhost:3000
+# Backend API: http://localhost:8081/api
 ```
 
 ## Services
 
-| Service    | Port | Description                        |
-|------------|------|------------------------------------|
-| frontend   | 80   | React app served via Nginx         |
-| backend    | 8080 | Spring Boot API                    |
-| postgres   | 5432 | PostgreSQL 18 with pgvector        |
+| Service    | Host Port | Container Port | Description                        |
+|------------|-----------|----------------|------------------------------------|
+| frontend   | 3000      | 80             | React app served via Nginx         |
+| backend    | 8081      | 8080           | Spring Boot API                    |
+| postgres   | 5432      | 5432           | PostgreSQL 18 with pgvector        |
+| keycloak   | 8180      | 8180           | Keycloak (OIDC profile only)       |
 
 ## Configuration
 
-All configuration is done via environment variables in `.env`. See `.env.example` for available options.
+All configuration is done via environment variables in `.env.docker`. Docker Compose loads this file via the `env_file` directive. See `.env.example` for all available options with descriptions.
 
-### Environment Variables
+> **Important:** Docker Compose automatically loads a `.env` file (if present) for variable interpolation in `docker-compose.yml` itself. To avoid conflicts with local development settings, Docker Compose services use `.env.docker` as their `env_file`. If you have a `.env` file for local development, make sure the Docker-relevant variables (ports, DB credentials) don't conflict.
+
+### Required Variables
+
+The only variable you must set before starting is:
+
+```env
+OPAA_OPENAI_API_KEY=sk-your-key-here
+```
+
+### Docker-Specific Variables
+
+These variables are important when running with Docker Compose and should be set in `.env.docker`:
+
+| Variable | Required Value | Why |
+|----------|---------------|-----|
+| `SPRING_PROFILES_ACTIVE` | `docker` (or `docker,oidc`) | Activates Docker-specific config (DB URL, Ollama URL) |
+| `OPAA_SERVER_ADDRESS` | `0.0.0.0` | Backend must bind to all interfaces to be reachable from other containers |
+| `OPAA_CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Must match the frontend's host port |
+| `OPAA_DB_USERNAME` | `opaa` | Must match between backend and postgres services |
+| `OPAA_DB_PASSWORD` | `opaa` | Must match between backend and postgres services |
+
+### Minimal `.env.docker`
+
+```env
+SPRING_PROFILES_ACTIVE=docker
+OPAA_SERVER_ADDRESS=0.0.0.0
+OPAA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+OPAA_AI_CHAT_PROVIDER=openai
+OPAA_AI_EMBEDDING_PROVIDER=openai
+OPAA_OPENAI_API_KEY=sk-your-key-here
+OPAA_DB_USERNAME=opaa
+OPAA_DB_PASSWORD=opaa
+```
+
+### All Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | **General** | | |
 | `OPAA_SERVER_ADDRESS` | `localhost` | Bind address (`0.0.0.0` for network access) |
 | `OPAA_HTTP_FORCE_HTTP1` | `false` | Force HTTP/1.1 for vLLM compatibility |
-| `OPAA_DOCUMENTS_PATH_HOST` | `./documents` | Host path for documents (mounted into container) |
+| `OPAA_CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | Allowed CORS origins (comma-separated) |
+| `OPAA_INDEXING_DOCUMENT_PATH_HOST` | `./documents` | Host path for documents (mounted into container) |
 | **Database** | | |
+| `OPAA_DB_URL` | `jdbc:postgresql://localhost:5432/opaa` | JDBC connection URL |
 | `OPAA_DB_USERNAME` | `opaa` | PostgreSQL username |
 | `OPAA_DB_PASSWORD` | `opaa` | PostgreSQL password |
 | **LLM / Embedding** | | |
 | `OPAA_AI_CHAT_PROVIDER` | `openai` | Chat model provider (`openai` or `ollama`) |
+| `OPAA_AI_EMBEDDING_PROVIDER` | `openai` | Embedding model provider (`openai` or `ollama`) |
 | `OPAA_OPENAI_API_KEY` | — | OpenAI API key (required when using OpenAI) |
+| `OPAA_OPENAI_BASE_URL` | `https://api.openai.com` | OpenAI-compatible API base URL |
 | `OPAA_OPENAI_CHAT_MODEL` | `gpt-4o` | OpenAI chat model name |
 | `OPAA_OPENAI_CHAT_TEMPERATURE` | `0.7` | Chat response temperature (0.0–2.0) |
 | `OPAA_OPENAI_CHAT_MAX_TOKENS` | `2000` | Maximum tokens in chat response |
 | `OPAA_OPENAI_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model name |
-| `OPAA_OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama API base URL |
+| `OPAA_OLLAMA_BASE_URL` | `http://ollama:11434` | Ollama API base URL |
+| `OPAA_OLLAMA_CHAT_MODEL` | `phi3:mini` | Ollama chat model name |
+| `OPAA_OLLAMA_EMBEDDING_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | **Query (RAG Retrieval)** | | |
 | `OPAA_QUERY_TOP_K` | `5` | Number of document chunks retrieved per query (1–100) |
 | `OPAA_QUERY_SIMILARITY_THRESHOLD` | `0.3` | Minimum cosine similarity for chunk inclusion (0.0–1.0) |
@@ -57,6 +99,9 @@ All configuration is done via environment variables in `.env`. See `.env.example
 | `OPAA_INDEXING_THREAD_POOL_CORE_SIZE` | `2` | Core threads for async indexing |
 | `OPAA_INDEXING_THREAD_POOL_MAX_SIZE` | `4` | Maximum threads for async indexing |
 | `OPAA_INDEXING_THREAD_POOL_QUEUE_CAPACITY` | `20` | Task queue capacity for async indexing |
+| **pgvector** | | |
+| `OPAA_PGVECTOR_DIMENSIONS` | `1536` | Vector dimensions (must match embedding model) |
+| `OPAA_PGVECTOR_DISTANCE_TYPE` | `cosine_distance` | Distance function for similarity search |
 | **Rate Limiting** | | |
 | `OPAA_RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting |
 | `OPAA_RATE_LIMIT_QUERY_MAX_REQUESTS` | `10` | Max query requests per IP per window |
@@ -65,6 +110,22 @@ All configuration is done via environment variables in `.env`. See `.env.example
 | `OPAA_RATE_LIMIT_INDEXING_MAX_REQUESTS` | `1` | Max indexing requests per IP per window |
 | `OPAA_RATE_LIMIT_INDEXING_WINDOW_SECONDS` | `60` | Indexing rate limit window in seconds |
 | `OPAA_RATE_LIMIT_INDEXING_GLOBAL_MAX_REQUESTS` | `5` | Max indexing requests across all IPs per window |
+| **Authentication** | | |
+| `OPAA_AUTH_MODE` | `mock` | Auth mode: `mock`, `basic`, or `oidc` |
+| `OPAA_AUTH_BASIC_USERNAME` | `admin` | Username for basic auth |
+| `OPAA_AUTH_BASIC_PASSWORD` | `admin` | Password for basic auth |
+| `OPAA_AUTH_BASIC_SECRET` | — | JWT signing secret (min 256 bit) |
+| `OPAA_AUTH_BASIC_TOKEN_EXPIRATION` | `3600` | JWT token expiration in seconds |
+| `OPAA_AUTH_BASIC_ISSUER` | `opaa-basic` | JWT issuer claim |
+| `OPAA_INITIAL_ADMIN_EMAIL` | — | Email for auto-created initial admin user |
+| **OIDC** | | |
+| `OPAA_OIDC_JWK_SET_URI` | `http://localhost:8180/...` | JWK Set URI for token verification |
+| `OPAA_OIDC_ISSUER_URI` | `http://localhost:8180/realms/opaa` | OIDC issuer URI for token validation |
+| `OPAA_OIDC_AUTHORITY` | `http://localhost:8180/realms/opaa` | OIDC authority URL (used by frontend) |
+| `OPAA_OIDC_CLIENT_ID` | `opaa-frontend` | OIDC client ID |
+| **Docker Compose Ports** | | |
+| `OPAA_BACKEND_PORT` | `8081` | Backend host port |
+| `OPAA_FRONTEND_PORT` | `3000` | Frontend host port |
 
 ### Network Access
 
@@ -74,13 +135,13 @@ By default, the backend binds to `localhost`. To make OPAA accessible from other
 OPAA_SERVER_ADDRESS=0.0.0.0
 ```
 
+> **Note:** In Docker Compose, `OPAA_SERVER_ADDRESS` **must** be set to `0.0.0.0` so the backend is reachable from the frontend container's Nginx reverse proxy.
+
 For local development, also start the frontend with `npm run dev -- --host` and add the access origin to CORS:
 
 ```env
 OPAA_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://your-hostname:5173
 ```
-
-> **Note:** In Docker Compose, `OPAA_SERVER_ADDRESS` defaults to `0.0.0.0` since the container must be reachable from outside.
 
 ### LLM Provider
 
@@ -90,6 +151,7 @@ To use Ollama (local LLM) instead, set:
 
 ```env
 OPAA_AI_CHAT_PROVIDER=ollama
+OPAA_AI_EMBEDDING_PROVIDER=ollama
 OPAA_OLLAMA_BASE_URL=http://localhost:11434
 ```
 
@@ -104,11 +166,51 @@ OPAA_OPENAI_BASE_URL=http://your-vllm-server:8000/v1
 
 This is required because Spring Boot's default HTTP client prefers HTTP/2, which causes connection failures with Uvicorn-based servers like vLLM.
 
-### Documents
+## Authentication
 
-Place documents in the `./documents` directory (or change `OPAA_DOCUMENTS_PATH_HOST` in `.env`). The directory is mounted into the backend container at `/app/documents`.
+### Mock Mode (Default)
 
-### Database
+No authentication — all requests are allowed. Suitable for local development only.
+
+### Basic Auth
+
+```env
+SPRING_PROFILES_ACTIVE=docker
+OPAA_AUTH_MODE=basic
+OPAA_AUTH_BASIC_USERNAME=admin
+OPAA_AUTH_BASIC_PASSWORD=admin
+OPAA_AUTH_BASIC_SECRET=change-me-to-a-256-bit-secret-key-in-production!!
+```
+
+### OIDC (Keycloak)
+
+To enable OIDC authentication with the bundled Keycloak:
+
+```bash
+docker compose --profile oidc up --build
+```
+
+Required variables in `.env.docker`:
+
+```env
+SPRING_PROFILES_ACTIVE=docker,oidc
+OPAA_AUTH_MODE=oidc
+OPAA_OIDC_JWK_SET_URI=http://keycloak:8180/realms/opaa/protocol/openid-connect/certs
+```
+
+> **Important:** `OPAA_OIDC_JWK_SET_URI` must use the Docker-internal hostname `keycloak` (not `localhost`), because the backend container validates JWT tokens by fetching keys from Keycloak. `OPAA_OIDC_ISSUER_URI` and `OPAA_OIDC_AUTHORITY` should remain `http://localhost:8180/...` since the browser uses these URLs.
+
+A test user is pre-configured in the Keycloak realm:
+- **Username:** `testuser`
+- **Password:** `testpass`
+
+The Keycloak admin console is available at http://localhost:8180 (admin/admin).
+
+## Documents
+
+Place documents in the `./documents` directory (or change `OPAA_INDEXING_DOCUMENT_PATH_HOST` in `.env.docker`). The directory is mounted into the backend container at `/app/documents`.
+
+## Database
 
 PostgreSQL data is persisted in a Docker volume (`opaa-postgres-data`). Data survives `docker compose down` and `docker compose up` cycles.
 
@@ -117,6 +219,32 @@ To reset the database:
 ```bash
 docker compose down -v
 ```
+
+> **Note:** You must run `docker compose down -v` when changing `OPAA_DB_USERNAME` or `OPAA_DB_PASSWORD`, because PostgreSQL only creates the initial user on first startup. Without removing the volume, credential changes are ignored.
+
+## Troubleshooting
+
+### Backend returns empty responses or connection refused
+
+The backend binds to `localhost` by default, which is only reachable from inside the container. Set `OPAA_SERVER_ADDRESS=0.0.0.0` in `.env.docker`.
+
+### POST requests return 403 Forbidden
+
+CORS is likely misconfigured. Ensure `OPAA_CORS_ALLOWED_ORIGINS` matches the frontend URL (e.g., `http://localhost:3000`). GET requests may work because they don't trigger CORS preflight, while POST requests with `Content-Type: application/json` do.
+
+### Password authentication failed for user
+
+The PostgreSQL volume still contains data from a previous initialization with different credentials. Run `docker compose down -v` to remove the volume and restart.
+
+### OIDC: "Completing sign in..." hangs or falls back to mock
+
+- Ensure Keycloak is running (`docker compose --profile oidc ps`)
+- If Keycloak was restarted, the access token may have expired — reload the page and log in again
+- Check that `OPAA_OIDC_JWK_SET_URI` uses `keycloak:8180` (not `localhost:8180`)
+
+### Environment variable changes not taking effect
+
+After changing `.env.docker`, use `docker compose up -d <service>` (not `restart`) to recreate the container with the new environment. `restart` reuses the existing container and ignores `.env.docker` changes.
 
 ## Stopping
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:22-alpine AS build
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
-COPY . .
+COPY frontend/ .
+COPY backend/src/main/resources/openapi/opaa-api.yaml /backend/src/main/resources/openapi/opaa-api.yaml
 RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -8,12 +8,16 @@ import { useAuthStore } from '../stores/authStore'
 export default function AuthCallbackPage() {
   const handleOidcCallback = useAuthStore((s) => s.handleOidcCallback)
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const isLoading = useAuthStore((s) => s.isLoading)
+  const userManager = useAuthStore((s) => s.userManager)
   const error = useAuthStore((s) => s.error)
   const navigate = useNavigate()
 
   useEffect(() => {
-    handleOidcCallback()
-  }, [handleOidcCallback])
+    if (!isLoading && userManager) {
+      handleOidcCallback()
+    }
+  }, [isLoading, userManager, handleOidcCallback])
 
   useEffect(() => {
     if (isAuthenticated) {


### PR DESCRIPTION
## Summary

- Replaced 30+ inline environment variables in `docker-compose.yml` with `env_file: .env.docker` directive
- Expanded `.env.example` with all 50+ available variables, grouped by category with descriptions
- Renamed `OPAA_DOCUMENTS_PATH_HOST` → `OPAA_INDEXING_DOCUMENT_PATH_HOST` for consistency
- Fixed frontend Dockerfile to use project root as build context (OpenAPI spec needed for type generation)
- Fixed OIDC callback race condition in `AuthCallbackPage`
- Rewrote deployment docs with Docker-specific config, auth modes, OIDC/Keycloak setup, and troubleshooting

## Related Issues

Closes #157

## Type of Change

- [x] Enhancement to an existing feature

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated the documentation accordingly
- [x] I have tested the Docker Compose deployment (mock, basic, oidc modes)

## AI Agent Disclosure

This PR was authored with AI assistance (Claude Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)