### PR TITLE
fix(auth): eliminate implicit algorithm coupling in basic-auth JWT signing/decoding

### DIFF
--- a/backend/src/main/java/io/opaa/auth/BasicSecurityConfig.java
+++ b/backend/src/main/java/io/opaa/auth/BasicSecurityConfig.java
@@ -1,7 +1,6 @@
 package io.opaa.auth;
 
 import jakarta.annotation.PostConstruct;
-import javax.crypto.spec.SecretKeySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -92,8 +91,7 @@ public class BasicSecurityConfig {
 
   @Bean
   JwtDecoder jwtDecoder() {
-    byte[] secret = authProperties.basic().secret().getBytes();
-    return NimbusJwtDecoder.withSecretKey(new SecretKeySpec(secret, "HmacSHA256"))
+    return NimbusJwtDecoder.withSecretKey(JwtTokenService.buildKey(authProperties.basic().secret()))
         .macAlgorithm(MacAlgorithm.HS256)
         .build();
   }

--- a/backend/src/main/java/io/opaa/auth/JwtTokenService.java
+++ b/backend/src/main/java/io/opaa/auth/JwtTokenService.java
@@ -1,11 +1,11 @@
 package io.opaa.auth;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 public class JwtTokenService {
 
@@ -14,9 +14,17 @@ public class JwtTokenService {
   private final String issuer;
 
   public JwtTokenService(String secret, long expirationSeconds, String issuer) {
-    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    this.key = buildKey(secret);
     this.expirationSeconds = expirationSeconds;
     this.issuer = issuer;
+  }
+
+  /**
+   * Builds the HS256 signing key from the given secret. Both token signing and JWT decoding must
+   * use this method so that algorithm and key construction stay in sync.
+   */
+  public static SecretKey buildKey(String secret) {
+    return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
   }
 
   public String generateToken(String subject, String email, String displayName) {

--- a/backend/src/test/java/io/opaa/auth/JwtTokenServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/JwtTokenServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class JwtTokenServiceTest {
@@ -21,7 +19,7 @@ class JwtTokenServiceTest {
 
     Claims claims =
         Jwts.parser()
-            .verifyWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)))
+            .verifyWith(JwtTokenService.buildKey(SECRET))
             .build()
             .parseSignedClaims(token)
             .getPayload();


### PR DESCRIPTION
## Summary

- Extract `JwtTokenService.buildKey(String secret)` as the single source of truth for HS256 key construction
- `BasicSecurityConfig.jwtDecoder()` now delegates to `buildKey()` instead of duplicating `SecretKeySpec` logic
- Update `JwtTokenServiceTest` to verify tokens via the same `buildKey()` helper, removing the `Keys.hmacShaKeyFor` dependency from the test

## Related Issues

Closes #164

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Backend formatting (`spotlessApply`)
- [x] Backend build + test (`./gradlew build`)
- [ ] Frontend (not affected)

## AI Agent Disclosure

This PR was created with Claude Code (claude-sonnet-4-5).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>