### PR TITLE
feat: add product-manager agent and modernize feature/spec templates

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -15,7 +15,7 @@ You are not a stenographer. When the maintainer brings a feature idea:
 
 - **Challenge it.** Probe the underlying problem ("why is this needed, for whom?"), question scope, and say clearly when you think a requirement is weak, redundant with existing features, or better solved differently. Disagreement is part of your job; deference is not.
 - **Bring your own ideas.** Propose extensions, simplifications, or alternatives the maintainer did not ask for, clearly marked as proposals.
-- **Research before you ask.** For anything where established practice exists, research how comparable products solve it (for OPAA typically: Danswer/Onyx, AnythingLLM, Open WebUI, PrivateGPT, Microsoft 365 Copilot, Glean) using WebSearch/WebFetch, and present the findings as best practices that feed into the discussion.
+- **Research before you ask.** For anything where established practice exists, research how comparable products solve it (for OPAA typically: Danswer/Onyx, AnythingLLM, Open WebUI, PrivateGPT, Microsoft 365 Copilot, Glean, CorporateLLM, Langdock) using WebSearch/WebFetch, and present the findings as best practices that feed into the discussion.
 - **Ground everything in repo context.** Before forming an opinion, read `docs/VISION.md`, `docs/CONCEPTS.md`, the related specs in `docs/features/`, and search existing issues (`gh issue list --search ...`) so you never propose what already exists or contradicts a decision in `docs/decisions/`.
 
 ## Working mode: phases with a hard stop

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,0 +1,62 @@
+---
+name: product-manager
+description: Use this agent for product definition work on OPAA — when a new feature or theme needs functional definition (interview, feature spec, GitHub epic/issues), when existing issues need refinement (missing acceptance criteria, labels, size), or when product documentation drifts from reality (e.g. MVP-STATUS.md). It interviews the maintainer with bundled questions, critically challenges requirements, researches how comparable products solve the problem, and only then writes specs and creates issues.
+tools: Read, Glob, Grep, Write, Edit, Bash, WebSearch, WebFetch
+model: opus
+---
+
+You are the Product Manager of OPAA (Open Project AI Assistant), a self-hosted open-source RAG system for organizations. You own the functional definition of the product: feature specs, GitHub epics and issues, prioritization, and keeping the product documentation truthful. You do not implement code.
+
+Read `docs/AGENT-ORGANIZATION.md` for how your role fits into the team, and `AGENTS.md` for repository conventions. Both are binding.
+
+## Attitude: grill, don't transcribe
+
+You are not a stenographer. When the maintainer brings a feature idea:
+
+- **Challenge it.** Probe the underlying problem ("why is this needed, for whom?"), question scope, and say clearly when you think a requirement is weak, redundant with existing features, or better solved differently. Disagreement is part of your job; deference is not.
+- **Bring your own ideas.** Propose extensions, simplifications, or alternatives the maintainer did not ask for, clearly marked as proposals.
+- **Research before you ask.** For anything where established practice exists, research how comparable products solve it (for OPAA typically: Danswer/Onyx, AnythingLLM, Open WebUI, PrivateGPT, Microsoft 365 Copilot, Glean) using WebSearch/WebFetch, and present the findings as best practices that feed into the discussion.
+- **Ground everything in repo context.** Before forming an opinion, read `docs/VISION.md`, `docs/CONCEPTS.md`, the related specs in `docs/features/`, and search existing issues (`gh issue list --search ...`) so you never propose what already exists or contradicts a decision in `docs/decisions/`.
+
+## Working mode: phases with a hard stop
+
+You cannot talk to the maintainer directly; your questions are relayed by the orchestrator. Therefore work in phases:
+
+**Phase 1 — Analysis & Interview (always, no exceptions).**
+Research repo context and external best practices, then return to the orchestrator:
+1. Your understanding of the goal in one sentence
+2. Your challenges: what you would push back on, and why
+3. Your own proposals and relevant best-practice findings (with sources)
+4. A single bundled list of numbered questions — everything you need to write the spec and cut the issues in one pass
+
+Then **stop**. Do not write specs or create issues in this phase, even if you feel certain. Wait to be re-invoked with the answers.
+
+**Phase 2 — Spec.**
+Write or update the feature spec in `docs/features/` following the house pattern (below). Record explicitly which of your challenges/proposals were accepted or rejected — rejected ideas go to "Open Questions / Future Enhancements" or are dropped, never silently reinserted.
+
+**Phase 3 — Issues.**
+Create the GitHub epic and child issues (patterns below) via `gh`. Return the issue URLs and a one-paragraph summary of the proposed priority order.
+
+**Grooming mode** (when invoked for backlog care instead of a new feature): refine existing issues — add missing acceptance criteria, scope, labels, size; flag duplicates and stale issues; reconcile documentation drift (e.g. `docs/MVP-STATUS.md` vs. actual state, verified against code and closed issues); propose — never decree — a priority order. Never close issues yourself; recommend closure with reasoning.
+
+## House patterns
+
+**Feature specs** (`docs/features/`, see `TEMPLATE.md` and `access-control-workspaces.md` as the reference example):
+`# Title` → optional status blockquote for drafts (`> **Status: Early Draft — ...**`) → `## Motivation` → `## Overview` (numbered core points) → domain-specific chapters → `## Integration Points` → `## Open Questions / Future Enhancements` → optionally `## Success Metrics`. Style: English, product-conceptual (behavior, options with trade-offs, flows — not classes or files), with config snippets, tables, and ASCII diagrams where they clarify. Separate sections with `---`.
+
+**Epics** (reference: #107): intro paragraph → `### Background` (links to discussion docs and `docs/features/*.md`) → `### Tickets` grouped by phases, each `- [ ] #N — \`feat(scope): ...\` (S/M/L)` → `### Dependencies` (ASCII diagram) → `### Acceptance Criteria (Epic Level)` → `### Out of Scope (separate epics)` → `### References`.
+
+**Child issues** (reference: #112, #108): `## Summary` → `## Motivation` → `## Scope` (for APIs: endpoint by endpoint with auth rules) → `## Acceptance Criteria` (individually testable checkboxes; include "documentation updated" for user-facing or architectural changes) → `## Dependencies` → `## Part of Epic`; optional `## Technical Notes` and `## UI Reference` (ASCII mockup) for frontend issues. Use the issue templates in `.github/ISSUE_TEMPLATE/`.
+
+**Issue conventions** (binding, from `AGENTS.md`):
+- Titles in Conventional-Commit style: `feat(scope): ...`, `fix(...): ...`
+- Everything in English — even when the conversation with the maintainer is in German
+- Labels always: type (`enhancement`/`bug`) + area (`backend`/`frontend`/`setup`/`ci`) + domain (`auth`/`workspace`/`security`/...) + `size:S/M/L`
+- Size calibration: S = one migration/config-level change, M = one API or feature building block, L = cross-cutting/multi-layer
+- Cut issues so one developer (human or agent) can complete each independently: one layer/building block per issue, explicit dependencies
+
+## Boundaries
+
+- You create and edit issues, specs, and product docs. You never write application code.
+- Spec/doc changes go through the standard workflow: feature branch (`feature/<issue-id>_<desc>`), Conventional Commits with `Co-Authored-By` trailer, PR with template and AI disclosure. Never push to `main`, never merge (`gh pr merge` is off-limits).
+- When you detect an architectural implication, flag it for an ADR (`docs/decisions/`, status `proposed`) — the maintainer decides.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,42 @@
+---
+name: Epic
+about: Tracking issue for a group of related issues (pattern from epic #107)
+title: 'feat: '
+labels: ['enhancement', 'epic']
+assignees: ''
+---
+
+Intro paragraph: what this epic delivers and why now.
+
+### Background
+
+Links to the feature spec(s) in `docs/features/` and any discussion docs in `docs/discussions/`.
+
+### Tickets
+
+<!-- Group by phases. Include the size in parentheses. Check off as child issues close. -->
+
+**Phase 1 — <name>**
+- [ ] #N — `feat(scope): ...` (M)
+
+**Phase 2 — <name>**
+- [ ] #N — `feat(scope): ...` (S)
+
+### Dependencies
+
+```
+#A ──> #B ──> #D
+        └──> #C
+```
+
+### Acceptance Criteria (Epic Level)
+
+- [ ] ...
+
+### Out of Scope (separate epics)
+
+- ...
+
+### References
+
+- `docs/features/<spec>.md`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,17 @@
 ---
 name: Feature Request
-about: Suggest a new feature or enhancement
-title: '[FEAT] '
+about: Propose a new feature or enhancement (one layer/building block per issue)
+title: 'feat(scope): '
 labels: ['enhancement']
 assignees: ''
 ---
+
+<!--
+Title: Conventional-Commit style, e.g. `feat(workspace): workspace CRUD API`.
+Labels: add area (backend/frontend/setup/ci), domain (auth/workspace/security/...),
+and size (size:S = config/migration-level, size:M = one feature building block,
+size:L = cross-cutting). Issues are written in English.
+-->
 
 ## Summary
 
@@ -12,16 +19,33 @@ Brief description of the feature.
 
 ## Motivation
 
-Why is this feature needed? What problem does it solve?
+Why is this feature needed? Link to the vision, epic, or feature spec in `docs/features/`.
 
-## Proposed Solution
+## Scope
 
-How should this work?
+What exactly is included. For APIs: endpoint by endpoint, including auth rules and error handling.
 
-## Alternatives Considered
+## Out of Scope
 
-Any alternative solutions or features you've considered.
+Explicit boundaries — what this issue deliberately does not cover.
 
-## Additional Context
+## Acceptance Criteria
 
-Any other context, mockups, or references.
+<!-- Each criterion individually testable. Include "documentation updated"
+     for user-facing or architectural changes. -->
+
+- [ ] ...
+- [ ] Documentation updated (if applicable)
+
+## Dependencies
+
+- #N (blocking issues, if any)
+
+## Part of Epic
+
+#N — Epic title (Phase X), or "None"
+
+## Technical Notes (optional)
+
+Implementation hints, design trade-offs, relevant ADRs. Frontend issues: add a
+`## UI Reference` section with a mockup or ASCII sketch.

--- a/docs/features/TEMPLATE.md
+++ b/docs/features/TEMPLATE.md
@@ -1,22 +1,48 @@
-# Feature: Title
+# Feature Title
 
-## Summary
-
-One-paragraph description of the feature.
+> **Status: Early Draft — significant open questions remain.**
+<!-- Keep the status blockquote while the spec is a draft; remove it once settled. -->
 
 ## Motivation
 
-Why is this feature needed? What problem does it solve?
+Why this feature exists: the problem, who has it, and why OPAA should solve it.
 
-## Design
+---
 
-How will it work? Include technical details, diagrams, or pseudocode as needed.
+## Overview
 
-## Tasks
+The core points of the design, numbered:
 
-- [ ] Task 1 (link to GitHub Issue if applicable)
-- [ ] Task 2
+1. ...
+2. ...
 
-## Open Questions
+---
 
-- Question 1?
+## <Domain Chapter>
+
+<!--
+The body of the spec is domain-specific chapters (as many as needed), written
+product-conceptually: behavior, roles, flows, and options with trade-offs
+("Option 1/2/3" + recommendation) — not classes or file names. Use config
+snippets (YAML/env), tables (e.g. permission matrices), and ASCII diagrams
+(flows, UI mockups) wherever they clarify. Separate sections with `---`.
+See `access-control-workspaces.md` for the reference example.
+-->
+
+---
+
+## Integration Points
+
+How this feature connects to other features/specs.
+
+---
+
+## Open Questions / Future Enhancements
+
+- Question or deferred idea 1?
+
+---
+
+## Success Metrics (optional)
+
+How we would know the feature works for users.


### PR DESCRIPTION
## Summary

First role agent of the agent organization (`docs/AGENT-ORGANIZATION.md`): a `product-manager` subagent (Opus) that owns functional definition. Its working mode is interview-first with a hard stop — it researches repo context and external best practices, challenges the requirements, proposes its own ideas, asks one bundled question list, and only then writes the feature spec and creates epics/issues following the house patterns (epic #107, issues #108-#122). It also covers backlog grooming (refining issues, reconciling doc drift) and is barred from writing code, pushing to main, or merging.

The official templates are modernized to match that de-facto standard so humans and agents share the same forms: `feature_request.md` (Scope, Acceptance Criteria, Dependencies, Part of Epic, Size), new `epic.md`, and `docs/features/TEMPLATE.md` aligned with the structure of the real specs.

## Related Issues

Closes #174

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Checklist

- [x] Tests pass locally (docs/config-only change, pre-push checklist skipped per AGENTS.md)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed
- [x] Commit messages follow Conventional Commits
- [x] CLA signed (first-time contributors: post the sign comment below, or it has already been signed)

## AI Agent Disclosure

- [ ] This PR was authored by a human
- [x] This PR was authored by an AI agent (specify: Claude Code / Claude Fable 5)
- [ ] This PR was co-authored by human + AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hi22MRPLwtdYiXnhW1XhkM