### PR TITLE
docs: document git worktree usage for parallel agent sessions

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -6,6 +6,14 @@
 - PRs fokussiert halten: eine logische Änderung pro PR
 - Bei der Behebung eines Issues im PR-Body mit „Closes #N" referenzieren
 
+## Git Worktrees für parallele Sessions
+
+Wenn mehrere Agent-Sessions gleichzeitig in diesem Verzeichnis arbeiten (z. B. mehrere Features parallel), für jede neue Aufgabe einen eigenen Git Worktree nutzen, statt im Hauptverzeichnis zu branchen. So blockieren sich parallele Sessions nicht gegenseitig durch Branch-Wechsel im selben Arbeitsverzeichnis.
+
+- Neue Aufgabe → eigenen Worktree anlegen (eigener Branch, eigenes Arbeitsverzeichnis)
+- Aufgabe fertig & gemerged → Worktree entfernen
+- Aufgabe unterbrochen, später weiterführen → Worktree behalten
+
 # Pre-Push-Checkliste
 
 Bei reinen Dokumentationsänderungen überspringen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ KI-Agenten müssen einen `Co-Authored-By`-Trailer in Commits einfügen.
 - PRs fokussiert halten: eine logische Änderung pro PR
 - Bei der Behebung eines Issues in der PR-Beschreibung mit `Closes #N` referenzieren
 
+### Git Worktrees für parallele Sessions
+
+Wenn mehrere Agent-Sessions gleichzeitig in diesem Verzeichnis arbeiten (z. B. mehrere Features parallel), für jede neue Aufgabe einen eigenen Git Worktree nutzen, statt im Hauptverzeichnis zu branchen. So blockieren sich parallele Sessions nicht gegenseitig durch Branch-Wechsel im selben Arbeitsverzeichnis.
+
+- Neue Aufgabe → eigenen Worktree anlegen (eigener Branch, eigenes Arbeitsverzeichnis)
+- Aufgabe fertig & gemerged → Worktree entfernen
+- Aufgabe unterbrochen, später weiterführen → Worktree behalten
+
 ### Branch-Benennung
 
 Format: `feature/<issue-id>_<kurze-beschreibung>`


### PR DESCRIPTION
## Zusammenfassung

Documents that parallel agent sessions working in the same checkout should use a separate git worktree per task instead of branching in the shared working directory, to avoid sessions blocking each other on branch switches.

## Zugehörige Issues

Closes #194

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst