### PR TITLE
ci: publish backend and frontend images to GHCR

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,56 @@
+name: Publish Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: backend
+            dockerfile: backend/Dockerfile
+            context: backend
+          - name: frontend
+            dockerfile: frontend/Dockerfile
+            context: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/opaa-${{ matrix.name }}
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,format=long
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,32 @@
 # Deployment
 
+## Deployment aus vorgebauten Images (GHCR)
+
+Für Zielsysteme, auf denen nicht aus dem Quellcode gebaut werden soll, veröffentlicht CI bei jedem Push auf `main` fertige Container-Images:
+
+| Image | Tags |
+|-------|------|
+| `ghcr.io/criew/opaa-backend` | `main`, `sha-<commit>` |
+| `ghcr.io/criew/opaa-frontend` | `main`, `sha-<commit>` |
+
+Auf dem Zielsystem wird kein Repository-Checkout benötigt — es genügt eine `docker-compose.yml`, die `image:` statt `build:` verwendet:
+
+```yaml
+services:
+  backend:
+    image: ghcr.io/criew/opaa-backend:main
+  frontend:
+    image: ghcr.io/criew/opaa-frontend:main
+```
+
+Aktualisieren auf den neuesten `main`-Stand:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+`main` folgt dem jeweils letzten Stand; für reproduzierbare Deployments stattdessen einen `sha-<commit>`-Tag pinnen.
+
 ## Schnellstart
 
 ```bash


### PR DESCRIPTION
## Zusammenfassung

Adds a `Publish Images` workflow that builds `backend/Dockerfile` and `frontend/Dockerfile` on every push to `main` (plus manual dispatch) and pushes them to GHCR as `ghcr.io/criew/opaa-backend` and `ghcr.io/criew/opaa-frontend`, tagged with both `main` and the commit SHA.

This lets a deployment target run `docker compose pull && docker compose up -d` against published images instead of checking out the repository and building from source. Layer caching via GitHub Actions cache keeps rebuilds cheap.

Also documents the new images and the pull-based deployment flow in `docs/deployment.md`.

## Zugehörige Issues

Closes #196

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst