### PR TITLE
docs: Projektsprache Deutsch für Issues und Pull Requests festlegen

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,8 @@ assignees: ''
 Titel: Conventional-Commit-Stil, z. B. `feat(workspace): workspace CRUD API`.
 Labels: Bereich hinzufügen (backend/frontend/setup/ci), Domäne (auth/workspace/security/...),
 und Größe (size:S = Konfigurations-/Migrationsebene, size:M = ein Feature-Baustein,
-size:L = querschnittlich). Issues werden auf Englisch verfasst.
+size:L = querschnittlich). Issues werden auf Deutsch verfasst; nur der Conventional-Commit-Typ
+und -Scope im Titel bleiben englisch.
 -->
 
 ## Zusammenfassung

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
 AGENTS.md im Repository-Stammverzeichnis für Projektanweisungen und -konventionen lesen.
 Conventional Commits für alle Commit-Nachrichten verwenden.
 Die Branch-Namenskonvention einhalten: feature/<issue-id>_<kurze-beschreibung>.
+Projektsprache ist Deutsch: Issues, Pull Requests, Dokumentation und alle in der Anwendung sichtbaren Texte auf Deutsch verfassen. Englisch bleibt dem Quellcode vorbehalten (Bezeichner, Dateinamen, Kommentare, Log-Ausgaben).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,28 @@
 OPAA (Open Project AI Assistant) ist ein quelloffenes Projekt, das einen KI-gestützten Projektassistenten entwickelt.
 Beiträge von Menschen und KI-Agenten sind gleichermaßen willkommen.
 
+## Projektsprache
+
+Die Projektsprache ist **Deutsch**. Englisch bleibt ausschließlich dem Quellcode vorbehalten.
+
+**Deutsch:**
+
+- GitHub-Issues (Titel und Beschreibung)
+- Pull Requests (Titel und Beschreibung)
+- Dokumentation (`README.md`, `docs/`, ADRs, Feature-Spezifikationen)
+- Templates unter `.github/`
+- Commit-Beschreibungen und -Body (der Conventional-Commit-Typ und -Scope bleiben englisch, z. B. `feat(workspace): Rollenverwaltung ergänzen`)
+- Alle in der Anwendung sichtbaren Texte — Frontend-UI, `aria-label`-Attribute und nutzerseitige API-Fehlermeldungen
+
+**Englisch:**
+
+- Bezeichner im Quellcode (Klassen, Methoden, Variablen, CSS-Klassen)
+- Datei- und Verzeichnisnamen
+- Code-Kommentare
+- Log-Ausgaben und entwicklerseitige Exception-Messages
+- Technische Konstanten, Enum-Werte, API-Feldnamen und die OpenAPI-Spezifikation
+- Labels und Branch-Namen
+
 ## Architektur
 
 - **Backend:** Java 21 + Spring Boot 4.1.0 + Spring AI 2.0.0 (Gradle 9.6.1, Kotlin DSL)
@@ -101,14 +123,14 @@ Jeder Branch ist über seine ID mit einem GitHub-Issue verknüpft.
 
 - Beim Erstellen eines GitHub-Issues IMMER passende Labels basierend auf dem Inhalt zuweisen
 - Vorhandene Labels verwenden (z. B. `bug`, `enhancement`, `backend`, `frontend`, `security`, `auth`, `size:S/M/L`, usw.)
-- Issue-Titel und -Beschreibungen MÜSSEN auf Englisch verfasst werden
+- Issue-Titel und -Beschreibungen MÜSSEN auf Deutsch verfasst werden (siehe [Projektsprache](#projektsprache))
 
 ### Pull Requests
 
 - Keine direkten Pushes zu `main` — alle Änderungen gehen über PRs
 - PRs müssen vor dem Merge überprüft werden
 - Beim Erstellen eines PRs IMMER passende Labels basierend auf dem Inhalt zuweisen
-- PR-Titel und -Beschreibungen MÜSSEN auf Englisch verfasst werden
+- PR-Titel und -Beschreibungen MÜSSEN auf Deutsch verfasst werden (siehe [Projektsprache](#projektsprache))
 - IMMER das PR-Template (Zusammenfassung, Zugehörige Issues, Art der Änderung, Checkliste, KI-Agenten-Offenlegung) in [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) für neue Pull Requests verwenden
 
 ### Pre-Push-Checkliste

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ docs: update architecture decision records
 
 ## Issues
 
-- **Issues müssen auf Englisch verfasst werden**
+- **Issues müssen auf Deutsch verfasst werden** — ebenso Pull Requests und Dokumentation. Englisch bleibt dem Quellcode vorbehalten (Bezeichner, Dateinamen, Kommentare); Details in [AGENTS.md](AGENTS.md#projektsprache)
 - Bereitgestellte Issue-Templates für Bug-Reports und Feature-Requests verwenden
 - Für größere Features eine Feature-Spezifikation in `docs/features/` erstellen und vom Issue verlinken
 

--- a/agents/roles/developer.md
+++ b/agents/roles/developer.md
@@ -24,7 +24,7 @@ Sie sind Software-Entwickler bei OPAA (Java 21 + Spring Boot 3.5 Backend, React 
 - Das Issue und nichts weiter implementieren. Nicht über den Auftrag hinaus refaktorieren oder nebenbei Fixes vornehmen.
 - Bei kleinen Unklarheiten eine vernünftige Annahme treffen und sie unter `## Annahmen` im PR dokumentieren.
 - Bei grundlegenden Fragen, widersprüchlichen Kriterien oder nicht geklärten Architekturentscheidungen stoppen und an den Orchestrator melden, statt zu raten.
-- Für einen Bug außerhalb des Umfangs ein beschriftetes englisches Follow-up-Issue erstellen und es im PR erwähnen — in diesem PR nicht beheben.
+- Für einen Bug außerhalb des Umfangs ein beschriftetes deutschsprachiges Follow-up-Issue erstellen und es im PR erwähnen — in diesem PR nicht beheben.
 - Bei harten Blockern wie einem kaputten Main-Branch oder fehlender Infrastruktur stoppen und melden; niemals Workarounds um eine kaputte Basis bauen.
 - Niemals auf `main` pushen, niemals mergen und niemals die Arbeit anderer Branches anfassen.
 

--- a/agents/roles/marketing.md
+++ b/agents/roles/marketing.md
@@ -37,7 +37,7 @@ Landing Page, Pitch, One-Pager und README-Messaging autonom aus der Quelle der W
 
 ## Ton: zwei verbindliche Spuren
 
-- **Community-Spur** (README, GitHub, Docs): Englisch, informell, entwicklerrespektierend — informieren, nicht überzeugen. Marketing-Vokabular wie `empower` oder `revolutionize` vermeiden; Quickstarts, Architektur und ehrliche Vergleiche sind das Marketing.
+- **Community-Spur** (README, GitHub, Docs): Deutsch, informell, entwicklerrespektierend — informieren, nicht überzeugen. Marketing-Vokabular wie `empower` oder `revolutionize` vermeiden; Quickstarts, Architektur und ehrliche Vergleiche sind das Marketing.
 - **Käufer-Spur** (Landing Page, Decks, One-Pager): Deutsch und Englisch, professionelles `Sie`. Prioritätssegmente sind Behörden, Gesundheitswesen und Anwaltskanzleien. Risiko, Compliance, TCO und Exit-Sicherheit betonen.
 
 ## Disziplin

--- a/agents/roles/product-manager.md
+++ b/agents/roles/product-manager.md
@@ -42,16 +42,16 @@ Wenn für Backlog-Pflege statt eines neuen Features aufgerufen: vorhandene Issue
 
 ## Hausmuster
 
-**Feature-Spezifikationen** in `docs/features/` folgen `TEMPLATE.md` und `access-control-workspaces.md`: `# Title`, ein optionaler Draft-Status-Block, `## Motivation`, `## Overview` mit nummerierten Kernpunkten, domänenspezifische Kapitel, `## Integration Points`, `## Open Questions / Future Enhancements` und optionale `## Success Metrics`. Auf Englisch auf dem Produkt-Konzeptlevel schreiben: Verhalten, Optionen mit Abwägungen und Abläufe — keine Klassen oder Dateien. Konfigurationsausschnitte, Tabellen und ASCII-Diagramme verwenden, wo sie Klarheit schaffen. Abschnitte mit `---` trennen.
+**Feature-Spezifikationen** in `docs/features/` folgen `TEMPLATE.md` und `access-control-workspaces.md`: `# Title`, ein optionaler Draft-Status-Block, `## Motivation`, `## Überblick` mit nummerierten Kernpunkten, domänenspezifische Kapitel, `## Integrationspunkte`, `## Offene Fragen / Zukünftige Erweiterungen` und optionale `## Erfolgs-Metriken`. Auf Deutsch auf dem Produkt-Konzeptlevel schreiben: Verhalten, Optionen mit Abwägungen und Abläufe — keine Klassen oder Dateien. Konfigurationsausschnitte, Tabellen und ASCII-Diagramme verwenden, wo sie Klarheit schaffen. Abschnitte mit `---` trennen.
 
-**Epics** folgen Issue #107: eine Einleitung, `### Background`, `### Tickets` gruppiert nach Phase, `### Dependencies`, `### Acceptance Criteria (Epic Level)`, `### Out of Scope (separate epics)` und `### References`.
+**Epics** folgen `.github/ISSUE_TEMPLATE/epic.md`: eine Einleitung, `### Hintergrund`, `### Tickets` gruppiert nach Phase, `### Abhängigkeiten`, `### Abnahmekriterien (Epic-Ebene)`, `### Außerhalb des Umfangs (separate Epics)` und `### Referenzen`.
 
-**Child-Issues** folgen Issues #112 und #108: `## Summary`, `## Motivation`, `## Scope`, `## Acceptance Criteria`, `## Dependencies` und `## Part of Epic`; `## Technical Notes` und `## UI Reference` hinzufügen, wenn sinnvoll. Die Issue-Templates in `.github/ISSUE_TEMPLATE/` verwenden.
+**Child-Issues** folgen `.github/ISSUE_TEMPLATE/feature_request.md`: `## Zusammenfassung`, `## Motivation`, `## Umfang`, `## Außerhalb des Umfangs`, `## Abnahmekriterien`, `## Abhängigkeiten` und `## Teil von Epic`; `## Technische Hinweise` und einen UI-Referenzabschnitt hinzufügen, wenn sinnvoll. Die Issue-Templates in `.github/ISSUE_TEMPLATE/` verwenden.
 
 ## Issue-Konventionen
 
 - Titel verwenden Conventional-Commit-Stil: `feat(scope): ...`, `fix(...): ...`.
-- Alles auf Englisch, auch wenn das Gespräch auf Deutsch ist.
+- Alles auf Deutsch verfassen; nur der Conventional-Commit-Typ und -Scope im Titel sowie Label- und Branch-Namen bleiben englisch.
 - Immer Typ (`enhancement` oder `bug`), Bereich (`backend`, `frontend`, `setup` oder `ci`), Domäne (`auth`, `workspace`, `security` usw.) und `size:S`, `size:M` oder `size:L` Labels zuweisen.
 - Größen-Kalibrierung: S ist eine Migration oder Konfigurationsänderung; M ist ein API- oder Feature-Baustein; L ist querschnittlich oder mehrstufig.
 - Issues so schneiden, dass ein Entwickler, Mensch oder Agent, jeden unabhängig abschließen kann: eine Schicht oder ein Baustein pro Issue und explizite Abhängigkeiten.

--- a/agents/roles/qa-engineer.md
+++ b/agents/roles/qa-engineer.md
@@ -33,7 +33,7 @@ Sie sind der QA Engineer von OPAA. Sie testen das laufende System aus der Perspe
 
 ## Bug-Reports
 
-Englische, beschriftete Bug-Reports mit Schweregrad und Bereich erstellen, die Folgendes enthalten:
+Deutschsprachige, beschriftete Bug-Reports mit Schweregrad und Bereich erstellen, die Folgendes enthalten:
 
 1. **Repro** — deterministische Schritte im Clean-State mit dem Docker-Compose-Stack, Mock-Auth und Seed-Dokumenten aus `backend/src/test/resources/test-documents/`
 2. **Erwartet** — mit Verweis auf das Abnahmekriterium, die Spezifikation oder die Dokumentation


### PR DESCRIPTION
## Zusammenfassung

Die Issue- und PR-Templates sind bereits auf Deutsch, die Regelwerke schrieben aber weiterhin Englisch für Issue- und PR-Titel/-Beschreibungen vor. Dieser PR löst den Widerspruch auf und legt die Sprachtrennung an einer Stelle verbindlich fest.

Neuer Abschnitt **Projektsprache** in `AGENTS.md`:

- **Deutsch:** Issues, Pull Requests, Dokumentation, `.github/`-Templates, Commit-Beschreibungen und alle in der Anwendung sichtbaren Texte
- **Englisch:** Bezeichner im Quellcode, Datei- und Verzeichnisnamen, Code-Kommentare, Conventional-Commit-Typ und -Scope, Log-Ausgaben, technische Konstanten, Labels und Branch-Namen

Nachgezogen: `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, `.github/copilot-instructions.md` sowie die Agenten-Rollen `product-manager`, `developer`, `qa-engineer` und `marketing`.

Nebenbei korrigiert: `agents/roles/product-manager.md` verwies noch auf englische Abschnittsnamen (`## Overview`, `### Background`), obwohl die Templates längst deutsche Überschriften haben.

Die Umstellung der Anwendungstexte selbst folgt separat in #221.

## Zugehörige Issues

Closes #219

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal (reine Dokumentationsänderung — Pre-Push-Checkliste entfällt)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF