### PR TITLE
feat: Anwendungstexte auf Deutsch umstellen

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -60,9 +60,16 @@ spotless {
     }
 }
 
+// Deutsche Texte in Quellen und Ressourcen sind UTF-8. Ohne diese Einstellung
+// nutzt javac das Plattform-Encoding, was auf Windows Umlaute verfälscht.
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+    systemProperty("file.encoding", "UTF-8")
 }
 
 tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openApiGenerate") {

--- a/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
         ex.getBindingResult().getFieldErrors().stream()
             .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
             .findFirst()
-            .orElse("Validation failed");
+            .orElse("Validierung fehlgeschlagen");
     return ResponseEntity.badRequest()
         .body(new ErrorResponse(message, HttpStatus.BAD_REQUEST.value(), Instant.now()));
   }
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest()
         .body(
             new ErrorResponse(
-                "Request body is missing or malformed",
+                "Der Anfragetext fehlt oder ist fehlerhaft",
                 HttpStatus.BAD_REQUEST.value(),
                 Instant.now()));
   }
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
         .body(
             new ErrorResponse(
-                "AI service temporarily unavailable",
+                "KI-Dienst vorübergehend nicht verfügbar",
                 HttpStatus.SERVICE_UNAVAILABLE.value(),
                 Instant.now()));
   }
@@ -67,13 +67,15 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleNonTransientAiException(NonTransientAiException ex) {
     log.error("Non-transient AI service error: {}", errorSanitizer.sanitize(ex.getMessage()));
     return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
-        .body(new ErrorResponse("AI service error", HttpStatus.BAD_GATEWAY.value(), Instant.now()));
+        .body(
+            new ErrorResponse(
+                "Fehler im KI-Dienst", HttpStatus.BAD_GATEWAY.value(), Instant.now()));
   }
 
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
     return ResponseEntity.status(HttpStatus.FORBIDDEN)
-        .body(new ErrorResponse("Access denied", HttpStatus.FORBIDDEN.value(), Instant.now()));
+        .body(new ErrorResponse("Zugriff verweigert", HttpStatus.FORBIDDEN.value(), Instant.now()));
   }
 
   @ExceptionHandler(Exception.class)
@@ -82,6 +84,6 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(
             new ErrorResponse(
-                "Internal server error", HttpStatus.INTERNAL_SERVER_ERROR.value(), Instant.now()));
+                "Interner Serverfehler", HttpStatus.INTERNAL_SERVER_ERROR.value(), Instant.now()));
   }
 }

--- a/backend/src/main/java/io/opaa/api/IndexingController.java
+++ b/backend/src/main/java/io/opaa/api/IndexingController.java
@@ -68,23 +68,23 @@ public class IndexingController {
         .map(this::toResponse)
         .orElse(
             new IndexingStatusResponse(IndexingStatus.IDLE, 0, 0, 0, Instant.now())
-                .message("No indexing job found"));
+                .message("Kein Indizierungslauf gefunden"));
   }
 
   private IndexingStatusResponse toResponse(IndexingJob job) {
     IndexingStatus status = mapStatus(job.getStatus());
     String message =
         switch (job.getStatus()) {
-          case RUNNING -> "Indexing in progress";
+          case RUNNING -> "Indizierung läuft";
           case COMPLETED ->
-              "Indexing completed: "
+              "Indizierung abgeschlossen: "
                   + job.getDocumentsProcessed()
-                  + " processed, "
+                  + " verarbeitet, "
                   + job.getDocumentsSkipped()
-                  + " skipped, "
+                  + " übersprungen, "
                   + job.getDocumentsFailed()
-                  + " failed";
-          case FAILED -> "Indexing failed: " + job.getErrorMessage();
+                  + " fehlgeschlagen";
+          case FAILED -> "Indizierung fehlgeschlagen: " + job.getErrorMessage();
         };
     return new IndexingStatusResponse(
             status,

--- a/backend/src/main/java/io/opaa/api/WorkspaceController.java
+++ b/backend/src/main/java/io/opaa/api/WorkspaceController.java
@@ -148,6 +148,7 @@ public class WorkspaceController {
 
     return userService
         .findBySubjectAndIssuer(jwt.getSubject(), issuer)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
   }
 }

--- a/backend/src/main/java/io/opaa/auth/AuthController.java
+++ b/backend/src/main/java/io/opaa/auth/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(
               new ErrorResponse(
-                  "Invalid credentials", HttpStatus.UNAUTHORIZED.value(), Instant.now()));
+                  "Ungültige Anmeldedaten", HttpStatus.UNAUTHORIZED.value(), Instant.now()));
     }
 
     String token =

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -19,8 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @EnableConfigurationProperties(AuthProperties.class)
 public class UserService {
 
-  private static final String PERSONAL_WORKSPACE_NAME = "My Documents";
-  private static final String PERSONAL_WORKSPACE_DESCRIPTION = "Private personal workspace";
+  private static final String PERSONAL_WORKSPACE_NAME = "Meine Dokumente";
+  private static final String PERSONAL_WORKSPACE_DESCRIPTION = "Privater persönlicher Workspace";
 
   private final UserRepository userRepository;
   private final WorkspaceRepository workspaceRepository;
@@ -81,7 +81,7 @@ public class UserService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new UserNotFoundException("User not found: " + userId));
+            .orElseThrow(() -> new UserNotFoundException("Benutzer nicht gefunden: " + userId));
     user.setSystemRole(role);
     return userRepository.save(user);
   }

--- a/backend/src/main/java/io/opaa/indexing/DocumentIndexingService.java
+++ b/backend/src/main/java/io/opaa/indexing/DocumentIndexingService.java
@@ -29,7 +29,7 @@ public class DocumentIndexingService {
       throw new IndexingAlreadyRunningException("An indexing job is already running");
     }
     if (request.url() == null || request.url().isBlank()) {
-      throw new IllegalArgumentException("URL must not be blank");
+      throw new IllegalArgumentException("Die URL darf nicht leer sein");
     }
     var job = indexingJobService.startJob();
     urlIndexingExecutor.execute(job.getId(), request);

--- a/backend/src/main/java/io/opaa/query/QueryService.java
+++ b/backend/src/main/java/io/opaa/query/QueryService.java
@@ -218,7 +218,7 @@ public class QueryService {
       return UUID.randomUUID().toString();
     }
     if (!VALID_CONVERSATION_ID.matcher(conversationId).matches()) {
-      throw new IllegalArgumentException("Invalid conversationId format");
+      throw new IllegalArgumentException("Ungültiges Format der conversationId");
     }
     return conversationId;
   }

--- a/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
+++ b/backend/src/main/java/io/opaa/workspace/WorkspaceService.java
@@ -33,17 +33,18 @@ public class WorkspaceService {
       WorkspaceRequest request, UUID currentUserId, boolean systemAdmin) {
     if (!systemAdmin) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Only system admins can create workspaces");
+          HttpStatus.FORBIDDEN, "Nur Systemadministratoren können Workspaces erstellen");
     }
 
     UUID ownerId = request.getOwnerId();
     if (ownerId == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ownerId is required");
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ownerId ist erforderlich");
     }
 
     String normalizedName = request.getName().trim();
     if (workspaceRepository.existsByNameIgnoreCase(normalizedName)) {
-      throw new ResponseStatusException(HttpStatus.CONFLICT, "Workspace name already exists");
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "Ein Workspace mit diesem Namen existiert bereits");
     }
 
     Workspace workspace =
@@ -67,11 +68,12 @@ public class WorkspaceService {
         workspaceRepository
             .findByIdWithMemberships(workspaceId)
             .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace not found"));
+                () ->
+                    new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace nicht gefunden"));
 
     if (!systemAdmin && userMembership(workspace, currentUserId) == null) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "You are not a member of this workspace");
+          HttpStatus.FORBIDDEN, "Sie sind kein Mitglied dieses Workspace");
     }
 
     return toWorkspaceResponse(workspace, currentUserId);
@@ -101,13 +103,15 @@ public class WorkspaceService {
     rejectPersonalWorkspaceMemberChanges(workspace);
 
     if (userMembership(workspace, memberUserId) != null) {
-      throw new ResponseStatusException(HttpStatus.CONFLICT, "User is already a workspace member");
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "Der Benutzer ist bereits Mitglied dieses Workspace");
     }
 
     WorkspaceRole roleToAssign = requestedRole == null ? WorkspaceRole.VIEWER : requestedRole;
     if (roleToAssign == WorkspaceRole.OWNER) {
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Use transfer ownership endpoint to assign OWNER role");
+          HttpStatus.BAD_REQUEST,
+          "Die Rolle Eigentümer wird über die Eigentumsübertragung vergeben");
     }
     ensureCanManageRole(actor.getRole(), roleToAssign);
 
@@ -126,25 +130,27 @@ public class WorkspaceService {
     Workspace workspace = loadWorkspace(workspaceId);
     WorkspaceMembership actor = requireManager(workspace, currentUserId);
     if (newRole == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "role is required");
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "role ist erforderlich");
     }
 
     WorkspaceMembership target = userMembership(workspace, memberUserId);
     if (target == null) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace member not found");
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Mitglied des Workspace nicht gefunden");
     }
     if (target.getRole() == WorkspaceRole.OWNER) {
       if (actor.getRole() != WorkspaceRole.OWNER) {
         throw new ResponseStatusException(
-            HttpStatus.FORBIDDEN, "Only owners can manage owner role assignments");
+            HttpStatus.FORBIDDEN, "Nur Eigentümer können die Eigentümerrolle vergeben");
       }
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Owner role changes require ownership transfer");
+          HttpStatus.BAD_REQUEST,
+          "Änderungen an der Eigentümerrolle erfordern eine Eigentumsübertragung");
     }
     if (newRole == WorkspaceRole.OWNER) {
       if (actor.getRole() != WorkspaceRole.OWNER) {
         throw new ResponseStatusException(
-            HttpStatus.FORBIDDEN, "Only owners can promote members to OWNER");
+            HttpStatus.FORBIDDEN, "Nur Eigentümer können Mitglieder zum Eigentümer machen");
       }
       actor.setRole(WorkspaceRole.ADMIN);
       target.setRole(WorkspaceRole.OWNER);
@@ -169,11 +175,12 @@ public class WorkspaceService {
 
     WorkspaceMembership target = userMembership(workspace, memberUserId);
     if (target == null) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace member not found");
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Mitglied des Workspace nicht gefunden");
     }
     if (target.getRole() == WorkspaceRole.OWNER) {
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Workspace owner cannot be removed");
+          HttpStatus.BAD_REQUEST, "Der Eigentümer des Workspace kann nicht entfernt werden");
     }
 
     ensureCanManageRole(actor.getRole(), target.getRole());
@@ -187,13 +194,13 @@ public class WorkspaceService {
     WorkspaceMembership actor = userMembership(workspace, currentUserId);
     if (actor == null || actor.getRole() != WorkspaceRole.OWNER) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Only workspace owners can transfer ownership");
+          HttpStatus.FORBIDDEN, "Nur Eigentümer können das Eigentum übertragen");
     }
 
     WorkspaceMembership newOwnerMembership = userMembership(workspace, newOwnerUserId);
     if (newOwnerMembership == null) {
       throw new ResponseStatusException(
-          HttpStatus.NOT_FOUND, "Target user is not a workspace member");
+          HttpStatus.NOT_FOUND, "Der ausgewählte Benutzer ist kein Mitglied dieses Workspace");
     }
     if (newOwnerMembership.getRole() == WorkspaceRole.OWNER) {
       return;
@@ -211,7 +218,8 @@ public class WorkspaceService {
         workspaceRepository
             .findByIdWithMemberships(workspaceId)
             .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace not found"));
+                () ->
+                    new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace nicht gefunden"));
 
     WorkspaceMembership membership = userMembership(workspace, currentUserId);
     boolean adminOrOwner =
@@ -220,13 +228,15 @@ public class WorkspaceService {
                 || membership.getRole() == WorkspaceRole.OWNER);
     if (!systemAdmin && !adminOrOwner) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Only admins or owners can update a workspace");
+          HttpStatus.FORBIDDEN,
+          "Nur Administratoren oder Eigentümer können einen Workspace ändern");
     }
 
     String normalizedName = request.getName().trim();
     if (!workspace.getName().equalsIgnoreCase(normalizedName)
         && workspaceRepository.existsByNameIgnoreCase(normalizedName)) {
-      throw new ResponseStatusException(HttpStatus.CONFLICT, "Workspace name already exists");
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "Ein Workspace mit diesem Namen existiert bereits");
     }
 
     workspace.updateDetails(normalizedName, request.getDescription());
@@ -240,14 +250,15 @@ public class WorkspaceService {
 
     if (workspace.isPersonal()) {
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Personal workspaces cannot be deleted");
+          HttpStatus.BAD_REQUEST, "Persönliche Workspaces können nicht gelöscht werden");
     }
 
     WorkspaceMembership membership = userMembership(workspace, currentUserId);
     boolean owner = membership != null && membership.getRole() == WorkspaceRole.OWNER;
     if (!systemAdmin && !owner) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Only the owner or system admin can delete a workspace");
+          HttpStatus.FORBIDDEN,
+          "Nur der Eigentümer oder ein Systemadministrator kann einen Workspace löschen");
     }
 
     workspaceRepository.delete(workspace);
@@ -257,14 +268,14 @@ public class WorkspaceService {
     return workspaceRepository
         .findByIdWithMemberships(workspaceId)
         .orElseThrow(
-            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace not found"));
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Workspace nicht gefunden"));
   }
 
   private WorkspaceMembership requireMembership(Workspace workspace, UUID userId) {
     WorkspaceMembership membership = userMembership(workspace, userId);
     if (membership == null) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "You are not a member of this workspace");
+          HttpStatus.FORBIDDEN, "Sie sind kein Mitglied dieses Workspace");
     }
     return membership;
   }
@@ -274,7 +285,7 @@ public class WorkspaceService {
     if (membership.getRole() != WorkspaceRole.ADMIN
         && membership.getRole() != WorkspaceRole.OWNER) {
       throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Only admins or owners can manage workspace members");
+          HttpStatus.FORBIDDEN, "Nur Administratoren oder Eigentümer können Mitglieder verwalten");
     }
     return membership;
   }
@@ -282,7 +293,8 @@ public class WorkspaceService {
   private void rejectPersonalWorkspaceMemberChanges(Workspace workspace) {
     if (workspace.isPersonal()) {
       throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Members cannot be added to personal workspaces");
+          HttpStatus.BAD_REQUEST,
+          "Zu persönlichen Workspaces können keine Mitglieder hinzugefügt werden");
     }
   }
 
@@ -295,7 +307,7 @@ public class WorkspaceService {
       return;
     }
     throw new ResponseStatusException(
-        HttpStatus.FORBIDDEN, "Insufficient role permissions for this member change");
+        HttpStatus.FORBIDDEN, "Unzureichende Berechtigung für diese Änderung am Mitglied");
   }
 
   private int roleRank(WorkspaceRole role) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     name: opaa
   profiles:
     default: local
+  # Feste deutsche Locale, damit Bean-Validation-Meldungen in API-Antworten
+  # unabhängig vom Accept-Language-Header des Clients deutsch sind.
+  web:
+    locale: de_DE
+    locale-resolver: fixed
   autoconfigure:
     exclude:
       - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration

--- a/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
@@ -19,7 +19,7 @@ class GlobalExceptionHandlerTest {
     ErrorResponse body = response.getBody();
     assertNotNull(body);
     assertEquals(500, body.getStatus());
-    assertEquals("Internal server error", body.getError());
+    assertEquals("Interner Serverfehler", body.getError());
     assertNotNull(body.getTimestamp());
   }
 
@@ -29,7 +29,7 @@ class GlobalExceptionHandlerTest {
     assertEquals(503, response.getStatusCode().value());
     ErrorResponse body = response.getBody();
     assertNotNull(body);
-    assertEquals("AI service temporarily unavailable", body.getError());
+    assertEquals("KI-Dienst vorübergehend nicht verfügbar", body.getError());
   }
 
   @Test
@@ -39,7 +39,7 @@ class GlobalExceptionHandlerTest {
     assertEquals(502, response.getStatusCode().value());
     ErrorResponse body = response.getBody();
     assertNotNull(body);
-    assertEquals("AI service error", body.getError());
+    assertEquals("Fehler im KI-Dienst", body.getError());
   }
 
   @Test
@@ -51,7 +51,7 @@ class GlobalExceptionHandlerTest {
     assertEquals(502, response.getStatusCode().value());
     ErrorResponse body = response.getBody();
     assertNotNull(body);
-    assertEquals("AI service error", body.getError());
+    assertEquals("Fehler im KI-Dienst", body.getError());
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/IndexingControllerTest.java
@@ -74,7 +74,7 @@ class IndexingControllerTest {
         .andExpect(jsonPath("$.status").value("IDLE"))
         .andExpect(jsonPath("$.totalDocuments").value(0))
         .andExpect(jsonPath("$.documentsSkipped").value(0))
-        .andExpect(jsonPath("$.message").value("No indexing job found"));
+        .andExpect(jsonPath("$.message").value("Kein Indizierungslauf gefunden"));
   }
 
   @Test
@@ -106,7 +106,7 @@ class IndexingControllerTest {
         .andExpect(jsonPath("$.status").value("COMPLETED"))
         .andExpect(jsonPath("$.documentCount").value(10))
         .andExpect(jsonPath("$.documentsSkipped").value(5))
-        .andExpect(jsonPath("$.message").value(containsString("5 skipped")));
+        .andExpect(jsonPath("$.message").value(containsString("5 übersprungen")));
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/api/QueryControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/QueryControllerTest.java
@@ -106,7 +106,7 @@ class QueryControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"What?\"}"))
         .andExpect(status().isServiceUnavailable())
-        .andExpect(jsonPath("$.error").value("AI service temporarily unavailable"))
+        .andExpect(jsonPath("$.error").value("KI-Dienst vorübergehend nicht verfügbar"))
         .andExpect(jsonPath("$.status").value(503));
   }
 
@@ -121,7 +121,7 @@ class QueryControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"What?\"}"))
         .andExpect(status().isBadGateway())
-        .andExpect(jsonPath("$.error").value("AI service error"))
+        .andExpect(jsonPath("$.error").value("Fehler im KI-Dienst"))
         .andExpect(jsonPath("$.status").value(502));
   }
 

--- a/backend/src/test/java/io/opaa/auth/AdminControllerTest.java
+++ b/backend/src/test/java/io/opaa/auth/AdminControllerTest.java
@@ -81,7 +81,7 @@ class AdminControllerTest {
   void changeRoleForNonexistentUserReturns404() throws Exception {
     UUID userId = UUID.randomUUID();
     when(userService.updateRole(userId, SystemRole.SYSTEM_ADMIN))
-        .thenThrow(new UserNotFoundException("User not found: " + userId));
+        .thenThrow(new UserNotFoundException("Benutzer nicht gefunden: " + userId));
 
     mockMvc
         .perform(

--- a/backend/src/test/java/io/opaa/auth/AuthControllerTest.java
+++ b/backend/src/test/java/io/opaa/auth/AuthControllerTest.java
@@ -69,7 +69,7 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"username\": \"admin\", \"password\": \"wrong\"}"))
         .andExpect(status().isUnauthorized())
-        .andExpect(jsonPath("$.error").value("Invalid credentials"))
+        .andExpect(jsonPath("$.error").value("Ungültige Anmeldedaten"))
         .andExpect(jsonPath("$.status").value(401))
         .andExpect(jsonPath("$.timestamp").isNotEmpty());
   }

--- a/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
@@ -140,6 +140,6 @@ class QueryIntegrationTest {
   void queryRejectsInvalidConversationId() {
     assertThatThrownBy(() -> queryService.query("Test question", "<script>alert(1)</script>"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid conversationId format");
+        .hasMessage("Ungültiges Format der conversationId");
   }
 }

--- a/backend/src/test/java/io/opaa/query/QueryServiceTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryServiceTest.java
@@ -353,7 +353,7 @@ class QueryServiceTest {
     String tooLong = "a".repeat(51);
     assertThatThrownBy(() -> queryService.validateConversationId(tooLong))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid conversationId format");
+        .hasMessage("Ungültiges Format der conversationId");
   }
 
   @Test

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -26,7 +26,7 @@ describe('App', () => {
   it('redirects to chat page by default', async () => {
     render(<App />)
     await waitFor(() => {
-      expect(screen.getByText('How can I help you today?')).toBeInTheDocument()
+      expect(screen.getByText('Womit kann ich Ihnen heute helfen?')).toBeInTheDocument()
     })
   })
 
@@ -35,7 +35,7 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('Workspaces')).toBeInTheDocument()
       expect(screen.getByText('Chats')).toBeInTheDocument()
-      expect(screen.getByText('Settings')).toBeInTheDocument()
+      expect(screen.getByText('Einstellungen')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/components/CreateWorkspaceDialog.test.tsx
@@ -47,14 +47,14 @@ describe('CreateWorkspaceDialog', () => {
       <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
     )
     expect(screen.getByLabelText(/name/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/beschreibung/i)).toBeInTheDocument()
   })
 
   it('disables create button when name is empty', () => {
     renderWithProviders(
       <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
     )
-    expect(screen.getByRole('button', { name: /create/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /erstellen/i })).toBeDisabled()
   })
 
   it('calls onCreated with workspace id after submit', async () => {
@@ -64,7 +64,7 @@ describe('CreateWorkspaceDialog', () => {
     )
 
     await user.type(screen.getByLabelText(/name/i), 'My New Workspace')
-    await user.click(screen.getByRole('button', { name: /create/i }))
+    await user.click(screen.getByRole('button', { name: /erstellen/i }))
 
     await waitFor(() => {
       expect(onCreated).toHaveBeenCalledWith('ws-new')
@@ -77,7 +77,7 @@ describe('CreateWorkspaceDialog', () => {
       <CreateWorkspaceDialog open={true} onClose={onClose} onCreated={onCreated} />,
     )
 
-    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    await user.click(screen.getByRole('button', { name: /abbrechen/i }))
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/CreateWorkspaceDialog.tsx
+++ b/frontend/src/components/CreateWorkspaceDialog.tsx
@@ -34,7 +34,7 @@ export default function CreateWorkspaceDialog({
   async function handleCreate() {
     const trimmedName = name.trim()
     if (!trimmedName) {
-      setError('Name is required')
+      setError('Name ist erforderlich')
       return
     }
     setError(null)
@@ -48,7 +48,7 @@ export default function CreateWorkspaceDialog({
       setDescription('')
       onCreated(workspaceId)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create workspace')
+      setError(err instanceof Error ? err.message : 'Workspace konnte nicht erstellt werden')
     } finally {
       setSubmitting(false)
     }
@@ -56,7 +56,7 @@ export default function CreateWorkspaceDialog({
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Create Workspace</DialogTitle>
+      <DialogTitle>Workspace erstellen</DialogTitle>
       <DialogContent>
         {error && (
           <Alert severity="error" sx={{ mb: 2 }}>
@@ -74,7 +74,7 @@ export default function CreateWorkspaceDialog({
           sx={{ mt: 1 }}
         />
         <TextField
-          label="Description"
+          label="Beschreibung"
           fullWidth
           multiline
           minRows={2}
@@ -86,10 +86,10 @@ export default function CreateWorkspaceDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={submitting}>
-          Cancel
+          Abbrechen
         </Button>
         <Button onClick={handleCreate} variant="contained" disabled={submitting || !name.trim()}>
-          {submitting ? 'Creating...' : 'Create'}
+          {submitting ? 'Wird erstellt …' : 'Erstellen'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -28,12 +28,12 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
 
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('Etwas ist schiefgelaufen')).toBeInTheDocument()
     expect(
-      screen.getByText('An unexpected error occurred. Please try reloading the page.'),
+      screen.getByText('Ein unerwarteter Fehler ist aufgetreten. Bitte laden Sie die Seite neu.'),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Show Details' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Neu laden' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Details anzeigen' })).toBeInTheDocument()
   })
 
   it('shows error details when "Show Details" is clicked', async () => {
@@ -46,10 +46,10 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Show Details' }))
+    await user.click(screen.getByRole('button', { name: 'Details anzeigen' }))
 
     expect(screen.getByText('Something broke')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Hide Details' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Details ausblenden' })).toBeInTheDocument()
   })
 
   it('hides error details when "Hide Details" is clicked', async () => {
@@ -62,11 +62,11 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Show Details' }))
-    expect(screen.getByRole('button', { name: 'Hide Details' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Details anzeigen' }))
+    expect(screen.getByRole('button', { name: 'Details ausblenden' })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Hide Details' }))
-    expect(screen.getByRole('button', { name: 'Show Details' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Details ausblenden' }))
+    expect(screen.getByRole('button', { name: 'Details anzeigen' })).toBeInTheDocument()
   })
 
   it('logs the error to console', () => {

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -46,19 +46,19 @@ export default class ErrorBoundary extends Component<Props, State> {
           }}
         >
           <ErrorOutlineIcon sx={{ fontSize: 64 }} color="error" />
-          <Typography variant="h5">Something went wrong</Typography>
+          <Typography variant="h5">Etwas ist schiefgelaufen</Typography>
           <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center' }}>
-            An unexpected error occurred. Please try reloading the page.
+            Ein unerwarteter Fehler ist aufgetreten. Bitte laden Sie die Seite neu.
           </Typography>
           <Box sx={{ display: 'flex', gap: 2 }}>
             <Button variant="contained" onClick={() => window.location.reload()}>
-              Reload
+              Neu laden
             </Button>
             <Button
               variant="outlined"
               onClick={() => this.setState((prev) => ({ showDetails: !prev.showDetails }))}
             >
-              {showDetails ? 'Hide Details' : 'Show Details'}
+              {showDetails ? 'Details ausblenden' : 'Details anzeigen'}
             </Button>
           </Box>
           <Collapse in={showDetails}>

--- a/frontend/src/components/admin/AdminDrawer.test.tsx
+++ b/frontend/src/components/admin/AdminDrawer.test.tsx
@@ -24,20 +24,20 @@ describe('AdminDrawer', () => {
     renderWithProviders(<AdminDrawer />)
 
     expect(screen.getByText('Admin')).toBeInTheDocument()
-    expect(screen.getByText('Index Documents')).toBeInTheDocument()
+    expect(screen.getByText('Dokumente indizieren')).toBeInTheDocument()
   })
 
   it('shows close button', () => {
     renderWithProviders(<AdminDrawer />)
 
-    expect(screen.getByLabelText('Close admin drawer')).toBeInTheDocument()
+    expect(screen.getByLabelText('Admin-Bereich schließen')).toBeInTheDocument()
   })
 
   it('closes drawer on close button click', async () => {
     const user = userEvent.setup()
     renderWithProviders(<AdminDrawer />)
 
-    await user.click(screen.getByLabelText('Close admin drawer'))
+    await user.click(screen.getByLabelText('Admin-Bereich schließen'))
     expect(useIndexingStore.getState().drawerOpen).toBe(false)
   })
 
@@ -45,19 +45,19 @@ describe('AdminDrawer', () => {
     const user = userEvent.setup()
     renderWithProviders(<AdminDrawer />)
 
-    await user.click(screen.getByText('URL Source (optional)'))
+    await user.click(screen.getByText('URL-Quelle (optional)'))
 
     expect(screen.getByLabelText('URL')).toBeInTheDocument()
     expect(screen.getByLabelText('Proxy')).toBeInTheDocument()
-    expect(screen.getByLabelText('Credentials')).toBeInTheDocument()
-    expect(screen.getByRole('switch', { name: 'Skip SSL verification' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Anmeldedaten')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'SSL-Prüfung überspringen' })).toBeInTheDocument()
   })
 
   it('disables button when indexing is running', () => {
     useIndexingStore.setState({ status: 'RUNNING' })
     renderWithProviders(<AdminDrawer />)
 
-    expect(screen.getByRole('button', { name: /indexing/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /indizierung läuft/i })).toBeDisabled()
   })
 
   it('shows indeterminate progress when total is unknown', () => {
@@ -69,7 +69,7 @@ describe('AdminDrawer', () => {
     renderWithProviders(<AdminDrawer />)
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
-    expect(screen.getByText(/discovering documents/i)).toBeInTheDocument()
+    expect(screen.getByText(/dokumente werden ermittelt/i)).toBeInTheDocument()
   })
 
   it('shows determinate progress with document counts', () => {
@@ -84,7 +84,7 @@ describe('AdminDrawer', () => {
     const progressbar = screen.getByRole('progressbar')
     expect(progressbar).toBeInTheDocument()
     expect(progressbar).toHaveAttribute('aria-valuenow', '24')
-    expect(screen.getByText(/10 of 42 documents processed/i)).toBeInTheDocument()
+    expect(screen.getByText(/10 von 42 dokumenten verarbeitet/i)).toBeInTheDocument()
   })
 
   it('shows last indexing info when completed', () => {
@@ -97,8 +97,8 @@ describe('AdminDrawer', () => {
     })
     renderWithProviders(<AdminDrawer />)
 
-    expect(screen.getByText(/completed/i)).toBeInTheDocument()
-    expect(screen.getByText(/documents: 42 processed/i)).toBeInTheDocument()
+    expect(screen.getByText(/abgeschlossen/i)).toBeInTheDocument()
+    expect(screen.getByText(/dokumente: 42 verarbeitet/i)).toBeInTheDocument()
   })
 
   it('shows skipped count when documents were skipped', () => {
@@ -111,7 +111,7 @@ describe('AdminDrawer', () => {
     })
     renderWithProviders(<AdminDrawer />)
 
-    expect(screen.getByText(/10 skipped/i)).toBeInTheDocument()
+    expect(screen.getByText(/10 übersprungen/i)).toBeInTheDocument()
   })
 
   it('does not show skipped text when zero skipped', () => {
@@ -124,7 +124,7 @@ describe('AdminDrawer', () => {
     })
     renderWithProviders(<AdminDrawer />)
 
-    expect(screen.queryByText(/skipped/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/übersprungen/i)).not.toBeInTheDocument()
   })
 
   it('does not render content when drawer is closed', () => {

--- a/frontend/src/components/admin/AdminDrawer.tsx
+++ b/frontend/src/components/admin/AdminDrawer.tsx
@@ -72,7 +72,7 @@ export default function AdminDrawer() {
           <Typography variant="h6" sx={{ fontWeight: 700 }}>
             Admin
           </Typography>
-          <IconButton onClick={() => setDrawerOpen(false)} aria-label="Close admin drawer">
+          <IconButton onClick={() => setDrawerOpen(false)} aria-label="Admin-Bereich schließen">
             <CloseIcon />
           </IconButton>
         </Box>
@@ -81,7 +81,7 @@ export default function AdminDrawer() {
 
         <Box sx={{ p: 2 }}>
           <Typography variant="overline" color="text.secondary">
-            Document Indexing
+            Dokumentenindizierung
           </Typography>
 
           <Accordion
@@ -97,7 +97,7 @@ export default function AdminDrawer() {
             }}
           >
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="body2">URL Source (optional)</Typography>
+              <Typography variant="body2">URL-Quelle (optional)</Typography>
             </AccordionSummary>
             <AccordionDetails sx={{ pt: 0 }}>
               <TextField
@@ -121,14 +121,14 @@ export default function AdminDrawer() {
                 slotProps={{ htmlInput: { 'aria-label': 'Proxy' } }}
               />
               <TextField
-                label="Credentials (user:password)"
+                label="Anmeldedaten (Benutzer:Passwort)"
                 type="password"
                 value={credentials}
                 onChange={(e) => setCredentials(e.target.value)}
                 size="small"
                 fullWidth
                 sx={{ mb: 1 }}
-                slotProps={{ htmlInput: { 'aria-label': 'Credentials' } }}
+                slotProps={{ htmlInput: { 'aria-label': 'Anmeldedaten' } }}
               />
               <FormControlLabel
                 control={
@@ -136,12 +136,12 @@ export default function AdminDrawer() {
                     checked={insecureSsl}
                     onChange={(e) => setInsecureSsl(e.target.checked)}
                     size="small"
-                    slotProps={{ input: { 'aria-label': 'Skip SSL verification' } }}
+                    slotProps={{ input: { 'aria-label': 'SSL-Prüfung überspringen' } }}
                   />
                 }
                 label={
                   <Typography variant="body2" color="text.secondary">
-                    Skip SSL verification
+                    SSL-Prüfung überspringen
                   </Typography>
                 }
               />
@@ -156,7 +156,7 @@ export default function AdminDrawer() {
             fullWidth
             sx={{ mt: 1, mb: 2 }}
           >
-            {isRunning ? 'Indexing...' : 'Index Documents'}
+            {isRunning ? 'Indizierung läuft …' : 'Dokumente indizieren'}
           </Button>
 
           {isRunning && (
@@ -168,8 +168,8 @@ export default function AdminDrawer() {
               />
               <Typography variant="body2" color="text.secondary">
                 {totalDocuments > 0
-                  ? `${documentCount + documentsSkipped} of ${totalDocuments} documents processed`
-                  : 'Discovering documents...'}
+                  ? `${documentCount + documentsSkipped} von ${totalDocuments} Dokumenten verarbeitet`
+                  : 'Dokumente werden ermittelt …'}
               </Typography>
             </Box>
           )}
@@ -177,15 +177,15 @@ export default function AdminDrawer() {
           {status !== 'IDLE' && !isRunning && (
             <Box sx={{ mt: 1 }}>
               <Typography variant="body2" color="text.secondary" gutterBottom>
-                Last indexing: {status === 'COMPLETED' ? 'Completed' : 'Failed'}
+                Letzte Indizierung: {status === 'COMPLETED' ? 'Abgeschlossen' : 'Fehlgeschlagen'}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Documents: {documentCount} processed
-                {documentsSkipped > 0 && ` (${documentsSkipped} skipped)`}
+                Dokumente: {documentCount} verarbeitet
+                {documentsSkipped > 0 && ` (${documentsSkipped} übersprungen)`}
               </Typography>
               {timestamp && (
                 <Typography variant="caption" color="text.secondary">
-                  {new Date(timestamp).toLocaleString()}
+                  {new Date(timestamp).toLocaleString('de-DE')}
                 </Typography>
               )}
             </Box>

--- a/frontend/src/components/admin/AdminDrawerToggle.test.tsx
+++ b/frontend/src/components/admin/AdminDrawerToggle.test.tsx
@@ -13,17 +13,17 @@ describe('AdminDrawerToggle', () => {
   it('renders toggle button', () => {
     renderWithProviders(<AdminDrawerToggle />)
 
-    expect(screen.getByLabelText('Toggle admin drawer')).toBeInTheDocument()
+    expect(screen.getByLabelText('Admin-Bereich ein- oder ausblenden')).toBeInTheDocument()
   })
 
   it('toggles drawer on click', async () => {
     const user = userEvent.setup()
     renderWithProviders(<AdminDrawerToggle />)
 
-    await user.click(screen.getByLabelText('Toggle admin drawer'))
+    await user.click(screen.getByLabelText('Admin-Bereich ein- oder ausblenden'))
     expect(useIndexingStore.getState().drawerOpen).toBe(true)
 
-    await user.click(screen.getByLabelText('Toggle admin drawer'))
+    await user.click(screen.getByLabelText('Admin-Bereich ein- oder ausblenden'))
     expect(useIndexingStore.getState().drawerOpen).toBe(false)
   })
 })

--- a/frontend/src/components/admin/AdminDrawerToggle.tsx
+++ b/frontend/src/components/admin/AdminDrawerToggle.tsx
@@ -6,7 +6,11 @@ export default function AdminDrawerToggle() {
   const toggleDrawer = useIndexingStore((s) => s.toggleDrawer)
 
   return (
-    <IconButton onClick={toggleDrawer} aria-label="Toggle admin drawer" sx={{ ml: 'auto' }}>
+    <IconButton
+      onClick={toggleDrawer}
+      aria-label="Admin-Bereich ein- oder ausblenden"
+      sx={{ ml: 'auto' }}
+    >
       <AdminPanelSettingsIcon />
     </IconButton>
   )

--- a/frontend/src/components/admin/IndexingSnackbar.test.tsx
+++ b/frontend/src/components/admin/IndexingSnackbar.test.tsx
@@ -29,11 +29,11 @@ describe('IndexingSnackbar', () => {
 
   it('shows error snackbar', () => {
     useIndexingStore.setState({
-      snackbar: { open: true, message: 'Indexing failed', severity: 'error' },
+      snackbar: { open: true, message: 'Indizierung fehlgeschlagen', severity: 'error' },
     })
     renderWithProviders(<IndexingSnackbar />)
 
     expect(screen.getByRole('alert')).toBeInTheDocument()
-    expect(screen.getByText('Indexing failed')).toBeInTheDocument()
+    expect(screen.getByText('Indizierung fehlgeschlagen')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -5,18 +5,18 @@ import ChatInput from './ChatInput'
 describe('ChatInput', () => {
   it('renders input field and send button', () => {
     render(<ChatInput onSend={vi.fn()} />)
-    expect(screen.getByPlaceholderText('Ask a question...')).toBeInTheDocument()
-    expect(screen.getByLabelText('send message')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /search scope/i })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Stellen Sie eine Frage …')).toBeInTheDocument()
+    expect(screen.getByLabelText('Nachricht senden')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /suchbereich/i })).toBeInTheDocument()
   })
 
   it('calls onSend with trimmed text on button click', () => {
     const onSend = vi.fn()
     render(<ChatInput onSend={onSend} />)
 
-    const input = screen.getByPlaceholderText('Ask a question...')
+    const input = screen.getByPlaceholderText('Stellen Sie eine Frage …')
     fireEvent.change(input, { target: { value: 'Hello world' } })
-    fireEvent.click(screen.getByLabelText('send message'))
+    fireEvent.click(screen.getByLabelText('Nachricht senden'))
 
     expect(onSend).toHaveBeenCalledWith('Hello world')
   })
@@ -25,7 +25,7 @@ describe('ChatInput', () => {
     const onSend = vi.fn()
     render(<ChatInput onSend={onSend} />)
 
-    const input = screen.getByPlaceholderText('Ask a question...')
+    const input = screen.getByPlaceholderText('Stellen Sie eine Frage …')
     fireEvent.change(input, { target: { value: 'Test' } })
     fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
 
@@ -36,7 +36,7 @@ describe('ChatInput', () => {
     const onSend = vi.fn()
     render(<ChatInput onSend={onSend} />)
 
-    const input = screen.getByPlaceholderText('Ask a question...')
+    const input = screen.getByPlaceholderText('Stellen Sie eine Frage …')
     fireEvent.change(input, { target: { value: 'Test' } })
     fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
 
@@ -47,7 +47,7 @@ describe('ChatInput', () => {
     const onSend = vi.fn()
     render(<ChatInput onSend={onSend} />)
 
-    const input = screen.getByPlaceholderText('Ask a question...')
+    const input = screen.getByPlaceholderText('Stellen Sie eine Frage …')
     fireEvent.change(input, { target: { value: '   ' } })
     fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
 
@@ -56,6 +56,6 @@ describe('ChatInput', () => {
 
   it('disables input when disabled prop is true', () => {
     render(<ChatInput onSend={vi.fn()} disabled />)
-    expect(screen.getByPlaceholderText('Ask a question...')).toBeDisabled()
+    expect(screen.getByPlaceholderText('Stellen Sie eine Frage …')).toBeDisabled()
   })
 })

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -12,6 +12,7 @@ import FilterListIcon from '@mui/icons-material/FilterList'
 import SendIcon from '@mui/icons-material/Send'
 import { CHAT_MAX_WIDTH } from '../../theme/theme'
 import type { WorkspaceListResponse } from '../../types/api'
+import { workspaceRoleLabel } from '../../utils/labels'
 
 interface ChatInputProps {
   onSend: (message: string) => void
@@ -46,7 +47,7 @@ export default function ChatInput({
   )
 
   const filterSummary =
-    selectedWorkspaces.length === 0 ? 'All Workspaces' : `${selectedWorkspaces.length} selected`
+    selectedWorkspaces.length === 0 ? 'Alle Workspaces' : `${selectedWorkspaces.length} ausgewählt`
 
   const handleSend = () => {
     const trimmed = value.trim()
@@ -90,7 +91,7 @@ export default function ChatInput({
           fullWidth
           multiline
           maxRows={6}
-          placeholder="Ask a question..."
+          placeholder="Stellen Sie eine Frage …"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -116,7 +117,7 @@ export default function ChatInput({
           color="primary"
           onClick={handleSend}
           disabled={disabled || !value.trim()}
-          aria-label="send message"
+          aria-label="Nachricht senden"
           sx={{
             bgcolor: 'primary.main',
             color: 'white',
@@ -146,10 +147,10 @@ export default function ChatInput({
           disabled={disabled}
           sx={{ textTransform: 'none' }}
         >
-          Search scope: {filterSummary}
+          Suchbereich: {filterSummary}
         </Button>
         <Typography variant="caption" color="text.secondary">
-          Enter to send, Shift+Enter for new line
+          Enter zum Senden, Umschalt+Enter für eine neue Zeile
         </Typography>
       </Box>
 
@@ -176,20 +177,20 @@ export default function ChatInput({
                   <Box>
                     <Typography variant="body2">{option.name}</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      {option.userRole}
+                      {workspaceRoleLabel(option.userRole)}
                     </Typography>
                   </Box>
                 </li>
               )
             }}
-            renderInput={(params) => <TextField {...params} label="Select workspaces" />}
+            renderInput={(params) => <TextField {...params} label="Workspaces auswählen" />}
           />
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 1.5 }}>
             <Button size="small" onClick={() => onWorkspaceFilterChange?.([])}>
-              Clear
+              Zurücksetzen
             </Button>
             <Button size="small" variant="contained" onClick={handleCloseFilter}>
-              Done
+              Fertig
             </Button>
           </Box>
         </Box>

--- a/frontend/src/components/chat/DateSeparator.tsx
+++ b/frontend/src/components/chat/DateSeparator.tsx
@@ -6,7 +6,7 @@ interface DateSeparatorProps {
 }
 
 export default function DateSeparator({ date }: DateSeparatorProps) {
-  const label = date.toLocaleDateString(undefined, {
+  const label = date.toLocaleDateString('de-DE', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',

--- a/frontend/src/components/chat/FeedbackButtons.test.tsx
+++ b/frontend/src/components/chat/FeedbackButtons.test.tsx
@@ -6,14 +6,14 @@ import FeedbackButtons from './FeedbackButtons'
 describe('FeedbackButtons', () => {
   it('renders thumbs up and down buttons', () => {
     render(<FeedbackButtons />)
-    expect(screen.getByLabelText('thumbs up')).toBeInTheDocument()
-    expect(screen.getByLabelText('thumbs down')).toBeInTheDocument()
+    expect(screen.getByLabelText('Daumen hoch')).toBeInTheDocument()
+    expect(screen.getByLabelText('Daumen runter')).toBeInTheDocument()
   })
 
   it('toggles thumbs up on click', async () => {
     const user = userEvent.setup()
     render(<FeedbackButtons />)
-    const button = screen.getByLabelText('thumbs up')
+    const button = screen.getByLabelText('Daumen hoch')
 
     // Initially no primary color
     expect(button).not.toHaveClass('MuiIconButton-colorPrimary')

--- a/frontend/src/components/chat/FeedbackButtons.tsx
+++ b/frontend/src/components/chat/FeedbackButtons.tsx
@@ -19,10 +19,10 @@ export default function FeedbackButtons() {
 
   return (
     <Box sx={{ display: 'flex', gap: 0.5 }}>
-      <Tooltip title="Feedback coming soon">
+      <Tooltip title="Feedback folgt in Kürze">
         <IconButton
           size="small"
-          aria-label="thumbs up"
+          aria-label="Daumen hoch"
           onClick={() => handleFeedback('up')}
           color={feedback === 'up' ? 'primary' : 'default'}
         >
@@ -33,10 +33,10 @@ export default function FeedbackButtons() {
           )}
         </IconButton>
       </Tooltip>
-      <Tooltip title="Feedback coming soon">
+      <Tooltip title="Feedback folgt in Kürze">
         <IconButton
           size="small"
-          aria-label="thumbs down"
+          aria-label="Daumen runter"
           onClick={() => handleFeedback('down')}
           color={feedback === 'down' ? 'error' : 'default'}
         >

--- a/frontend/src/components/chat/MessageBubble.test.tsx
+++ b/frontend/src/components/chat/MessageBubble.test.tsx
@@ -42,7 +42,7 @@ describe('MessageBubble', () => {
     }
     render(<MessageBubble message={msg} />)
     expect(screen.getByText('Here is the answer')).toBeInTheDocument()
-    expect(screen.getByLabelText('thumbs up')).toBeInTheDocument()
+    expect(screen.getByLabelText('Daumen hoch')).toBeInTheDocument()
   })
 
   it('renders assistant message with markdown', () => {

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -93,7 +93,9 @@ export default function MessageBubble({ message }: MessageBubbleProps) {
                 </Typography>
                 <IconButton
                   size="small"
-                  aria-label={uncitedOpen ? 'collapse uncited sources' : 'expand uncited sources'}
+                  aria-label={
+                    uncitedOpen ? 'Weitere Quellen einklappen' : 'Weitere Quellen ausklappen'
+                  }
                   sx={{
                     ml: 0.5,
                     transform: uncitedOpen ? 'rotate(180deg)' : 'rotate(0deg)',

--- a/frontend/src/components/chat/MessageList.test.tsx
+++ b/frontend/src/components/chat/MessageList.test.tsx
@@ -6,7 +6,7 @@ import type { ChatMessage } from '../../types/chat'
 describe('MessageList', () => {
   it('renders empty state when no messages', () => {
     render(<MessageList messages={[]} isLoading={false} />)
-    expect(screen.getByText('How can I help you today?')).toBeInTheDocument()
+    expect(screen.getByText('Womit kann ich Ihnen heute helfen?')).toBeInTheDocument()
   })
 
   it('renders messages', () => {
@@ -21,6 +21,6 @@ describe('MessageList', () => {
 
   it('shows loading indicator', () => {
     render(<MessageList messages={[]} isLoading={true} />)
-    expect(screen.getByText('Thinking...')).toBeInTheDocument()
+    expect(screen.getByText('Denkt nach …')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -43,8 +43,8 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
         }}
       >
         <SmartToyIcon sx={{ fontSize: 48 }} />
-        <Typography variant="h6">How can I help you today?</Typography>
-        <Typography variant="body2">Ask a question about your project documents.</Typography>
+        <Typography variant="h6">Womit kann ich Ihnen heute helfen?</Typography>
+        <Typography variant="body2">Stellen Sie eine Frage zu Ihren Projektdokumenten.</Typography>
       </Box>
     )
   }
@@ -63,7 +63,7 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 2, mb: 2 }}>
             <CircularProgress size={20} />
             <Typography variant="body2" color="text.secondary">
-              Thinking...
+              Denkt nach …
             </Typography>
           </Box>
         )}

--- a/frontend/src/components/chat/SourceCard.test.tsx
+++ b/frontend/src/components/chat/SourceCard.test.tsx
@@ -35,24 +35,26 @@ describe('SourceCard', () => {
 
   it('shows Public badge for .md files', () => {
     render(<SourceCard source={baseSource} />)
-    expect(screen.getByText('Public')).toBeInTheDocument()
+    expect(screen.getByText('Öffentlich')).toBeInTheDocument()
   })
 
   it('shows Confidential badge for .pdf files', () => {
     render(<SourceCard source={{ ...baseSource, fileName: 'report.pdf' }} />)
-    expect(screen.getByText('Confidential')).toBeInTheDocument()
+    expect(screen.getByText('Vertraulich')).toBeInTheDocument()
   })
 
   it('shows Internal badge for other files', () => {
     render(<SourceCard source={{ ...baseSource, fileName: 'config.yaml' }} />)
-    expect(screen.getByText('Internal')).toBeInTheDocument()
+    expect(screen.getByText('Intern')).toBeInTheDocument()
   })
 
   it('shows tooltip on access level badge hover', async () => {
     const user = userEvent.setup()
     render(<SourceCard source={{ ...baseSource, fileName: 'config.yaml' }} />)
-    await user.hover(screen.getByText('Internal'))
-    expect(await screen.findByText('Access levels coming in a future release')).toBeInTheDocument()
+    await user.hover(screen.getByText('Intern'))
+    expect(
+      await screen.findByText('Zugriffsstufen folgen in einer künftigen Version'),
+    ).toBeInTheDocument()
   })
 
   it('renders cited source with full opacity', () => {

--- a/frontend/src/components/chat/SourceCard.tsx
+++ b/frontend/src/components/chat/SourceCard.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography'
 import type { SourceReference } from '../../types/api'
 import type { AccessLevel } from '../../types/chat'
 import { deriveAccessLevel } from '../../utils/accessLevel'
+import { accessLevelLabel } from '../../utils/labels'
 
 const accessLevelColors: Record<AccessLevel, 'error' | 'warning' | 'success'> = {
   Confidential: 'error',
@@ -45,9 +46,9 @@ export default function SourceCard({ source }: SourceCardProps) {
             {source.fileName}
           </Typography>
         </Tooltip>
-        <Tooltip title="Access levels coming in a future release">
+        <Tooltip title="Zugriffsstufen folgen in einer künftigen Version">
           <Chip
-            label={accessLevel}
+            label={accessLevelLabel(accessLevel)}
             size="small"
             color={accessLevelColors[accessLevel]}
             sx={{ height: 20, fontSize: '0.7rem' }}
@@ -67,7 +68,7 @@ export default function SourceCard({ source }: SourceCardProps) {
           {relevancePercent}% relevant
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          {source.matchCount} {source.matchCount === 1 ? 'Treffer' : 'Treffer'}
+          {source.matchCount} Treffer
         </Typography>
       </Box>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>

--- a/frontend/src/layouts/AppShell.test.tsx
+++ b/frontend/src/layouts/AppShell.test.tsx
@@ -8,7 +8,7 @@ describe('AppShell', () => {
     renderWithProviders(<AppShell />, { withRouter: true, initialRoute: '/chat' })
     expect(screen.getByText('Workspaces')).toBeInTheDocument()
     expect(screen.getByText('Chats')).toBeInTheDocument()
-    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByText('Einstellungen')).toBeInTheDocument()
   })
 
   it('renders OPAA branding', () => {

--- a/frontend/src/layouts/MobileHeader.tsx
+++ b/frontend/src/layouts/MobileHeader.tsx
@@ -22,7 +22,7 @@ export default function MobileHeader() {
       }}
     >
       <Toolbar>
-        <IconButton edge="start" color="inherit" aria-label="open menu" onClick={toggleSidebar}>
+        <IconButton edge="start" color="inherit" aria-label="Menü öffnen" onClick={toggleSidebar}>
           <MenuIcon />
         </IconButton>
         <Typography variant="h6" sx={{ fontWeight: 700, ml: 1 }}>

--- a/frontend/src/layouts/Sidebar.test.tsx
+++ b/frontend/src/layouts/Sidebar.test.tsx
@@ -13,7 +13,7 @@ describe('Sidebar', () => {
       workspaces: [
         {
           id: 'ws-personal',
-          name: 'My Documents',
+          name: 'Meine Dokumente',
           description: 'Private',
           type: 'PERSONAL',
           memberCount: 1,
@@ -30,19 +30,19 @@ describe('Sidebar', () => {
     renderWithProviders(<Sidebar />, { withRouter: true })
     expect(screen.getByText('Workspaces')).toBeInTheDocument()
     expect(screen.getByText('Chats')).toBeInTheDocument()
-    expect(screen.getByText('My Documents')).toBeInTheDocument()
-    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByText('Meine Dokumente')).toBeInTheDocument()
+    expect(screen.getByText('Einstellungen')).toBeInTheDocument()
   })
 
   it('renders OPAA branding', () => {
     renderWithProviders(<Sidebar />, { withRouter: true })
     expect(screen.getByText('OPAA')).toBeInTheDocument()
-    expect(screen.getByText('AI Project Assistant')).toBeInTheDocument()
+    expect(screen.getByText('KI-Projektassistent')).toBeInTheDocument()
   })
 
   it('renders New Chat button', () => {
     renderWithProviders(<Sidebar />, { withRouter: true })
-    expect(screen.getByRole('button', { name: /new chat/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /neuer chat/i })).toBeInTheDocument()
   })
 
   it('clears messages when New Chat button is clicked', async () => {
@@ -53,7 +53,7 @@ describe('Sidebar', () => {
 
     renderWithProviders(<Sidebar />, { withRouter: true })
 
-    await userEvent.click(screen.getByRole('button', { name: /new chat/i }))
+    await userEvent.click(screen.getByRole('button', { name: /neuer chat/i }))
 
     const state = useChatStore.getState()
     expect(state.messages).toHaveLength(0)

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -25,6 +25,7 @@ import CreateWorkspaceDialog from '../components/CreateWorkspaceDialog'
 import { useChatStore } from '../stores/chatStore'
 import { useAuthStore } from '../stores/authStore'
 import { useWorkspaceStore } from '../stores/workspaceStore'
+import { workspaceRoleLabel } from '../utils/labels'
 import { useState } from 'react'
 
 const SIDEBAR_WIDTH = 300
@@ -74,7 +75,7 @@ export default function Sidebar() {
           OPAA
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          AI Project Assistant
+          KI-Projektassistent
         </Typography>
       </Box>
 
@@ -90,7 +91,7 @@ export default function Sidebar() {
               <IconButton
                 size="small"
                 onClick={() => setCreateDialogOpen(true)}
-                aria-label="create workspace"
+                aria-label="Workspace erstellen"
               >
                 <AddIcon fontSize="small" />
               </IconButton>
@@ -98,7 +99,7 @@ export default function Sidebar() {
             <IconButton
               size="small"
               onClick={() => setWorkspacesOpen((open) => !open)}
-              aria-label="toggle workspaces"
+              aria-label="Workspaces ein- oder ausklappen"
             >
               {workspacesOpen ? (
                 <ExpandLessIcon fontSize="small" />
@@ -133,10 +134,14 @@ export default function Sidebar() {
                     </ListItemIcon>
                     <ListItemText
                       primary={workspace.name}
-                      secondary={`${workspace.memberCount} member${workspace.memberCount === 1 ? '' : 's'}`}
+                      secondary={`${workspace.memberCount} ${workspace.memberCount === 1 ? 'Mitglied' : 'Mitglieder'}`}
                       slotProps={{ primary: { noWrap: true } }}
                     />
-                    <Chip label={workspace.userRole} size="small" variant="outlined" />
+                    <Chip
+                      label={workspaceRoleLabel(workspace.userRole)}
+                      size="small"
+                      variant="outlined"
+                    />
                   </ListItemButton>
                 )
               })}
@@ -154,7 +159,7 @@ export default function Sidebar() {
           <IconButton
             size="small"
             onClick={() => setChatsOpen((open) => !open)}
-            aria-label="toggle chats"
+            aria-label="Chats ein- oder ausklappen"
           >
             {chatsOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
           </IconButton>
@@ -168,7 +173,7 @@ export default function Sidebar() {
               onClick={handleNewChat}
               sx={{ mt: 1, borderRadius: 2, justifyContent: 'flex-start', textTransform: 'none' }}
             >
-              New Chat
+              Neuer Chat
             </Button>
             <List sx={{ px: 0, pt: 1 }}>
               <ListItemButton
@@ -179,7 +184,7 @@ export default function Sidebar() {
                 <ListItemIcon sx={{ minWidth: 36 }}>
                   <ChatIcon fontSize="small" />
                 </ListItemIcon>
-                <ListItemText primary="Current Chat" />
+                <ListItemText primary="Aktueller Chat" />
               </ListItemButton>
             </List>
           </>
@@ -197,7 +202,7 @@ export default function Sidebar() {
           <ListItemIcon sx={{ minWidth: 36 }}>
             <SettingsIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText primary="Settings" />
+          <ListItemText primary="Einstellungen" />
         </ListItemButton>
         <ListItemButton
           component={NavLink}
@@ -208,7 +213,7 @@ export default function Sidebar() {
           <ListItemIcon sx={{ minWidth: 36 }}>
             <DescriptionIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText primary="Documents" />
+          <ListItemText primary="Dokumente" />
         </ListItemButton>
       </List>
 
@@ -223,10 +228,10 @@ export default function Sidebar() {
             </Avatar>
             <Box sx={{ flex: 1, minWidth: 0 }}>
               <Typography variant="body2" noWrap>
-                {user.displayName ?? user.email ?? 'User'}
+                {user.displayName ?? user.email ?? 'Benutzer'}
               </Typography>
             </Box>
-            <IconButton size="small" onClick={logout} aria-label="sign out">
+            <IconButton size="small" onClick={logout} aria-label="Abmelden">
               <LogoutIcon fontSize="small" />
             </IconButton>
           </Box>

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -27,7 +27,7 @@ export const mockIndexingCompleted: IndexingStatusResponse = {
   documentCount: 37,
   totalDocuments: 42,
   documentsSkipped: 5,
-  message: 'Indexing completed: 37 processed, 5 skipped, 0 failed',
+  message: 'Indizierung abgeschlossen: 37 verarbeitet, 5 übersprungen, 0 fehlgeschlagen',
   timestamp: '2025-01-15T10:30:00Z',
 }
 
@@ -37,10 +37,10 @@ export const mockIndexingStatus = mockIndexingCompleted
 export const mockQueryResponses: QueryResponse[] = [
   {
     answer:
-      'The project uses a modular monolith architecture with three main modules: ' +
-      'api, indexing, and query. The api module handles REST endpoints and DTOs, ' +
-      'the indexing module manages document ingestion, and the query module ' +
-      'handles question answering via RAG.',
+      'Das Projekt nutzt eine modulare Monolith-Architektur mit drei Hauptmodulen: ' +
+      'api, indexing und query. Das Modul api stellt die REST-Endpunkte und DTOs bereit, ' +
+      'das Modul indexing verwaltet die Dokumentenaufnahme und das Modul query ' +
+      'beantwortet Fragen über RAG.',
     sources: [
       {
         fileName: 'architecture-overview.md',
@@ -52,7 +52,7 @@ export const mockQueryResponses: QueryResponse[] = [
       },
       {
         fileName: 'getting-started.pdf',
-        workspaceName: 'My Documents',
+        workspaceName: 'Meine Dokumente',
         relevanceScore: 0.85,
         matchCount: 1,
         indexedAt: '2025-01-15T10:30:00Z',
@@ -76,10 +76,10 @@ export const mockQueryResponses: QueryResponse[] = [
   },
   {
     answer:
-      'To add a new REST endpoint, create a controller class in the api module ' +
-      'annotated with @RestController. Define your request/response DTOs as Java records ' +
-      'and use Jakarta Bean Validation for input validation. The endpoint will be ' +
-      'automatically documented via the OpenAPI specification.',
+      'Für einen neuen REST-Endpunkt legen Sie im Modul api eine Controller-Klasse mit der ' +
+      'Annotation @RestController an. Request- und Response-DTOs werden als Java-Records ' +
+      'definiert, die Eingabevalidierung erfolgt über Jakarta Bean Validation. Der Endpunkt ' +
+      'wird automatisch über die OpenAPI-Spezifikation dokumentiert.',
     sources: [
       {
         fileName: 'contributing-guide.md',
@@ -99,10 +99,10 @@ export const mockQueryResponses: QueryResponse[] = [
   },
   {
     answer:
-      'The deployment pipeline uses Docker Compose to orchestrate all services. ' +
-      'PostgreSQL with pgvector handles vector storage for embeddings, while Liquibase ' +
-      'manages database migrations. The CI/CD pipeline runs on GitHub Actions with ' +
-      'separate jobs for backend and frontend builds, linting, and test execution.',
+      'Die Deployment-Pipeline orchestriert alle Dienste über Docker Compose. ' +
+      'PostgreSQL mit pgvector speichert die Vektoren der Embeddings, Liquibase verwaltet ' +
+      'die Datenbankmigrationen. Die CI/CD-Pipeline läuft auf GitHub Actions mit getrennten ' +
+      'Jobs für Backend- und Frontend-Build, Linting und Testausführung.',
     sources: [
       {
         fileName: 'docker-compose.yml',
@@ -138,7 +138,7 @@ export const mockQueryResponses: QueryResponse[] = [
       },
       {
         fileName: 'liquibase-changelog.xml',
-        workspaceName: 'My Documents',
+        workspaceName: 'Meine Dokumente',
         relevanceScore: 0.82,
         matchCount: 1,
         indexedAt: '2025-01-12T09:00:00Z',
@@ -146,7 +146,7 @@ export const mockQueryResponses: QueryResponse[] = [
       },
       {
         fileName: 'postgres-setup.md',
-        workspaceName: 'My Documents',
+        workspaceName: 'Meine Dokumente',
         relevanceScore: 0.79,
         matchCount: 1,
         indexedAt: '2025-01-11T14:00:00Z',
@@ -199,7 +199,7 @@ export function getRandomMockResponse(): QueryResponse {
 }
 
 export const mockErrorResponse = {
-  error: 'question: Question must not be blank',
+  error: 'question: darf nicht leer sein',
   status: 400,
   timestamp: '2025-01-15T10:30:00Z',
 }
@@ -221,8 +221,8 @@ export const mockUser: AuthUser = {
 export const mockWorkspaces: WorkspaceListResponse[] = [
   {
     id: 'ws-personal',
-    name: 'My Documents',
-    description: 'Private docs',
+    name: 'Meine Dokumente',
+    description: 'Private Dokumente',
     type: 'PERSONAL',
     memberCount: 1,
     userRole: 'OWNER',
@@ -232,7 +232,7 @@ export const mockWorkspaces: WorkspaceListResponse[] = [
   {
     id: 'ws-engineering',
     name: 'Engineering',
-    description: 'Engineering docs',
+    description: 'Dokumente der Entwicklung',
     type: 'SHARED',
     memberCount: 3,
     userRole: 'ADMIN',
@@ -242,7 +242,7 @@ export const mockWorkspaces: WorkspaceListResponse[] = [
   {
     id: 'ws-phoenix',
     name: 'Phoenix',
-    description: 'Project docs',
+    description: 'Projektdokumente',
     type: 'SHARED',
     memberCount: 2,
     userRole: 'EDITOR',
@@ -254,8 +254,8 @@ export const mockWorkspaces: WorkspaceListResponse[] = [
 export const mockWorkspaceDetails: Record<string, WorkspaceResponse> = {
   'ws-personal': {
     id: 'ws-personal',
-    name: 'My Documents',
-    description: 'Private docs',
+    name: 'Meine Dokumente',
+    description: 'Private Dokumente',
     type: 'PERSONAL',
     ownerId: 'mock-user-id',
     memberCount: 1,
@@ -275,7 +275,7 @@ export const mockWorkspaceDetails: Record<string, WorkspaceResponse> = {
   'ws-engineering': {
     id: 'ws-engineering',
     name: 'Engineering',
-    description: 'Engineering docs',
+    description: 'Dokumente der Entwicklung',
     type: 'SHARED',
     ownerId: 'owner-1',
     memberCount: 3,
@@ -297,7 +297,7 @@ export const mockWorkspaceDetails: Record<string, WorkspaceResponse> = {
   'ws-phoenix': {
     id: 'ws-phoenix',
     name: 'Phoenix',
-    description: 'Project docs',
+    description: 'Projektdokumente',
     type: 'SHARED',
     ownerId: 'owner-2',
     memberCount: 2,
@@ -364,5 +364,5 @@ export const mockUsers: UserInfo[] = [
   { id: 'owner-1', email: 'alice@opaa.local', displayName: 'Alice', systemRole: 'USER' },
   { id: 'owner-2', email: 'chris@opaa.local', displayName: 'Chris', systemRole: 'USER' },
   { id: 'editor-1', email: 'bob@opaa.local', displayName: 'Bob', systemRole: 'USER' },
-  { id: 'demo-user', email: 'demo@opaa.local', displayName: 'Demo User', systemRole: 'USER' },
+  { id: 'demo-user', email: 'demo@opaa.local', displayName: 'Demo-Benutzer', systemRole: 'USER' },
 ]

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -70,7 +70,7 @@ export const handlers = [
         documentCount: 0,
         totalDocuments: 0,
         documentsSkipped: 0,
-        message: 'Indexing started',
+        message: 'Indizierung gestartet',
         timestamp: new Date().toISOString(),
       } satisfies IndexingStatusResponse,
       { status: 202 },
@@ -121,10 +121,16 @@ export const handlers = [
   http.post('/api/v1/workspaces', async ({ request }) => {
     const body = (await request.json()) as { name: string; description?: string }
     if (!body.name || body.name.trim() === '') {
-      return HttpResponse.json({ error: 'Workspace name is required' }, { status: 400 })
+      return HttpResponse.json(
+        { error: 'Der Name des Workspace ist erforderlich' },
+        { status: 400 },
+      )
     }
     if (mockWorkspaces.some((ws) => ws.name.toLowerCase() === body.name.trim().toLowerCase())) {
-      return HttpResponse.json({ error: 'Workspace name already exists' }, { status: 409 })
+      return HttpResponse.json(
+        { error: 'Ein Workspace mit diesem Namen existiert bereits' },
+        { status: 409 },
+      )
     }
     const id = `ws-${crypto.randomUUID().slice(0, 8)}`
     const now = new Date().toISOString()
@@ -158,7 +164,7 @@ export const handlers = [
     const workspaceId = String(params.workspaceId)
     const workspace = mockWorkspaceDetails[workspaceId]
     if (!workspace) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
     return HttpResponse.json(workspace)
   }),
@@ -172,7 +178,7 @@ export const handlers = [
     const workspaceId = String(params.workspaceId)
     const workspace = mockWorkspaceDetails[workspaceId]
     if (!workspace) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
 
     const body = (await request.json()) as { userId: string; role?: 'VIEWER' | 'EDITOR' | 'ADMIN' }
@@ -180,7 +186,10 @@ export const handlers = [
       return HttpResponse.json({ error: 'userId is required' }, { status: 400 })
     }
     if (workspace.members.some((member) => member.userId === body.userId)) {
-      return HttpResponse.json({ error: 'Member already exists' }, { status: 409 })
+      return HttpResponse.json(
+        { error: 'Der Benutzer ist bereits Mitglied dieses Workspace' },
+        { status: 409 },
+      )
     }
 
     const role = body.role ?? 'VIEWER'
@@ -195,7 +204,7 @@ export const handlers = [
     const userId = String(params.userId)
     const workspace = mockWorkspaceDetails[workspaceId]
     if (!workspace) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
     workspace.members = workspace.members.filter((member) => member.userId !== userId)
     recalculateRoleCounts(workspaceId)
@@ -207,11 +216,11 @@ export const handlers = [
     const userId = String(params.userId)
     const workspace = mockWorkspaceDetails[workspaceId]
     if (!workspace) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
     const target = workspace.members.find((member) => member.userId === userId)
     if (!target) {
-      return HttpResponse.json({ error: 'Member not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Mitglied des Workspace nicht gefunden' }, { status: 404 })
     }
     const body = (await request.json()) as { role: 'VIEWER' | 'EDITOR' | 'ADMIN' }
     target.role = body.role
@@ -223,13 +232,13 @@ export const handlers = [
     const workspaceId = String(params.workspaceId)
     const workspace = mockWorkspaceDetails[workspaceId]
     if (!workspace) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
     const body = (await request.json()) as { userId: string }
     const currentOwner = workspace.members.find((member) => member.role === 'OWNER')
     const newOwner = workspace.members.find((member) => member.userId === body.userId)
     if (!currentOwner || !newOwner) {
-      return HttpResponse.json({ error: 'Member not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Mitglied des Workspace nicht gefunden' }, { status: 404 })
     }
     currentOwner.role = 'ADMIN'
     newOwner.role = 'OWNER'
@@ -242,7 +251,7 @@ export const handlers = [
     const workspace = mockWorkspaceDetails[workspaceId]
     const listEntry = mockWorkspaces.find((item) => item.id === workspaceId)
     if (!workspace || !listEntry) {
-      return HttpResponse.json({ error: 'Workspace not found' }, { status: 404 })
+      return HttpResponse.json({ error: 'Workspace nicht gefunden' }, { status: 404 })
     }
     const body = (await request.json()) as { name: string; description: string }
     workspace.name = body.name
@@ -276,7 +285,7 @@ export const handlers = [
     if (body.username === 'admin' && body.password === 'admin') {
       return HttpResponse.json(mockLoginResponse)
     }
-    return HttpResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+    return HttpResponse.json({ error: 'Ungültige Anmeldedaten' }, { status: 401 })
   }),
 
   http.get('/api/v1/auth/me', () => {

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -40,7 +40,7 @@ export default function AuthCallbackPage() {
       ) : (
         <>
           <CircularProgress />
-          <Typography sx={{ mt: 2 }}>Completing sign in...</Typography>
+          <Typography sx={{ mt: 2 }}>Anmeldung wird abgeschlossen …</Typography>
         </>
       )}
     </Box>

--- a/frontend/src/pages/ChatPage.test.tsx
+++ b/frontend/src/pages/ChatPage.test.tsx
@@ -11,15 +11,15 @@ describe('ChatPage', () => {
 
   it('renders empty state', () => {
     renderWithProviders(<ChatPage />)
-    expect(screen.getByText('How can I help you today?')).toBeInTheDocument()
+    expect(screen.getByText('Womit kann ich Ihnen heute helfen?')).toBeInTheDocument()
   })
 
   it('sends a message and displays response with sources', async () => {
     renderWithProviders(<ChatPage />)
 
-    const input = screen.getByPlaceholderText('Ask a question...')
+    const input = screen.getByPlaceholderText('Stellen Sie eine Frage …')
     fireEvent.change(input, { target: { value: 'What is the architecture?' } })
-    fireEvent.click(screen.getByLabelText('send message'))
+    fireEvent.click(screen.getByLabelText('Nachricht senden'))
 
     // User message should appear immediately
     expect(screen.getByText('What is the architecture?')).toBeInTheDocument()
@@ -27,7 +27,7 @@ describe('ChatPage', () => {
     // Wait for MSW response — loading indicator should disappear and assistant reply should appear
     await waitFor(
       () => {
-        expect(screen.queryByText('Thinking...')).not.toBeInTheDocument()
+        expect(screen.queryByText('Denkt nach …')).not.toBeInTheDocument()
       },
       { timeout: 10000 },
     )
@@ -37,8 +37,8 @@ describe('ChatPage', () => {
   }, 15000)
 
   it('shows error alert when present', () => {
-    useChatStore.setState({ error: 'Something went wrong' })
+    useChatStore.setState({ error: 'Etwas ist schiefgelaufen' })
     renderWithProviders(<ChatPage />)
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('Etwas ist schiefgelaufen')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -16,8 +16,8 @@ export default function DocumentsPage() {
       }}
     >
       <DescriptionIcon sx={{ fontSize: 48 }} />
-      <Typography variant="h5">Documents</Typography>
-      <Typography variant="body1">Coming soon</Typography>
+      <Typography variant="h5">Dokumente</Typography>
+      <Typography variant="body1">Demnächst verfügbar</Typography>
     </Box>
   )
 }

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -27,21 +27,21 @@ describe('LoginPage', () => {
   it('renders login form for basic mode', () => {
     useAuthStore.setState({ mode: 'basic' })
     renderWithProviders(<LoginPage />, { withRouter: true })
-    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/benutzername/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/passwort/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /anmelden/i })).toBeInTheDocument()
   })
 
   it('renders SSO button for oidc mode', () => {
     useAuthStore.setState({ mode: 'oidc' })
     renderWithProviders(<LoginPage />, { withRouter: true })
-    expect(screen.getByRole('button', { name: /sign in with sso/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /mit sso anmelden/i })).toBeInTheDocument()
   })
 
   it('displays error message', () => {
-    useAuthStore.setState({ mode: 'basic', error: 'Invalid credentials' })
+    useAuthStore.setState({ mode: 'basic', error: 'Ungültige Anmeldedaten' })
     renderWithProviders(<LoginPage />, { withRouter: true })
-    expect(screen.getByText('Invalid credentials')).toBeInTheDocument()
+    expect(screen.getByText('Ungültige Anmeldedaten')).toBeInTheDocument()
   })
 
   it('submits basic login form', async () => {
@@ -49,9 +49,9 @@ describe('LoginPage', () => {
     renderWithProviders(<LoginPage />, { withRouter: true })
     const user = userEvent.setup()
 
-    await user.type(screen.getByLabelText(/username/i), 'admin')
-    await user.type(screen.getByLabelText(/password/i), 'admin')
-    await user.click(screen.getByRole('button', { name: /sign in/i }))
+    await user.type(screen.getByLabelText(/benutzername/i), 'admin')
+    await user.type(screen.getByLabelText(/passwort/i), 'admin')
+    await user.click(screen.getByRole('button', { name: /anmelden/i }))
 
     // After successful login via MSW, user should be authenticated
     const state = useAuthStore.getState()
@@ -61,6 +61,6 @@ describe('LoginPage', () => {
   it('redirects away from login when already authenticated', () => {
     useAuthStore.setState({ mode: 'basic', isAuthenticated: true })
     renderWithProviders(<LoginPage />, { withRouter: true, initialRoute: '/login' })
-    expect(screen.queryByRole('button', { name: /sign in/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /anmelden/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
           OPAA
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Sign in to continue
+          Zum Fortfahren anmelden
         </Typography>
 
         {error && (
@@ -62,7 +62,7 @@ export default function LoginPage() {
         {mode === 'basic' && (
           <form onSubmit={handleBasicLogin}>
             <TextField
-              label="Username"
+              label="Benutzername"
               fullWidth
               margin="normal"
               value={username}
@@ -70,7 +70,7 @@ export default function LoginPage() {
               autoComplete="username"
             />
             <TextField
-              label="Password"
+              label="Passwort"
               type="password"
               fullWidth
               margin="normal"
@@ -79,14 +79,14 @@ export default function LoginPage() {
               autoComplete="current-password"
             />
             <Button type="submit" variant="contained" fullWidth disabled={isLoading} sx={{ mt: 2 }}>
-              Sign In
+              Anmelden
             </Button>
           </form>
         )}
 
         {mode === 'oidc' && (
           <Button variant="contained" fullWidth onClick={loginOidc} disabled={isLoading}>
-            Sign in with SSO
+            Mit SSO anmelden
           </Button>
         )}
       </Paper>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,15 +16,15 @@ export default function SettingsPage() {
   return (
     <Box sx={{ flexGrow: 1, p: 4, maxWidth: 600 }}>
       <Typography variant="h5" gutterBottom>
-        Settings
+        Einstellungen
       </Typography>
 
       <Paper variant="outlined" sx={{ p: 3, mt: 2 }}>
         <Typography variant="subtitle1" gutterBottom sx={{ fontWeight: 'medium' }}>
-          Appearance
+          Darstellung
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Choose how OPAA looks to you.
+          Legen Sie fest, wie OPAA für Sie aussieht.
         </Typography>
         <ToggleButtonGroup
           value={themeMode}
@@ -32,19 +32,19 @@ export default function SettingsPage() {
           onChange={(_e, value: ThemeMode | null) => {
             if (value !== null) setThemeMode(value)
           }}
-          aria-label="theme mode"
+          aria-label="Farbschema"
         >
-          <ToggleButton value="light" aria-label="light mode">
+          <ToggleButton value="light" aria-label="Helles Farbschema">
             <LightModeIcon sx={{ mr: 1 }} fontSize="small" />
-            Light
+            Hell
           </ToggleButton>
-          <ToggleButton value="system" aria-label="system default">
+          <ToggleButton value="system" aria-label="Systemvorgabe">
             <SettingsBrightnessIcon sx={{ mr: 1 }} fontSize="small" />
             System
           </ToggleButton>
-          <ToggleButton value="dark" aria-label="dark mode">
+          <ToggleButton value="dark" aria-label="Dunkles Farbschema">
             <DarkModeIcon sx={{ mr: 1 }} fontSize="small" />
-            Dark
+            Dunkel
           </ToggleButton>
         </ToggleButtonGroup>
       </Paper>

--- a/frontend/src/pages/WorkspaceManagementPage.test.tsx
+++ b/frontend/src/pages/WorkspaceManagementPage.test.tsx
@@ -28,7 +28,7 @@ describe('WorkspaceManagementPage', () => {
       selectedWorkspaceId: 'ws-personal',
       selectedWorkspace: {
         id: 'ws-personal',
-        name: 'My Documents',
+        name: 'Meine Dokumente',
         description: 'Private docs',
         type: 'PERSONAL',
         ownerId: 'u1',
@@ -49,7 +49,7 @@ describe('WorkspaceManagementPage', () => {
 
   it('shows personal workspace message and disables member management', () => {
     renderWithProviders(<WorkspaceManagementPage />, { withRouter: true })
-    expect(screen.getByText(/personal workspace/i)).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /add member/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/persönlicher workspace/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /mitglied hinzufügen/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/WorkspaceManagementPage.tsx
+++ b/frontend/src/pages/WorkspaceManagementPage.tsx
@@ -15,6 +15,7 @@ import { useNavigate, useParams } from 'react-router'
 import type { UserInfo, WorkspaceRole } from '../types/api'
 import { getUsers } from '../services/api'
 import { useWorkspaceStore } from '../stores/workspaceStore'
+import { workspaceRoleLabel } from '../utils/labels'
 
 const editableRoles: WorkspaceRole[] = ['VIEWER', 'EDITOR', 'ADMIN']
 
@@ -77,7 +78,7 @@ export default function WorkspaceManagementPage() {
   if (!workspaceId || !workspace) {
     return (
       <Box sx={{ flexGrow: 1, p: 3 }}>
-        <Typography variant="h6">Workspace not loaded</Typography>
+        <Typography variant="h6">Workspace nicht geladen</Typography>
       </Box>
     )
   }
@@ -98,12 +99,12 @@ export default function WorkspaceManagementPage() {
       <Stack spacing={2.5}>
         <Paper variant="outlined" sx={{ p: 2.5 }}>
           <Typography variant="h6" gutterBottom>
-            Workspace Settings
+            Workspace-Einstellungen
           </Typography>
           <Divider sx={{ mb: 2 }} />
           <Stack spacing={1.5}>
             <TextField
-              label="Workspace name"
+              label="Name des Workspace"
               value={name}
               onChange={(event) =>
                 setDraft({
@@ -115,7 +116,7 @@ export default function WorkspaceManagementPage() {
               disabled={!canManage}
             />
             <TextField
-              label="Description"
+              label="Beschreibung"
               value={description}
               onChange={(event) =>
                 setDraft({
@@ -135,13 +136,15 @@ export default function WorkspaceManagementPage() {
                   setLocalError(null)
                   try {
                     await updateDetails(workspaceId, name, description)
-                    setSuccessMessage('Workspace updated')
+                    setSuccessMessage('Workspace aktualisiert')
                   } catch (err) {
-                    setLocalError(err instanceof Error ? err.message : 'Update failed')
+                    setLocalError(
+                      err instanceof Error ? err.message : 'Aktualisierung fehlgeschlagen',
+                    )
                   }
                 }}
               >
-                Save Settings
+                Einstellungen speichern
               </Button>
             )}
             {isOwner && workspace.type !== 'PERSONAL' && (
@@ -149,7 +152,11 @@ export default function WorkspaceManagementPage() {
                 color="error"
                 variant="outlined"
                 onClick={async () => {
-                  if (!window.confirm('Delete this workspace? This action cannot be undone.')) {
+                  if (
+                    !window.confirm(
+                      'Diesen Workspace löschen? Diese Aktion kann nicht rückgängig gemacht werden.',
+                    )
+                  ) {
                     return
                   }
                   setLocalError(null)
@@ -157,11 +164,11 @@ export default function WorkspaceManagementPage() {
                     await deleteSelectedWorkspace(workspaceId)
                     navigate('/workspaces')
                   } catch (err) {
-                    setLocalError(err instanceof Error ? err.message : 'Deletion failed')
+                    setLocalError(err instanceof Error ? err.message : 'Löschen fehlgeschlagen')
                   }
                 }}
               >
-                Delete Workspace
+                Workspace löschen
               </Button>
             )}
           </Stack>
@@ -169,12 +176,12 @@ export default function WorkspaceManagementPage() {
 
         <Paper variant="outlined" sx={{ p: 2.5 }}>
           <Typography variant="h6" gutterBottom>
-            Members
+            Mitglieder
           </Typography>
           <Divider sx={{ mb: 2 }} />
           {workspace.type === 'PERSONAL' ? (
             <Alert severity="info">
-              This is your personal workspace. Member management is disabled.
+              Dies ist Ihr persönlicher Workspace. Die Mitgliederverwaltung ist deaktiviert.
             </Alert>
           ) : (
             <Stack spacing={1.5}>
@@ -206,7 +213,9 @@ export default function WorkspaceManagementPage() {
                           try {
                             await updateMemberRole(workspaceId, member.userId, nextRole)
                           } catch (err) {
-                            setLocalError(err instanceof Error ? err.message : 'Role update failed')
+                            setLocalError(
+                              err instanceof Error ? err.message : 'Rollenänderung fehlgeschlagen',
+                            )
                           }
                         }}
                         disabled={member.role === 'OWNER'}
@@ -215,19 +224,23 @@ export default function WorkspaceManagementPage() {
                           .filter((value, index, arr) => arr.indexOf(value) === index)
                           .map((role) => (
                             <MenuItem key={role} value={role}>
-                              {role}
+                              {workspaceRoleLabel(role)}
                             </MenuItem>
                           ))}
                       </Select>
                     ) : (
-                      <Chip label={member.role} size="small" />
+                      <Chip label={workspaceRoleLabel(member.role)} size="small" />
                     )}
                     {canManage && member.role !== 'OWNER' && (
                       <Button
                         color="error"
                         size="small"
                         onClick={async () => {
-                          if (!window.confirm(`Remove ${member.userId} from this workspace?`)) {
+                          if (
+                            !window.confirm(
+                              `${member.displayName ?? member.userId} aus diesem Workspace entfernen?`,
+                            )
+                          ) {
                             return
                           }
                           setLocalError(null)
@@ -235,33 +248,41 @@ export default function WorkspaceManagementPage() {
                             await removeMember(workspaceId, member.userId)
                           } catch (err) {
                             setLocalError(
-                              err instanceof Error ? err.message : 'Member removal failed',
+                              err instanceof Error
+                                ? err.message
+                                : 'Entfernen des Mitglieds fehlgeschlagen',
                             )
                           }
                         }}
                       >
-                        Remove
+                        Entfernen
                       </Button>
                     )}
                     {isOwner && member.role !== 'OWNER' && (
                       <Button
                         size="small"
                         onClick={async () => {
-                          if (!window.confirm(`Transfer ownership to ${member.userId}?`)) {
+                          if (
+                            !window.confirm(
+                              `Eigentum an ${member.displayName ?? member.userId} übertragen?`,
+                            )
+                          ) {
                             return
                           }
                           setLocalError(null)
                           try {
                             await transferOwnership(workspaceId, member.userId)
-                            setSuccessMessage('Ownership transferred')
+                            setSuccessMessage('Eigentum übertragen')
                           } catch (err) {
                             setLocalError(
-                              err instanceof Error ? err.message : 'Ownership transfer failed',
+                              err instanceof Error
+                                ? err.message
+                                : 'Übertragung des Eigentums fehlgeschlagen',
                             )
                           }
                         }}
                       >
-                        Make Owner
+                        Zum Eigentümer machen
                       </Button>
                     )}
                   </Stack>
@@ -280,7 +301,7 @@ export default function WorkspaceManagementPage() {
                     value={selectedUser}
                     onChange={(_event, value) => setSelectedUser(value)}
                     renderInput={(params) => (
-                      <TextField {...params} label="User" placeholder="Search users..." />
+                      <TextField {...params} label="Benutzer" placeholder="Benutzer suchen …" />
                     )}
                     isOptionEqualToValue={(option, value) => option.id === value.id}
                     sx={{ minWidth: 280 }}
@@ -289,11 +310,11 @@ export default function WorkspaceManagementPage() {
                     size="small"
                     value={newMemberRole}
                     onChange={(event) => setNewMemberRole(event.target.value as WorkspaceRole)}
-                    sx={{ width: 140 }}
+                    sx={{ width: 180 }}
                   >
                     {editableRoles.map((role) => (
                       <MenuItem key={role} value={role}>
-                        {role}
+                        {workspaceRoleLabel(role)}
                       </MenuItem>
                     ))}
                   </Select>
@@ -306,13 +327,17 @@ export default function WorkspaceManagementPage() {
                       try {
                         await addMember(workspaceId, selectedUser.id, newMemberRole)
                         setSelectedUser(null)
-                        setSuccessMessage('Member added')
+                        setSuccessMessage('Mitglied hinzugefügt')
                       } catch (err) {
-                        setLocalError(err instanceof Error ? err.message : 'Failed to add member')
+                        setLocalError(
+                          err instanceof Error
+                            ? err.message
+                            : 'Mitglied konnte nicht hinzugefügt werden',
+                        )
                       }
                     }}
                   >
-                    Add Member
+                    Mitglied hinzufügen
                   </Button>
                 </Stack>
               )}

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -16,6 +16,7 @@ import UploadIcon from '@mui/icons-material/Upload'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
 import { useNavigate, useParams } from 'react-router'
 import { useWorkspaceStore } from '../stores/workspaceStore'
+import { workspaceRoleLabel, workspaceTypeLabel } from '../utils/labels'
 
 function canUpload(role: string | undefined): boolean {
   return role === 'EDITOR' || role === 'ADMIN' || role === 'OWNER'
@@ -66,7 +67,7 @@ export default function WorkspacePage() {
   if (!workspace) {
     return (
       <Box sx={{ flexGrow: 1, p: 3 }}>
-        <Typography variant="h6">No workspace selected</Typography>
+        <Typography variant="h6">Kein Workspace ausgewählt</Typography>
       </Box>
     )
   }
@@ -88,16 +89,21 @@ export default function WorkspacePage() {
             <Box>
               <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>
                 <Typography variant="h5">{workspace.name}</Typography>
-                <Chip label={workspace.type} size="small" color="primary" variant="outlined" />
+                <Chip
+                  label={workspaceTypeLabel(workspace.type)}
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                />
               </Stack>
               <Typography color="text.secondary">
-                {workspace.description || 'No description provided.'}
+                {workspace.description || 'Keine Beschreibung hinterlegt.'}
               </Typography>
             </Box>
             <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
               {canUpload(workspace.userRole) && (
                 <Button variant="contained" startIcon={<UploadIcon />}>
-                  Upload
+                  Hochladen
                 </Button>
               )}
               {canManage(workspace.userRole) && (
@@ -106,7 +112,7 @@ export default function WorkspacePage() {
                   startIcon={<ManageAccountsIcon />}
                   onClick={() => navigate(`/workspaces/${workspace.id}/manage`)}
                 >
-                  Manage Workspace
+                  Workspace verwalten
                 </Button>
               )}
             </Stack>
@@ -120,12 +126,14 @@ export default function WorkspacePage() {
           disableGutters
         >
           <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 2.5 }}>
-            <Typography variant="h6">Documents</Typography>
+            <Typography variant="h6">Dokumente</Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ px: 2.5, pb: 2.5, pt: 0 }}>
             <Divider sx={{ mb: 2 }} />
             {documents.length === 0 ? (
-              <Typography color="text.secondary">No documents in this workspace yet.</Typography>
+              <Typography color="text.secondary">
+                Noch keine Dokumente in diesem Workspace.
+              </Typography>
             ) : (
               <Stack spacing={1.25}>
                 {documents.map((document) => (
@@ -141,7 +149,7 @@ export default function WorkspacePage() {
                     <Typography>{document.name}</Typography>
                     <Typography color="text.secondary">
                       {document.type} · {document.ownerDisplayName} ·{' '}
-                      {new Date(document.uploadedAt).toLocaleDateString()}
+                      {new Date(document.uploadedAt).toLocaleDateString('de-DE')}
                     </Typography>
                   </Box>
                 ))}
@@ -157,12 +165,12 @@ export default function WorkspacePage() {
           disableGutters
         >
           <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 2.5 }}>
-            <Typography variant="h6">Members</Typography>
+            <Typography variant="h6">Mitglieder</Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ px: 2.5, pb: 2.5, pt: 0 }}>
             <Divider sx={{ mb: 2 }} />
             {workspace.members.length === 0 ? (
-              <Typography color="text.secondary">No members found.</Typography>
+              <Typography color="text.secondary">Keine Mitglieder gefunden.</Typography>
             ) : (
               <Stack spacing={1}>
                 {workspace.members.map((member) => (
@@ -173,7 +181,7 @@ export default function WorkspacePage() {
                     <Typography sx={member.displayName ? undefined : { fontFamily: 'monospace' }}>
                       {member.displayName ?? member.userId}
                     </Typography>
-                    <Chip label={member.role} size="small" />
+                    <Chip label={workspaceRoleLabel(member.role)} size="small" />
                   </Box>
                 ))}
               </Stack>

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -161,7 +161,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     } catch (err) {
       clearBasicSession()
       set({
-        error: err instanceof Error ? err.message : 'Login failed',
+        error: err instanceof Error ? err.message : 'Anmeldung fehlgeschlagen',
         isLoading: false,
       })
     }
@@ -188,7 +188,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       })
     } catch (err) {
       set({
-        error: err instanceof Error ? err.message : 'OIDC callback failed',
+        error: err instanceof Error ? err.message : 'OIDC-Rückmeldung fehlgeschlagen',
         isLoading: false,
       })
     }

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -51,7 +51,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }))
     } catch (err) {
       // TODO: Add retry UX (e.g. "Retry" button on failed messages)
-      const message = err instanceof Error ? err.message : 'An unexpected error occurred'
+      const message = err instanceof Error ? err.message : 'Ein unerwarteter Fehler ist aufgetreten'
       set({ error: message, isLoading: false })
     }
   },

--- a/frontend/src/stores/indexingStore.ts
+++ b/frontend/src/stores/indexingStore.ts
@@ -64,10 +64,10 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
     } catch (err) {
       set({
         status: 'FAILED',
-        message: err instanceof Error ? err.message : 'Failed to trigger indexing',
+        message: err instanceof Error ? err.message : 'Indizierung konnte nicht gestartet werden',
         snackbar: {
           open: true,
-          message: 'Failed to trigger indexing',
+          message: 'Indizierung konnte nicht gestartet werden',
           severity: 'error',
         },
       })
@@ -98,8 +98,8 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
               open: true,
               message:
                 response.status === 'COMPLETED'
-                  ? `Indexing completed: ${response.documentCount} processed, ${response.documentsSkipped} skipped`
-                  : (response.message ?? 'Indexing failed'),
+                  ? `Indizierung abgeschlossen: ${response.documentCount} verarbeitet, ${response.documentsSkipped} übersprungen`
+                  : (response.message ?? 'Indizierung fehlgeschlagen'),
               severity: response.status === 'COMPLETED' ? 'success' : 'error',
             },
           })
@@ -108,10 +108,10 @@ export const useIndexingStore = create<IndexingState>((set, get) => ({
         get().stopPolling()
         set({
           status: 'FAILED',
-          message: 'Failed to fetch indexing status',
+          message: 'Indizierungsstatus konnte nicht abgerufen werden',
           snackbar: {
             open: true,
-            message: 'Failed to fetch indexing status',
+            message: 'Indizierungsstatus konnte nicht abgerufen werden',
             severity: 'error',
           },
         })

--- a/frontend/src/stores/workspaceStore.test.ts
+++ b/frontend/src/stores/workspaceStore.test.ts
@@ -17,7 +17,7 @@ vi.mock('../services/api', () => ({
     },
     {
       id: 'ws-personal',
-      name: 'My Documents',
+      name: 'Meine Dokumente',
       description: 'Private',
       type: 'PERSONAL',
       memberCount: 1,
@@ -28,7 +28,7 @@ vi.mock('../services/api', () => ({
   ]),
   getWorkspace: vi.fn(async (workspaceId: string) => ({
     id: workspaceId,
-    name: 'My Documents',
+    name: 'Meine Dokumente',
     description: 'Private',
     type: 'PERSONAL',
     ownerId: 'u1',
@@ -60,7 +60,7 @@ describe('workspaceStore', () => {
   it('sorts personal workspace first', async () => {
     await useWorkspaceStore.getState().loadWorkspaces()
     const names = useWorkspaceStore.getState().workspaces.map((workspace) => workspace.name)
-    expect(names[0]).toBe('My Documents')
+    expect(names[0]).toBe('Meine Dokumente')
   })
 
   it('updates chat filter selection', () => {

--- a/frontend/src/stores/workspaceStore.ts
+++ b/frontend/src/stores/workspaceStore.ts
@@ -85,7 +85,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         isLoadingList: false,
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load workspaces'
+      const message = err instanceof Error ? err.message : 'Workspaces konnten nicht geladen werden'
       set({ error: message, isLoadingList: false })
     }
   },
@@ -103,7 +103,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         isLoadingDetails: false,
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load workspace details'
+      const message =
+        err instanceof Error ? err.message : 'Workspace-Details konnten nicht geladen werden'
       set({
         error: message,
         selectedWorkspace: null,

--- a/frontend/src/utils/labels.ts
+++ b/frontend/src/utils/labels.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceRole, WorkspaceType } from '../types/api'
+import type { AccessLevel } from '../types/chat'
+
+const workspaceRoleLabels: Record<WorkspaceRole, string> = {
+  VIEWER: 'Leser',
+  EDITOR: 'Bearbeiter',
+  ADMIN: 'Administrator',
+  OWNER: 'Eigentümer',
+}
+
+const workspaceTypeLabels: Record<WorkspaceType, string> = {
+  PERSONAL: 'Persönlich',
+  SHARED: 'Geteilt',
+}
+
+export function workspaceRoleLabel(role: WorkspaceRole | string | undefined): string {
+  if (!role) return ''
+  return workspaceRoleLabels[role as WorkspaceRole] ?? role
+}
+
+export function workspaceTypeLabel(type: WorkspaceType | string | undefined): string {
+  if (!type) return ''
+  return workspaceTypeLabels[type as WorkspaceType] ?? type
+}
+
+const accessLevelLabels: Record<AccessLevel, string> = {
+  Public: 'Öffentlich',
+  Internal: 'Intern',
+  Confidential: 'Vertraulich',
+}
+
+export function accessLevelLabel(level: AccessLevel): string {
+  return accessLevelLabels[level]
+}


### PR DESCRIPTION
## Zusammenfassung

Alle in der Anwendung sichtbaren Texte sind jetzt deutsch. Bezeichner, Dateinamen, Kommentare und Log-Ausgaben bleiben englisch — entsprechend der Sprachregel aus #219.

**Frontend**

- Seiten, Layouts und Komponenten inklusive `aria-label`-Attribute
- Neue Label-Zuordnung in `frontend/src/utils/labels.ts` übersetzt die Enum-Werte für Workspace-Rolle, Workspace-Typ und Zugriffsstufe nur für die Anzeige — die API-Werte bleiben unverändert
- Datumsformatierung auf `de-DE` festgelegt (vorher Browser-Locale beziehungsweise `undefined`)
- Fehlermeldungen in den Stores sowie MSW-Mocks und Fixtures
- Tests auf die deutschen Texte angepasst

**Backend**

- API-Fehlermeldungen in `GlobalExceptionHandler`, den Controllern und `WorkspaceService`
- Der persönliche Standard-Workspace heißt jetzt „Meine Dokumente"
- Feste Locale `de_DE`, damit Bean-Validation-Meldungen unabhängig vom `Accept-Language`-Header deutsch sind
- UTF-8 für `JavaCompile`- und `Test`-Tasks: ohne diese Einstellung nutzt javac das Plattform-Encoding und verfälscht Umlaute auf Windows

## Hinweise

- Kein i18n-Framework — die Texte stehen direkt im Code. Eine spätere Umstellung auf i18n bleibt möglich.
- Der Migrationseffekt auf bestehende Installationen ist auf neu angelegte persönliche Workspaces beschränkt; bereits vorhandene behalten ihren Namen.
- `AdminDrawer > labels the URL source fields for assistive technology` schlägt weiterhin fehl. Der Fehler besteht bereits auf `main` (MUI rendert den Switch mit `role="checkbox"` statt `role="switch"`) und ist unabhängig von diesem PR.

## Zugehörige Issues

Closes #221

## Art der Änderung

- [ ] Bugfix
- [x] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal — Backend: 207 Tests, 0 Fehler, 1 übersprungen. Frontend: 122 von 123 grün (der eine Fehler ist der oben genannte vorbestehende).
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF