### PR TITLE
fix(ci): CLA-Workflow nur für Pull-Request-Kommentare ausführen

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   cla-check:
+    # issue_comment feuert auch bei Kommentaren auf gewöhnlichen Issues. Die
+    # CLA-Action erwartet dort einen Pull Request und bricht ab, daher der Filter.
+    if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
## Zusammenfassung

Der CLA-Workflow war auf `main` rot — nicht der Build. Der Trigger `issue_comment` feuert bei jedem Kommentar, auch bei Kommentaren auf gewöhnlichen Issues. Die CLA-Action erwartet dort einen Pull Request und bricht ab:

```
##[error]graphql call to get the committers details failed:
GraphqlError: Could not resolve to a PullRequest with the number of 243.
```

Betroffen waren die Kommentare zu #239, #241, #242 und #243 — sieben fehlgeschlagene Läufe. Der eigentliche CI-Workflow ist auf allen Push-Läufen von `main` grün, zuletzt nach dem Merge von #223.

Der Job läuft bei `issue_comment` jetzt nur noch, wenn `github.event.issue.pull_request` gesetzt ist. Für `pull_request_target` bleibt alles unverändert, und die Signatur per PR-Kommentar funktioniert weiterhin.

## Zugehörige Issues

Closes #245

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (reine Workflow-Änderung; YAML-Syntax und Ausdruck geprüft)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF