### PR TITLE
test(e2e): Grundgerüst für browserbasierte End-to-End-Tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # Keeps the pipeline promise from AGENTS.md/e2e/README.md: the suite runs
+    # on every PR only as long as it stays comfortably under 10 minutes.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E suite
+        working-directory: e2e
+        run: npm test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload traces & screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: e2e/test-results/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,15 +3,63 @@ name: E2E
 on:
   pull_request:
     branches: [main]
+    # Building the full stack is the expensive part of this workflow (see
+    # "Build backend/frontend images" below); skip it for changes that can't
+    # affect the running app, matching the AGENTS.md pre-push rule of
+    # skipping checks for pure documentation changes.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+  push:
+    branches: [main]
+  schedule:
+    # Post-merge QA loop (see docs/AGENT-ORGANIZATION.md): catches
+    # regressions from base image updates etc. even without a new PR.
+    - cron: '17 3 * * *'
+
+env:
+  COMPOSE_PROJECT_NAME: opaa-e2e
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    # Keeps the pipeline promise from AGENTS.md/e2e/README.md: the suite runs
-    # on every PR only as long as it stays comfortably under 10 minutes.
-    timeout-minutes: 10
+    # Suite budget from #231 is 10 minutes for the *test run*; the image
+    # build below is intentionally outside that budget (see e2e/README.md)
+    # and sped up with a GitHub Actions layer cache, but still needs its own
+    # margin. Re-evaluate this number as the suite grows.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Pre-build the images with a GitHub Actions layer cache and load them
+      # into the local Docker daemon, tagged exactly as Compose would name
+      # them for project "opaa-e2e" (<project>-<service>:latest). run-e2e.mjs
+      # then runs with E2E_SKIP_BUILD=true and reuses these images instead of
+      # rebuilding, which is what keeps the actual `docker compose up`
+      # (and thus the suite run) fast and within the #231 time budget.
+      - name: Build backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile
+          tags: opaa-e2e-backend:latest
+          load: true
+          cache-from: type=gha,scope=e2e-backend
+          cache-to: type=gha,mode=max,scope=e2e-backend
+
+      - name: Build frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          tags: opaa-e2e-frontend:latest
+          load: true
+          cache-from: type=gha,scope=e2e-frontend
+          cache-to: type=gha,mode=max,scope=e2e-frontend
 
       - uses: actions/setup-node@v4
         with:
@@ -23,6 +71,10 @@ jobs:
         working-directory: e2e
         run: npm ci
 
+      - name: Type-check E2E suite
+        working-directory: e2e
+        run: npm run typecheck
+
       - name: Install Playwright browsers
         working-directory: e2e
         run: npx playwright install --with-deps chromium
@@ -30,19 +82,36 @@ jobs:
       - name: Run E2E suite
         working-directory: e2e
         run: npm test
+        env:
+          E2E_SKIP_BUILD: 'true'
 
+      # if: !cancelled() (not failure()) on purpose: when the job hits
+      # timeout-minutes, GitHub marks it cancelled, not failed, and
+      # if: failure() would silently skip artifact upload in exactly the
+      # case investigators need it most.
       - name: Upload Playwright report
-        if: failure()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: e2e/playwright-report/
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Upload traces & screenshots
-        if: failure()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-traces
           path: e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload container logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-logs
+          path: e2e/docker-compose.log
+          if-no-files-found: ignore
           retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,11 @@ npm run lint                            # Lint (ESLint)
 npm run test                            # Tests (Vitest)
 npm run format:check                    # Prettier-Formatierung prüfen
 npm run format                          # Automatisch mit Prettier formatieren
+
+# E2E-Suite (aus e2e/, siehe e2e/README.md)
+npm ci                                  # Abhängigkeiten installieren
+npx playwright install --with-deps chromium   # Browser installieren (einmalig)
+npm test                                # Stack via Docker Compose starten, Suite ausführen, Stack wieder stoppen
 ```
 
 ## Abhängigkeitsverwaltung
@@ -155,6 +160,7 @@ Bei reinen Dokumentationsänderungen überspringen. Vor jedem Push müssen alle 
 - `backend/` — Spring Boot Backend (Gradle-Projekt)
 - `frontend/` — React-Frontend (Vite-Projekt)
 - `frontend/src/test/test-utils.tsx` — Gemeinsame Test-Render-Helfer
+- `e2e/` — Browserbasierte End-to-End-Tests (Playwright), siehe `e2e/README.md`
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,29 @@ docs: update architecture decision records
 - Zugehörige GitHub-Issues mit `Closes #N` verknüpfen
 - Sicherstellen, dass Tests bestehen, bevor ein Review angefordert wird
 
+## Wann einen E2E-Test schreiben?
+
+Die browserbasierte End-to-End-Suite liegt unter [`e2e/`](e2e/README.md) (Playwright) und ist laut
+[`docs/AGENT-ORGANIZATION.md`](docs/AGENT-ORGANIZATION.md) Sache des QA-Engineer-Agenten, der aus
+den Abnahmekriterien eines Feature-Issues dedizierte `test(e2e)`-Issues ableitet — nicht jeder PR
+braucht einen eigenen E2E-Test. Ein E2E-Test lohnt sich für:
+
+- **Kritische, nutzersichtbare Abläufe end-to-end** (Anmeldung, Dokument indizieren, Frage stellen
+  und Antwort erhalten) — Dinge, die durch Unit-/Integrationstests allein nicht abgedeckt sind,
+  weil sie Frontend, Backend und Datenbank gemeinsam durchlaufen.
+- **Regressionen, die nur im Zusammenspiel mehrerer Schichten auftreten** (z. B. CORS-Konfiguration,
+  Auth-Redirects, Routing).
+
+Kein E2E-Test nötig für:
+
+- Reine Komponentenlogik oder isolierte Backend-Logik — dafür Vitest (Frontend) bzw. JUnit
+  (Backend) verwenden.
+- Visuelle Details oder Layout-Feinheiten (explizit außerhalb des Scopes der Suite).
+- Fälle, die sich genauso zuverlässig und schneller mit einem Integrationstest abdecken lassen.
+
+Neue Szenarien nutzen die vorhandenen Fixtures (z. B. die Anmeldung aus `e2e/fixtures/auth.ts`)
+statt sie zu kopieren; siehe `e2e/README.md` für Details zum lokalen Ausführen.
+
 ## Issues
 
 - **Issues müssen auf Deutsch verfasst werden** — ebenso Pull Requests und Dokumentation. Englisch bleibt dem Quellcode vorbehalten (Bezeichner, Dateinamen, Kommentare); Details in [AGENTS.md](AGENTS.md#projektsprache)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,9 @@ Kein E2E-Test nötig für:
 - Fälle, die sich genauso zuverlässig und schneller mit einem Integrationstest abdecken lassen.
 
 Neue Szenarien nutzen die vorhandenen Fixtures (z. B. die Anmeldung aus `e2e/fixtures/auth.ts`)
-statt sie zu kopieren; siehe `e2e/README.md` für Details zum lokalen Ausführen.
+statt sie zu kopieren; siehe `e2e/README.md` für Details zum lokalen Ausführen, die
+Selektor-Konvention (`getByRole`/`getByLabel` vor `data-testid` vor Text-/Placeholder-Selektoren)
+und die Serialisierungs-Konvention für Specs, die gemeinsamen Zustand verändern.
 
 ## Issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,18 @@
 services:
   postgres:
     image: pgvector/pgvector:pg18
-    container_name: opaa-postgres
-    env_file: .env.docker
+    # No fixed container_name: Compose prefixes container/network/volume
+    # names with the project name (directory name, or COMPOSE_PROJECT_NAME)
+    # instead, so this file can run as multiple independent stacks side by
+    # side (e.g. a developer's own dev stack and the E2E suite's stack, see
+    # e2e/scripts/run-e2e.mjs) without colliding.
+    env_file: ${OPAA_ENV_FILE:-.env.docker}
     environment:
       POSTGRES_DB: opaa
       POSTGRES_USER: ${OPAA_DB_USERNAME:-opaa}
       POSTGRES_PASSWORD: ${OPAA_DB_PASSWORD:-opaa}
     ports:
-      - "5432:5432"
+      - "${OPAA_DB_PORT:-5432}:5432"
     volumes:
       - opaa-postgres-data:/var/lib/postgresql
     healthcheck:
@@ -22,8 +26,7 @@ services:
 
   backend:
     build: ./backend
-    container_name: opaa-backend
-    env_file: .env.docker
+    env_file: ${OPAA_ENV_FILE:-.env.docker}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
@@ -38,7 +41,6 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
-    container_name: opaa-frontend
     ports:
       - "${OPAA_FRONTEND_PORT:-3000}:80"
     depends_on:
@@ -46,14 +48,13 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
-    container_name: opaa-keycloak
     command: start-dev --import-realm
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HTTP_PORT: 8180
     ports:
-      - "8180:8180"
+      - "${OPAA_KEYCLOAK_PORT:-8180}:8180"
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_USER: ${OPAA_DB_USERNAME:-opaa}
       POSTGRES_PASSWORD: ${OPAA_DB_PASSWORD:-opaa}
     ports:
-      - "${OPAA_DB_PORT:-5432}:5432"
+      - "127.0.0.1:${OPAA_DB_PORT:-5432}:5432"
     volumes:
       - opaa-postgres-data:/var/lib/postgresql
     healthcheck:

--- a/docs/MVP-VERIFICATION.md
+++ b/docs/MVP-VERIFICATION.md
@@ -82,7 +82,7 @@ Die GitHub-Actions-Pipeline (`.github/workflows/ci.yml`) läuft bei jedem Push u
    docker compose ps
    ```
 
-   Erwartet: `opaa-postgres` (healthy), `opaa-backend` (running), `opaa-frontend` (running)
+   Erwartet: `opaa-postgres-1` (healthy), `opaa-backend-1` (running), `opaa-frontend-1` (running)
 
 4. **Backend-Gesundheit prüfen:**
 

--- a/docs/decisions/0009-e2e-teststrategie.md
+++ b/docs/decisions/0009-e2e-teststrategie.md
@@ -1,0 +1,113 @@
+# ADR-0009: E2E-Teststrategie
+
+## Status
+
+Vorgeschlagen
+
+## Kontext
+
+Issue #231 verlangt ein Grundgerüst für browserbasierte End-to-End-Tests, auf dem #232 und #233
+(Indizierung und Suche im Demo-Korpus) sowie spätere `test(e2e)`-Issues aufbauen. Das Repository
+hatte zuvor keinerlei E2E-Infrastruktur (`backend/src/test/.../integration/` enthält nur einen
+OpenAI-Integrationstest). Für das Grundgerüst waren vier zusammenhängende Entscheidungen nötig,
+die über die reine Werkzeugwahl hinausgehen und Folgeissues betreffen:
+
+1. Welches Test-Werkzeug?
+2. Wie wird der volle Stack (Postgres, Backend, Frontend) für einen Testlauf orchestriert?
+3. Welcher Auth-Modus wird für die Suite verwendet?
+4. Woher kommen die KI-Modelle (Chat/Embedding) während eines Testlaufs?
+
+## Entscheidung
+
+### 1. Playwright, Chromium-only, eigenes Verzeichnis mit eigenem Lockfile
+
+`e2e/` ist ein eigenständiges npm-Projekt (eigenes `package.json`/`package-lock.json`, nicht Teil
+von `frontend/`), TypeScript-first, mit [Playwright](https://playwright.dev/). Begründung und
+Alternativen in `e2e/README.md#werkzeugwahl`. Die Suite startet bewusst nur mit dem
+`chromium`-Projekt; weitere Browser-Engines lassen sich in `playwright.config.ts` bei Bedarf
+ergänzen, ohne die übrige Struktur zu ändern.
+
+### 2. Vollständiger Stack pro Lauf, in einem eigenen Compose-Projekt
+
+`scripts/run-e2e.mjs` startet Postgres, Backend und Frontend über das bestehende
+`docker-compose.yml` (dieselben Dockerfiles wie für Produktions-Images), nicht über Testcontainers
+oder eine separate Compose-Datei. Das hält den Testkontext realitätsnah (echte Nginx-Reverse-Proxy-
+Konfiguration, echter Container-Build) und vermeidet eine zweite, potenziell abweichende
+Infrastrukturdefinition.
+
+Damit der Stack unabhängig von einem parallel laufenden Dev-Stack (`AGENTS.md` "Git Worktrees für
+parallele Sessions" beschreibt genau dieses Parallel-Szenario als Normalfall) betrieben werden
+kann, läuft er als **eigenes Compose-Projekt** (`COMPOSE_PROJECT_NAME=opaa-e2e`) mit **eigenen
+Host-Ports** und einem **eigenen Environment** (`e2e/e2e.env`, niemals `.env.docker`). Dafür wurde
+`docker-compose.yml` in zwei kleinen, rückwärtskompatiblen Punkten angepasst: die vier
+`container_name`-Festlegungen wurden entfernt (Compose vergibt sonst projektpräfixierte Namen von
+selbst) und `env_file` sowie der Postgres-Port wurden parametrisierbar gemacht
+(`${OPAA_ENV_FILE:-.env.docker}`, `${OPAA_DB_PORT:-5432}`) — beides ändert das Verhalten für
+bestehende `docker compose up`-Nutzung nicht (Standardwerte identisch zum vorherigen Verhalten).
+
+Jeder Lauf beginnt und endet mit `docker compose down -v` unter diesem Projektnamen — eine
+definierte, reproduzierbare Ausgangslage, ohne Container oder Volumes fremder Projekte anzufassen.
+`scripts/run-e2e.mjs` registriert `SIGINT`/`SIGTERM`-Handler, die denselben Teardown auslösen, damit
+ein abgebrochener Lauf (`Strg+C`, CI-Cancel) keinen laufenden Stack hinterlässt.
+
+Ein per Lauf zufällig erzeugtes JWT-Signing-Secret (`OPAA_AUTH_BASIC_SECRET`, siehe Punkt 3) wird
+ausschließlich über die Prozessumgebung durchgereicht und nie in eine Datei geschrieben.
+
+### 3. Auth-Modus `basic`, nicht `mock`
+
+Der dokumentierte Standard-Modus `mock` (ADR-0005: "Kein Auth — alle Anfragen erlaubt") ist im
+Backend nicht als eigenständiger, funktionierender Pfad implementiert: Es existieren nur zwei
+`SecurityFilterChain`-Beans (`@Profile("basic")`, `@Profile("oidc")`); ohne eines der beiden aktiven
+Spring-Profile bleibt Spring Boots generische Security-Auto-Konfiguration aktiv (blockt alle
+Anfragen) und die Fach-Controller (`WorkspaceController`, `UserInfoController`, `AdminController`,
+`UserService`, alle `@Profile({"oidc","basic"})`) existieren gar nicht als Beans. `mock` ist für den
+vollständig über Docker Compose laufenden E2E-Stack damit nicht nutzbar — dieser Mangel liegt im
+Produkt, nicht in der Teststrategie (siehe Follow-up-Issue "`mock`-Modus funktionsfähig machen oder
+aus Default und Doku entfernen").
+
+Die Suite verwendet daher `basic`: kein externer Identity-Provider (im Gegensatz zu `oidc`, das
+zusätzlich Keycloak bräuchte), ein Testnutzer mit fest hinterlegtem Benutzernamen/Passwort in
+`e2e/e2e.env` (keine echten Secrets) und ein pro Lauf zufällig erzeugtes Signing-Secret (Punkt 2).
+Der Testnutzer wird über `OPAA_INITIAL_ADMIN_EMAIL` zum `SYSTEM_ADMIN`, damit Indexing-/
+Admin-Endpunkte für spätere Szenarien erreichbar sind.
+
+### 4. Modelle lokal im Stack statt externer Anbieter
+
+Für das Grundgerüst (#231) genügt ein Platzhalter-API-Key (`OPAA_OPENAI_API_KEY=sk-e2e-placeholder`),
+da der einzige Testfall (Rauchtest) keinen KI-Aufruf auslöst. Sobald #232/#233 tatsächliche
+Chat-/Indizierungs-Läufe brauchen, darf kein Szenario von einem externen, kostenpflichtigen Dienst
+abhängen (Nichtdeterminismus, Kosten, Netzwerkabhängigkeit in CI). Die konkrete Umsetzung (lokaler
+Ollama-Service im Compose-Stack vs. OpenAI-kompatibler Stub) ist bewusst nicht Teil dieses ADRs,
+sondern eines eigenen, blockierenden Issues ("Lokale Modellbereitstellung für den E2E-Stack").
+
+## Konsequenzen
+
+### Positiv
+
+- Der E2E-Stack kann beliebig oft parallel zu einem Dev-Stack auf derselben Maschine laufen, ohne
+  Container, Volumes oder Ports zu teilen — verifiziert durch einen manuellen Test mit einem
+  simulierten, gleichnamigen Dev-Container.
+- Jeder Lauf startet und endet garantiert mit einem sauberen Compose-Projekt, auch bei Abbruch.
+- Kein Secret landet in einer committeten Datei.
+- Realitätsnahe Tests (echte Docker-Images, echter Nginx-Proxy), keine zweite
+  Infrastrukturdefinition zusätzlich zu `docker-compose.yml`.
+
+### Negativ
+
+- **Der Image-Build dominiert die CI-Zeit**, nicht der Testlauf selbst (der Rauchtest dauert
+  wenige Sekunden). Der CI-Job hat deshalb ein separates, großzügigeres Zeitbudget als die in #231
+  genannten 10 Minuten (die sich auf den Suite-Lauf beziehen); ein GitHub-Actions-Layer-Cache
+  mildert das, ersetzt aber keinen echten Cache über Runner-Neustarts hinweg.
+- **`basic` unterstützt aktuell nur einen konfigurierten Nutzer.** Szenarien, die einen
+  nicht-privilegierten Zweitnutzer brauchen (z. B. Berechtigungsprüfungen), sind mit dieser
+  Grundlage nicht abbildbar, ohne entweder die Backend-Konfiguration zu erweitern (mehrere
+  `opaa.auth.basic.users`-Einträge) oder auf Workspace-Rollenwechsel auszuweichen.
+- **`mock` bleibt ungetestet.** Solange der Produktmangel aus Punkt 3 nicht behoben ist, deckt die
+  E2E-Suite den dokumentierten Standard-Auth-Modus nicht ab.
+- Der zufällig generierte Signing-Secret bedeutet, dass zwischen zwei Läufen ausgestellte Tokens
+  nicht wiederverwendbar sind — für eine Suite, die pro Lauf ohnehin frisch anmeldet, ohne Nachteil.
+
+### Neutral
+
+- Diese Entscheidungen gelten für die E2E-Suite; sie ändern nichts an `docker-compose.yml`s
+  Verhalten für reguläre Dev-/Deployment-Nutzung (Standardwerte bleiben unverändert).

--- a/docs/decisions/0009-e2e-teststrategie.md
+++ b/docs/decisions/0009-e2e-teststrategie.md
@@ -39,11 +39,15 @@ Damit der Stack unabhängig von einem parallel laufenden Dev-Stack (`AGENTS.md` 
 parallele Sessions" beschreibt genau dieses Parallel-Szenario als Normalfall) betrieben werden
 kann, läuft er als **eigenes Compose-Projekt** (`COMPOSE_PROJECT_NAME=opaa-e2e`) mit **eigenen
 Host-Ports** und einem **eigenen Environment** (`e2e/e2e.env`, niemals `.env.docker`). Dafür wurde
-`docker-compose.yml` in zwei kleinen, rückwärtskompatiblen Punkten angepasst: die vier
-`container_name`-Festlegungen wurden entfernt (Compose vergibt sonst projektpräfixierte Namen von
-selbst) und `env_file` sowie der Postgres-Port wurden parametrisierbar gemacht
-(`${OPAA_ENV_FILE:-.env.docker}`, `${OPAA_DB_PORT:-5432}`) — beides ändert das Verhalten für
-bestehende `docker compose up`-Nutzung nicht (Standardwerte identisch zum vorherigen Verhalten).
+`docker-compose.yml` in drei Punkten angepasst: `env_file` sowie der Postgres-Port wurden
+parametrisierbar gemacht (`${OPAA_ENV_FILE:-.env.docker}`, `${OPAA_DB_PORT:-5432}`) — das ändert
+das Verhalten für bestehende `docker compose up`-Nutzung nicht (Standardwerte identisch zum
+vorherigen Verhalten; die `:-`-Form bleibt auch bei einer gesetzten, aber leeren Variable
+verhaltensneutral). Zusätzlich wurden die vier `container_name`-Festlegungen entfernt (Compose
+vergibt sonst projektpräfixierte Namen von selbst) — **das ändert das Verhalten für bestehende
+Nutzung einmalig**: Container heißen fortan `opaa-postgres-1`/`opaa-backend-1`/`opaa-frontend-1`
+statt `opaa-postgres`/`opaa-backend`/`opaa-frontend` (`docs/MVP-VERIFICATION.md` entsprechend
+aktualisiert; wer selbst Skripte oder Aliase mit den alten Namen hat, muss sie anpassen).
 
 Jeder Lauf beginnt und endet mit `docker compose down -v` unter diesem Projektnamen — eine
 definierte, reproduzierbare Ausgangslage, ohne Container oder Volumes fremder Projekte anzufassen.
@@ -106,8 +110,11 @@ sondern eines eigenen, blockierenden Issues ("Lokale Modellbereitstellung für d
   E2E-Suite den dokumentierten Standard-Auth-Modus nicht ab.
 - Der zufällig generierte Signing-Secret bedeutet, dass zwischen zwei Läufen ausgestellte Tokens
   nicht wiederverwendbar sind — für eine Suite, die pro Lauf ohnehin frisch anmeldet, ohne Nachteil.
+- **Die E2E-Suite hängt jetzt an `docker-compose.yml`.** Jede künftige Änderung an den Service-
+  Definitionen dort (z. B. neue Pflicht-Umgebungsvariablen, geänderte Ports, neue Abhängigkeiten)
+  kann die Suite brechen, ohne dass das beim Ändern von `docker-compose.yml` offensichtlich ist.
 
 ### Neutral
 
-- Diese Entscheidungen gelten für die E2E-Suite; sie ändern nichts an `docker-compose.yml`s
-  Verhalten für reguläre Dev-/Deployment-Nutzung (Standardwerte bleiben unverändert).
+- Ports und Environment-Handling ändern sich für bestehende `docker compose up`-Nutzung nicht
+  (Standardwerte identisch); die Container-Namen ändern sich einmalig (siehe Punkt 2).

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,92 @@
+# E2E-Suite
+
+Browserbasierte End-to-End-Tests für OPAA mit [Playwright](https://playwright.dev/).
+
+## Werkzeugwahl
+
+**Playwright** statt Cypress, Selenium o. ä.:
+
+- TypeScript-first, passt zum bestehenden Frontend-Stack (React + TypeScript + Vite).
+- Ein Test-Runner für mehrere Browser-Engines (Chromium, Firefox, WebKit); die Suite startet
+  hier bewusst nur mit Chromium — ausreichend für ein Grundgerüst, weitere Projekte lassen sich
+  in `playwright.config.ts` jederzeit ergänzen.
+- Eingebauter Trace-Viewer (`npx playwright show-trace`) und automatische Trace-/Screenshot-Erfassung
+  bei Fehlschlägen, ohne zusätzliche Tooling-Integration.
+- Gute CI-Unterstützung (offizielles `playwright install --with-deps`, Artefakt-Upload).
+
+## Verzeichnisstruktur
+
+```
+e2e/
+  fixtures/         Wiederverwendbare Playwright-Fixtures (z. B. Anmeldung)
+  tests/            Testfälle (*.spec.ts)
+  scripts/run-e2e.mjs   Orchestrierung: Stack starten → Suite ausführen → Stack stoppen
+  e2e.env          Environment für den Docker-Compose-Stack der Suite
+  playwright.config.ts
+```
+
+Neue Szenarien kommen als weitere `*.spec.ts`-Dateien unter `tests/`; neue wiederverwendbare
+Bausteine (z. B. Seiten-Interaktionen) gehören nach `fixtures/`.
+
+## Lokal ausführen
+
+Voraussetzung: Docker Desktop (bzw. Docker Engine + Compose) läuft.
+
+```bash
+cd e2e
+npm ci
+npx playwright install --with-deps chromium   # einmalig
+npm test
+```
+
+`npm test` (→ `scripts/run-e2e.mjs`) übernimmt den gesamten Lebenszyklus:
+
+1. Bestehende Container mit den Namen `opaa-postgres`/`opaa-backend`/`opaa-frontend` entfernen und
+   `docker compose down -v` ausführen (definierte Ausgangslage).
+2. `e2e/e2e.env` temporär als `.env.docker` im Projekt-Root installieren (eine eventuell vorhandene
+   eigene `.env.docker` wird gesichert und am Ende wiederhergestellt).
+3. `docker compose up -d --build postgres backend frontend` und auf Erreichbarkeit warten.
+4. `playwright test` ausführen.
+5. Stack wieder stoppen (`down -v`) und die eigene `.env.docker` wiederherstellen — auch bei
+   fehlgeschlagenen Tests oder Abbrüchen.
+
+Um nur Playwright gegen einen bereits laufenden Stack auszuführen (z. B. während der Entwicklung
+eines neuen Tests): `npm run test:playwright` (kein Docker-Lifecycle, erwartet den Stack unter
+`http://localhost:3000`, überschreibbar via `E2E_BASE_URL`).
+
+### Verifizieren, dass der Rauchtest bei nicht erreichbarem Frontend fehlschlägt
+
+```bash
+cd e2e
+npx playwright test   # ohne laufenden Stack
+```
+
+Der Test schlägt mit `net::ERR_CONNECTION_REFUSED` fehl und legt Trace/Screenshot ab.
+
+## Warum `basic` statt `mock`-Auth?
+
+OPAA unterstützt drei Auth-Modi (`opaa.auth.mode`: `mock`, `basic`, `oidc`). Für die E2E-Suite
+wurde bewusst **`basic`** gewählt, nicht der Standard-Modus `mock`:
+
+- `mock` ist im Backend nur als Frontend-Signal implementiert (`/api/v1/auth/config` meldet
+  `mode: mock`, das Frontend überspringt daraufhin die Login-Seite) — es aktiviert keinen
+  eigenen Security-/Controller-Satz. Die Fach-Controller (`WorkspaceController` usw.) sind mit
+  `@Profile({"oidc", "basic"})` annotiert und existieren ohne aktives Spring-Profil `basic`/`oidc`
+  gar nicht; ohne eines der beiden bleibt außerdem Spring Boots generische
+  Security-Auto-Konfiguration aktiv und blockt alle Anfragen. `mock` ist für den vollständig über
+  Docker Compose laufenden Stack der E2E-Suite also nicht nutzbar.
+- `oidc` bräuchte zusätzlich Keycloak (siehe `docker-compose.yml`, Profil `oidc`) — mehr
+  bewegliche Teile, mehr Startzeit, ohne zusätzlichen Testwert für dieses Grundgerüst.
+- `basic` ist der einfachste Modus, der tatsächlich End-to-End funktioniert: kein externer
+  Identity-Provider, feste Testnutzer-Zugangsdaten in `e2e.env` (siehe `OPAA_AUTH_BASIC_USERNAME`/
+  `OPAA_AUTH_BASIC_PASSWORD`, keine echten Secrets), und er übt das echte Login-Formular
+  (`frontend/src/pages/LoginPage.tsx`) aus.
+
+`e2e/fixtures/auth.ts` kapselt den Login-Ablauf als einzigen wiederverwendbaren Baustein; künftige
+Szenarien nutzen die `authenticatedPage`-Fixture, statt die Anmeldung zu kopieren.
+
+## CI
+
+`.github/workflows/e2e.yml` führt die Suite bei jedem Pull Request aus (Zeitbudget: 10 Minuten).
+Bei Fehlschlägen werden der Playwright-HTML-Report sowie Traces/Screenshots als Workflow-Artefakte
+hochgeladen.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,6 +2,10 @@
 
 Browserbasierte End-to-End-Tests für OPAA mit [Playwright](https://playwright.dev/).
 
+Architektur- und Modellentscheidungen für diese Suite sind in
+[`docs/decisions/0009-e2e-teststrategie.md`](../docs/decisions/0009-e2e-teststrategie.md)
+festgehalten (ADR).
+
 ## Werkzeugwahl
 
 **Playwright** statt Cypress, Selenium o. ä.:
@@ -18,10 +22,11 @@ Browserbasierte End-to-End-Tests für OPAA mit [Playwright](https://playwright.d
 
 ```
 e2e/
-  fixtures/         Wiederverwendbare Playwright-Fixtures (z. B. Anmeldung)
-  tests/            Testfälle (*.spec.ts)
-  scripts/run-e2e.mjs   Orchestrierung: Stack starten → Suite ausführen → Stack stoppen
-  e2e.env          Environment für den Docker-Compose-Stack der Suite
+  fixtures/                 Wiederverwendbare Playwright-Fixtures (z. B. Anmeldung)
+  tests/                    Testfälle (*.spec.ts)
+  scripts/run-e2e.mjs       Orchestrierung: Stack starten → Suite ausführen → Stack stoppen
+  e2e.env                   Environment für den Docker-Compose-Stack der Suite (kein Secret enthalten)
+  docker-compose.e2e.yml    Compose-Overlay: Secret-Injektion + dynamische CORS-Origin
   playwright.config.ts
 ```
 
@@ -41,18 +46,29 @@ npm test
 
 `npm test` (→ `scripts/run-e2e.mjs`) übernimmt den gesamten Lebenszyklus:
 
-1. Bestehende Container mit den Namen `opaa-postgres`/`opaa-backend`/`opaa-frontend` entfernen und
-   `docker compose down -v` ausführen (definierte Ausgangslage).
-2. `e2e/e2e.env` temporär als `.env.docker` im Projekt-Root installieren (eine eventuell vorhandene
-   eigene `.env.docker` wird gesichert und am Ende wiederhergestellt).
-3. `docker compose up -d --build postgres backend frontend` und auf Erreichbarkeit warten.
-4. `playwright test` ausführen.
-5. Stack wieder stoppen (`down -v`) und die eigene `.env.docker` wiederherstellen — auch bei
-   fehlgeschlagenen Tests oder Abbrüchen.
+1. `docker compose down -v` für das **eigene** Compose-Projekt `opaa-e2e` (definierte Ausgangslage;
+   siehe "Isolation von einem laufenden Dev-Stack" unten).
+2. `docker compose up -d --build postgres backend frontend` unter diesem Projektnamen, mit eigenen
+   Host-Ports und `e2e/e2e.env` als Environment (siehe unten), und Warten auf Erreichbarkeit.
+3. `playwright test` ausführen.
+4. Stack wieder stoppen (`down -v`) — auch bei fehlgeschlagenen Tests, Abbrüchen (`Strg+C` /
+   `SIGINT`/`SIGTERM`) oder Fehlern beim Hochfahren.
 
 Um nur Playwright gegen einen bereits laufenden Stack auszuführen (z. B. während der Entwicklung
 eines neuen Tests): `npm run test:playwright` (kein Docker-Lifecycle, erwartet den Stack unter
 `http://localhost:3000`, überschreibbar via `E2E_BASE_URL`).
+
+### Isolation von einem laufenden Dev-Stack
+
+Der E2E-Stack läuft als **eigenes Compose-Projekt** (`COMPOSE_PROJECT_NAME=opaa-e2e`) auf **eigenen
+Host-Ports** (Postgres `15432`, Backend `18081`, Frontend `13000`, überschreibbar via
+`OPAA_DB_PORT`/`OPAA_BACKEND_PORT`/`OPAA_FRONTEND_PORT`) und mit einem **eigenen Environment**
+(`e2e/e2e.env`, nie `.env.docker`). `docker-compose.yml` selbst hat keine festen `container_name`-
+Werte mehr — Compose präfixiert Container-, Netzwerk- und Volume-Namen automatisch mit dem
+Projektnamen. Ein parallel laufender Dev-Stack (`docker compose up`, Standardprojekt) wird von
+`npm test` also weder gestoppt noch entfernt, und umgekehrt. Das wurde manuell verifiziert: ein
+mit dem Namen `opaa-postgres` laufender Container bleibt während eines vollständigen `npm test`-
+Laufs unangetastet.
 
 ### Verifizieren, dass der Rauchtest bei nicht erreichbarem Frontend fehlschlägt
 
@@ -74,19 +90,77 @@ wurde bewusst **`basic`** gewählt, nicht der Standard-Modus `mock`:
   `@Profile({"oidc", "basic"})` annotiert und existieren ohne aktives Spring-Profil `basic`/`oidc`
   gar nicht; ohne eines der beiden bleibt außerdem Spring Boots generische
   Security-Auto-Konfiguration aktiv und blockt alle Anfragen. `mock` ist für den vollständig über
-  Docker Compose laufenden Stack der E2E-Suite also nicht nutzbar.
+  Docker Compose laufenden Stack der E2E-Suite also nicht nutzbar — siehe Issue "`mock`-Modus
+  funktionsfähig machen oder aus Default und Doku entfernen" für den zugrunde liegenden Produktmangel.
 - `oidc` bräuchte zusätzlich Keycloak (siehe `docker-compose.yml`, Profil `oidc`) — mehr
   bewegliche Teile, mehr Startzeit, ohne zusätzlichen Testwert für dieses Grundgerüst.
 - `basic` ist der einfachste Modus, der tatsächlich End-to-End funktioniert: kein externer
-  Identity-Provider, feste Testnutzer-Zugangsdaten in `e2e.env` (siehe `OPAA_AUTH_BASIC_USERNAME`/
+  Identity-Provider, ein fester Testnutzer in `e2e.env` (siehe `OPAA_AUTH_BASIC_USERNAME`/
   `OPAA_AUTH_BASIC_PASSWORD`, keine echten Secrets), und er übt das echte Login-Formular
   (`frontend/src/pages/LoginPage.tsx`) aus.
 
 `e2e/fixtures/auth.ts` kapselt den Login-Ablauf als einzigen wiederverwendbaren Baustein; künftige
 Szenarien nutzen die `authenticatedPage`-Fixture, statt die Anmeldung zu kopieren.
 
+### Secret-Handling
+
+`e2e/e2e.env` enthält absichtlich **kein** `OPAA_AUTH_BASIC_SECRET`. `scripts/run-e2e.mjs` erzeugt
+pro Lauf ein zufälliges JWT-Signing-Secret (`crypto.randomBytes(32)`) und reicht es ausschließlich
+über die Prozessumgebung an `docker-compose.e2e.yml` durch, das es in den Backend-Container
+injiziert. Es landet nie in einer Datei. Username/Passwort des Testnutzers sind unkritisch (nur
+innerhalb des E2E-Stacks gültig) und bleiben deshalb statisch in `e2e.env`.
+
+### Bekannte Einschränkung: nur ein Testnutzer
+
+Das `basic`-Profil (`application.yml`) definiert `opaa.auth.basic.users` derzeit als Liste mit
+genau einem Eintrag, gespeist aus `OPAA_AUTH_BASIC_USERNAME`/`OPAA_AUTH_BASIC_PASSWORD`. Der
+E2E-Stack hat also aktuell nur den einen Testnutzer `e2e-user`, der zugleich über
+`OPAA_INITIAL_ADMIN_EMAIL=e2e-user@opaa.local` zum `SYSTEM_ADMIN` gemacht wird (nötig für
+Indexing-/Admin-Endpunkte). Ein **nicht**-administrativer Zweitnutzer lässt sich damit nicht ohne
+Produktivcode-Änderung abbilden. Szenarien, die einen nicht-privilegierten Nutzer brauchen (z. B.
+Berechtigungsprüfungen), müssen das entweder über eine künftige Erweiterung von
+`opaa.auth.basic.users` auf mehrere Einträge lösen, oder auf Rollenwechsel innerhalb eines
+Workspace-Memberships ausweichen. Siehe auch den Kommentar dazu in Issue #232.
+
+## Serialisierungs-Konvention
+
+`playwright.config.ts` setzt `fullyParallel: false` und `workers: 1`: alle Specs teilen sich einen
+Stack und eine Datenbank. Specs, die globalen Zustand verändern (Indizierungsjobs, Rate-Limiting,
+Workspace-Daten, ...) laufen deshalb **nacheinander**, nie parallel — sonst können sich Läufe
+gegenseitig Daten wegschreiben oder Zähler verfälschen. Neue Spec-Dateien müssen diese Annahme
+nicht selbst absichern; sie dürfen nur nicht versuchen, `test.describe.configure({ mode: 'parallel'
+})` global zu aktivieren.
+
+## Selektor-Konvention
+
+Für neue Assertions bevorzugt in dieser Reihenfolge:
+
+1. `getByRole` (z. B. `getByRole('button', { name: 'Anmelden' })`) — am robustesten, testet
+   zugleich Zugänglichkeit.
+2. `getByLabel` für Formularfelder.
+3. `data-testid` für alles andere, das sich nicht sinnvoll über Rolle/Label fassen lässt.
+
+`getByPlaceholder`/`getByText` auf sichtbaren, für Menschen formulierten Text (wie im aktuellen
+Rauchtest) sind **zu vermeiden**, sobald sich das vermeiden lässt: Sie brechen bei jeder
+Textänderung (inkl. Sonderzeichen wie `…`) und sind kein stabiler Vertrag zwischen Frontend und
+Suite. Das Frontend hat aktuell kein einziges `data-testid`; wer für #232/#233 eine Assertion
+braucht, die sich nicht über Rolle/Label ausdrücken lässt, ergänzt das nötige `data-testid` im
+selben PR.
+
 ## CI
 
-`.github/workflows/e2e.yml` führt die Suite bei jedem Pull Request aus (Zeitbudget: 10 Minuten).
-Bei Fehlschlägen werden der Playwright-HTML-Report sowie Traces/Screenshots als Workflow-Artefakte
-hochgeladen.
+`.github/workflows/e2e.yml` führt die Suite aus bei:
+
+- jedem Pull Request (außer reinen Doku-Änderungen, `paths-ignore`),
+- jedem Push auf `main`,
+- täglich per `schedule` (Post-Merge-QA-Schleife, siehe `docs/AGENT-ORGANIZATION.md`).
+
+Der Job baut Backend- und Frontend-Image zunächst separat mit einem GitHub-Actions-Layer-Cache
+(`docker/build-push-action`, `cache-from/to: type=gha`) und lädt sie lokal, bevor
+`scripts/run-e2e.mjs` mit `E2E_SKIP_BUILD=true` läuft und diese Images wiederverwendet, statt sie
+erneut zu bauen. **Das 10-Minuten-Budget aus #231 bezieht sich auf den Suite-Lauf selbst** (aktuell
+wenige Sekunden), nicht auf den Image-Build davor — der Job hat dafür ein eigenes, großzügigeres
+`timeout-minutes`-Budget.
+
+Bei Fehlschlägen (inkl. Timeout/Cancel) werden Playwright-HTML-Report, Traces/Screenshots sowie die
+Container-Logs (`docker-compose.log`) als Workflow-Artefakte hochgeladen.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -118,9 +118,9 @@ E2E-Stack hat also aktuell nur den einen Testnutzer `e2e-user`, der zugleich üb
 `OPAA_INITIAL_ADMIN_EMAIL=e2e-user@opaa.local` zum `SYSTEM_ADMIN` gemacht wird (nötig für
 Indexing-/Admin-Endpunkte). Ein **nicht**-administrativer Zweitnutzer lässt sich damit nicht ohne
 Produktivcode-Änderung abbilden. Szenarien, die einen nicht-privilegierten Nutzer brauchen (z. B.
-Berechtigungsprüfungen), müssen das entweder über eine künftige Erweiterung von
-`opaa.auth.basic.users` auf mehrere Einträge lösen, oder auf Rollenwechsel innerhalb eines
-Workspace-Memberships ausweichen. Siehe auch den Kommentar dazu in Issue #232.
+Berechtigungsprüfungen), brauchen dafür #260 (mehrere `opaa.auth.basic.users`-Einträge
+konfigurierbar machen) — als Voraussetzung an #232 Szenario 5 verlinkt — oder weichen auf
+Rollenwechsel innerhalb eines Workspace-Memberships aus.
 
 ## Serialisierungs-Konvention
 
@@ -164,3 +164,9 @@ wenige Sekunden), nicht auf den Image-Build davor — der Job hat dafür ein eig
 
 Bei Fehlschlägen (inkl. Timeout/Cancel) werden Playwright-HTML-Report, Traces/Screenshots sowie die
 Container-Logs (`docker-compose.log`) als Workflow-Artefakte hochgeladen.
+
+> **Hinweis für später:** Sollte der `e2e`-Job jemals als Required Check für PRs konfiguriert
+> werden, blockiert `paths-ignore` reine Doku-PRs dauerhaft im Status "pending" (GitHub wartet auf
+> einen Check, der für diese PRs nie ausgelöst wird). In dem Fall muss stattdessen ein separater,
+> immer laufender Skip-Job mit demselben Job-Namen ergänzt werden, der für Doku-only-Änderungen
+> sofort grün durchläuft (Standardmuster für `paths-ignore` + Required Checks).

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -6,8 +6,10 @@ services:
     environment:
       # Per-run JWT signing secret: never persisted to any file. run-e2e.mjs
       # generates it fresh for every run and passes it through the host
-      # process environment only.
-      OPAA_AUTH_BASIC_SECRET: ${OPAA_AUTH_BASIC_SECRET}
+      # process environment only. The ":?" form fails loudly instead of
+      # silently starting the backend with an empty secret if this overlay
+      # is ever invoked manually without going through run-e2e.mjs.
+      OPAA_AUTH_BASIC_SECRET: ${OPAA_AUTH_BASIC_SECRET:?OPAA_AUTH_BASIC_SECRET must be set (see scripts/run-e2e.mjs)}
       # The E2E stack uses its own host ports (see run-e2e.mjs) so it can
       # run alongside a developer's own docker-compose.yml stack; the
       # allowed CORS origin must match the frontend's actual port.

--- a/e2e/docker-compose.e2e.yml
+++ b/e2e/docker-compose.e2e.yml
@@ -1,0 +1,14 @@
+# Overlay applied only by scripts/run-e2e.mjs (`-f docker-compose.yml -f
+# e2e/docker-compose.e2e.yml`), never by a developer's own `docker compose
+# up`.
+services:
+  backend:
+    environment:
+      # Per-run JWT signing secret: never persisted to any file. run-e2e.mjs
+      # generates it fresh for every run and passes it through the host
+      # process environment only.
+      OPAA_AUTH_BASIC_SECRET: ${OPAA_AUTH_BASIC_SECRET}
+      # The E2E stack uses its own host ports (see run-e2e.mjs) so it can
+      # run alongside a developer's own docker-compose.yml stack; the
+      # allowed CORS origin must match the frontend's actual port.
+      OPAA_CORS_ALLOWED_ORIGINS: http://localhost:${OPAA_FRONTEND_PORT}

--- a/e2e/e2e.env
+++ b/e2e/e2e.env
@@ -1,0 +1,34 @@
+# Environment for the Docker Compose stack used by the E2E suite.
+# scripts/run-e2e.mjs installs this file as the root .env.docker for the
+# duration of the run (and restores whatever was there before), so the
+# stack docker-compose.yml starts stays fully decoupled from a developer's
+# own .env.docker.
+#
+# Intentionally tracked in git and safe to commit: throwaway "basic" auth
+# credentials (see README.md "Warum `basic` statt `mock`?"), no real AI
+# secrets. The smoke test never calls the AI provider, so the placeholder
+# key is sufficient for the backend to start.
+
+# Activates docker-specific Spring config (DB host "postgres" instead of
+# "localhost") and the "basic" auth profile (see docs/deployment.md).
+SPRING_PROFILES_ACTIVE=docker,basic
+# Backend must listen on all interfaces to be reachable from the frontend
+# container (default is "localhost", which is loopback-only).
+OPAA_SERVER_ADDRESS=0.0.0.0
+
+OPAA_AI_CHAT_PROVIDER=openai
+OPAA_AI_EMBEDDING_PROVIDER=openai
+OPAA_OPENAI_API_KEY=sk-e2e-placeholder
+
+OPAA_DB_USERNAME=opaa
+OPAA_DB_PASSWORD=opaa
+
+# The frontend is served on :3000 by nginx (see docker-compose.yml); Spring
+# CORS validates the browser's Origin header even for same-origin requests
+# proxied through nginx, so it must match here.
+OPAA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+
+# Test user credentials used by e2e/fixtures/auth.ts. Not real secrets.
+OPAA_AUTH_BASIC_USERNAME=e2e-user
+OPAA_AUTH_BASIC_PASSWORD=e2e-password
+OPAA_AUTH_BASIC_SECRET=e2e-suite-only-jwt-signing-secret-not-for-production-0123456789

--- a/e2e/e2e.env
+++ b/e2e/e2e.env
@@ -1,13 +1,14 @@
 # Environment for the Docker Compose stack used by the E2E suite.
-# scripts/run-e2e.mjs installs this file as the root .env.docker for the
-# duration of the run (and restores whatever was there before), so the
-# stack docker-compose.yml starts stays fully decoupled from a developer's
-# own .env.docker.
+# scripts/run-e2e.mjs passes this file as OPAA_ENV_FILE (see
+# docker-compose.yml: `env_file: ${OPAA_ENV_FILE:-.env.docker}`), so the
+# stack never touches a developer's own .env.docker.
 #
 # Intentionally tracked in git and safe to commit: throwaway "basic" auth
-# credentials (see README.md "Warum `basic` statt `mock`?"), no real AI
-# secrets. The smoke test never calls the AI provider, so the placeholder
-# key is sufficient for the backend to start.
+# username/password (see README.md "Warum `basic` statt `mock`?"), no real
+# AI secrets. The JWT signing secret (OPAA_AUTH_BASIC_SECRET) is
+# deliberately NOT here — run-e2e.mjs generates a fresh one per run and
+# passes it through the process environment only (see
+# docker-compose.e2e.yml), so nothing sensitive ever lands in a file.
 
 # Activates docker-specific Spring config (DB host "postgres" instead of
 # "localhost") and the "basic" auth profile (see docs/deployment.md).
@@ -23,12 +24,16 @@ OPAA_OPENAI_API_KEY=sk-e2e-placeholder
 OPAA_DB_USERNAME=opaa
 OPAA_DB_PASSWORD=opaa
 
-# The frontend is served on :3000 by nginx (see docker-compose.yml); Spring
-# CORS validates the browser's Origin header even for same-origin requests
-# proxied through nginx, so it must match here.
-OPAA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+# OPAA_CORS_ALLOWED_ORIGINS is set dynamically in docker-compose.e2e.yml
+# (must match the frontend's host port, which run-e2e.mjs controls), not
+# here.
 
 # Test user credentials used by e2e/fixtures/auth.ts. Not real secrets.
 OPAA_AUTH_BASIC_USERNAME=e2e-user
 OPAA_AUTH_BASIC_PASSWORD=e2e-password
-OPAA_AUTH_BASIC_SECRET=e2e-suite-only-jwt-signing-secret-not-for-production-0123456789
+
+# Makes the test user SYSTEM_ADMIN (see UserService.isInitialAdmin), which
+# scenarios exercising indexing/admin endpoints will need. See README.md
+# for the known limitation that the "basic" profile only supports a single
+# configured user, i.e. there is currently no separate non-admin test user.
+OPAA_INITIAL_ADMIN_EMAIL=e2e-user@opaa.local

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,34 @@
+import { test as base, expect, type Page } from '@playwright/test'
+
+/**
+ * Test user credentials for the E2E stack (see ../e2e.env,
+ * OPAA_AUTH_BASIC_USERNAME / OPAA_AUTH_BASIC_PASSWORD). Not real secrets.
+ */
+const E2E_USERNAME = process.env.E2E_USERNAME ?? 'e2e-user'
+const E2E_PASSWORD = process.env.E2E_PASSWORD ?? 'e2e-password'
+
+/**
+ * Logs the E2E test user in through the real login form and returns once
+ * the app has navigated away from `/login`.
+ *
+ * This is the single reusable building block every scenario should use to
+ * reach the app as an authenticated user, instead of re-implementing the
+ * login flow in each spec (see AC "Anmeldung ist als wiederverwendbarer
+ * Baustein herausgezogen").
+ */
+async function login(page: Page): Promise<void> {
+  await page.goto('/login')
+  await page.getByLabel('Benutzername').fill(E2E_USERNAME)
+  await page.getByLabel('Passwort').fill(E2E_PASSWORD)
+  await page.getByRole('button', { name: 'Anmelden' }).click()
+  await expect(page).not.toHaveURL(/\/login(?:$|[/?#])/, { timeout: 15_000 })
+}
+
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ page }, use) => {
+    await login(page)
+    await use(page)
+  },
+})
+
+export { expect }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,114 @@
+{
+  "name": "e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.56.1",
+        "@types/node": "^26.1.2",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "node scripts/run-e2e.mjs",
     "test:playwright": "playwright test",
-    "install:browsers": "playwright install --with-deps chromium"
+    "install:browsers": "playwright install --with-deps chromium",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Browser-based end-to-end tests for OPAA (Playwright).",
+  "scripts": {
+    "test": "node scripts/run-e2e.mjs",
+    "test:playwright": "playwright test",
+    "install:browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@types/node": "^26.1.2",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright configuration for the OPAA browser E2E suite.
+ *
+ * The suite always targets an already running stack (see scripts/run-e2e.mjs,
+ * which starts the stack via Docker Compose before invoking `playwright test`
+ * and tears it down afterwards). There is no Playwright `webServer` entry
+ * here on purpose: composing the full stack (Postgres + backend + frontend)
+ * is out of scope for what Playwright's webServer can express.
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,12 @@ import { defineConfig, devices } from '@playwright/test'
  * and tears it down afterwards). There is no Playwright `webServer` entry
  * here on purpose: composing the full stack (Postgres + backend + frontend)
  * is out of scope for what Playwright's webServer can express.
+ *
+ * fullyParallel is deliberately false: every spec shares one stack/database
+ * (see e2e/README.md "Serialisierungs-Konvention"), so specs that mutate
+ * shared state (indexing jobs, rate limits, ...) must not run concurrently.
+ * Individual specs may still opt into parallel `test()` calls internally if
+ * they are self-contained.
  */
 export default defineConfig({
   testDir: './tests',
@@ -15,10 +21,10 @@ export default defineConfig({
   expect: {
     timeout: 10_000,
   },
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
   use: {
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',

--- a/e2e/scripts/run-e2e.mjs
+++ b/e2e/scripts/run-e2e.mjs
@@ -4,42 +4,70 @@
 // the stack back down (`down -v`) so the next run starts from the same
 // defined baseline. Used both locally (`npm test` in e2e/) and in CI
 // (.github/workflows/e2e.yml), so both environments behave identically.
+//
+// The stack runs as its own Compose project (COMPOSE_PROJECT_NAME below),
+// which prefixes container/network/volume names so it never collides with
+// a developer's own docker-compose.yml stack running at the same time (see
+// AGENTS.md "Git Worktrees für parallele Sessions"). It also uses its own
+// host ports and its own env file (OPAA_ENV_FILE, see docker-compose.yml),
+// so this script never reads or writes a developer's own .env.docker.
 
+import { randomBytes } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
-import { existsSync, copyFileSync, readFileSync, rmSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const e2eDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const repoRoot = resolve(e2eDir, '..')
 const isWindows = process.platform === 'win32'
-const baseUrl = process.env.E2E_BASE_URL ?? 'http://localhost:3000'
+
+const composeProjectName = process.env.COMPOSE_PROJECT_NAME ?? 'opaa-e2e'
+const backendPort = process.env.OPAA_BACKEND_PORT ?? '18081'
+const frontendPort = process.env.OPAA_FRONTEND_PORT ?? '13000'
+const dbPort = process.env.OPAA_DB_PORT ?? '15432'
+const baseUrl = process.env.E2E_BASE_URL ?? `http://localhost:${frontendPort}`
 const readyUrl = `${baseUrl}/api/v1/auth/config`
-const composeArgs = ['compose', '-f', 'docker-compose.yml']
+const skipBuild = process.env.E2E_SKIP_BUILD === 'true'
 const extraTestArgs = process.argv.slice(2)
 
-// docker-compose.yml pins fixed container_name values (opaa-postgres,
-// opaa-backend, opaa-frontend, opaa-keycloak), so `docker compose down`
-// scoped to a different Compose project (e.g. a stray container from
-// another worktree, or a plain `docker compose up` run outside of one of
-// the scripted flows) won't be cleaned up by our own `down -v` below, and
-// `up` then fails with a container-name conflict. Force-removing them by
-// name first guarantees the clean slate the E2E suite needs regardless of
-// where a same-named leftover container came from.
-const fixedContainerNames = ['opaa-postgres', 'opaa-backend', 'opaa-frontend', 'opaa-keycloak']
+const composeArgs = ['compose', '-f', 'docker-compose.yml', '-f', 'e2e/docker-compose.e2e.yml']
 
-// docker-compose.yml requires a root-level .env.docker file (env_file:) for
-// the postgres/backend services. To keep the E2E stack fully self-contained
-// (throwaway test credentials, placeholder AI key, no dependency on a
-// developer's own .env.docker), we temporarily install e2e/e2e.env as
-// .env.docker for the duration of the run and restore whatever was there
-// before, so this script never permanently overwrites a developer's own
-// configuration.
-const envDockerPath = join(repoRoot, '.env.docker')
-const envDockerBackupPath = join(repoRoot, '.env.docker.e2e-backup')
-const e2eEnvPath = join(e2eDir, 'e2e.env')
+// e2e/e2e.env deliberately does not contain OPAA_AUTH_BASIC_SECRET (no
+// signing secret should ever live in a tracked file): a fresh one is
+// generated for every run and passed through the process environment only
+// (see e2e/docker-compose.e2e.yml, which injects it into the backend
+// container).
+const authSecret = randomBytes(32).toString('hex')
 
-function run(command, args, cwd = repoRoot, env = process.env) {
+const composeEnv = {
+  ...process.env,
+  COMPOSE_PROJECT_NAME: composeProjectName,
+  OPAA_ENV_FILE: 'e2e/e2e.env',
+  OPAA_BACKEND_PORT: backendPort,
+  OPAA_FRONTEND_PORT: frontendPort,
+  OPAA_DB_PORT: dbPort,
+  OPAA_AUTH_BASIC_SECRET: authSecret,
+}
+
+let tornDown = false
+
+// e2e/e2e.env is the single source of truth for the test user's
+// username/password (OPAA_AUTH_BASIC_USERNAME/PASSWORD, consumed by the
+// backend container). Read them back here so Playwright (running on the
+// host, not in a container) logs in with the exact same credentials,
+// instead of duplicating them in a second place that could drift out of
+// sync.
+function readE2eEnvVar(name) {
+  const contents = readFileSync(join(e2eDir, 'e2e.env'), 'utf8')
+  const match = contents.match(new RegExp(`^${name}=(.*)$`, 'm'))
+  if (!match) {
+    throw new Error(`${name} not found in e2e/e2e.env`)
+  }
+  return match[1]
+}
+
+function run(command, args, { cwd = repoRoot, env = process.env } = {}) {
   const result = spawnSync(command, args, {
     cwd,
     stdio: 'inherit',
@@ -52,42 +80,40 @@ function run(command, args, cwd = repoRoot, env = process.env) {
   return result.status ?? 1
 }
 
-// e2e/e2e.env is the single source of truth for the test user credentials
-// (OPAA_AUTH_BASIC_USERNAME/PASSWORD, consumed by the backend container).
-// Read them back here so Playwright (running on the host, not in a
-// container) logs in with the exact same credentials, instead of
-// duplicating them in a second place that could drift out of sync.
-function readE2eEnvVar(name) {
-  const contents = readFileSync(e2eEnvPath, 'utf8')
-  const match = contents.match(new RegExp(`^${name}=(.*)$`, 'm'))
-  return match?.[1]
-}
-
-function installE2eEnvFile() {
-  if (existsSync(envDockerPath) && !existsSync(envDockerBackupPath)) {
-    copyFileSync(envDockerPath, envDockerBackupPath)
+function dumpLogs() {
+  const logPath = join(e2eDir, 'docker-compose.log')
+  console.log(`\n> Saving container logs to ${logPath}`)
+  const result = spawnSync('docker', [...composeArgs, 'logs', '--no-color', '--timestamps'], {
+    cwd: repoRoot,
+    shell: isWindows,
+    env: composeEnv,
+  })
+  try {
+    writeFileSync(
+      logPath,
+      Buffer.concat([result.stdout ?? Buffer.alloc(0), result.stderr ?? Buffer.alloc(0)]),
+    )
+  } catch (error) {
+    // Best-effort: log capture failures must never mask the real test result.
+    console.error('Failed to write docker-compose.log', error)
   }
-  copyFileSync(e2eEnvPath, envDockerPath)
-}
-
-function restoreEnvFile() {
-  if (existsSync(envDockerBackupPath)) {
-    copyFileSync(envDockerBackupPath, envDockerPath)
-    rmSync(envDockerBackupPath)
-  } else {
-    rmSync(envDockerPath, { force: true })
-  }
-}
-
-function removeStaleFixedNameContainers() {
-  run('docker', ['rm', '-f', ...fixedContainerNames])
 }
 
 function teardown() {
+  if (tornDown) {
+    return
+  }
+  tornDown = true
   console.log('\n> Tearing down E2E stack (docker compose down -v)')
-  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'])
-  removeStaleFixedNameContainers()
-  restoreEnvFile()
+  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'], { env: composeEnv })
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    console.log(`\n> Received ${signal}, tearing down before exit`)
+    teardown()
+    process.exit(130)
+  })
 }
 
 async function waitUntilReady(timeoutMs) {
@@ -107,24 +133,21 @@ async function waitUntilReady(timeoutMs) {
 }
 
 async function main() {
-  installE2eEnvFile()
+  console.log(`> Starting from a clean slate (docker compose -p ${composeProjectName} down -v)`)
+  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'], { env: composeEnv })
 
-  console.log('> Starting from a clean slate (docker compose down -v)')
-  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'])
-  removeStaleFixedNameContainers()
-
-  console.log('> Starting E2E stack (postgres, backend, frontend)')
-  const upStatus = run('docker', [
-    ...composeArgs,
-    'up',
-    '-d',
-    '--build',
-    'postgres',
-    'backend',
-    'frontend',
-  ])
+  console.log(
+    `> Starting E2E stack (postgres, backend, frontend) as Compose project "${composeProjectName}"` +
+      ` on ports ${dbPort}/${backendPort}/${frontendPort}`,
+  )
+  const upArgs = [...composeArgs, 'up', '-d', 'postgres', 'backend', 'frontend']
+  if (!skipBuild) {
+    upArgs.splice(upArgs.indexOf('up') + 1, 0, '--build')
+  }
+  const upStatus = run('docker', upArgs, { env: composeEnv })
   if (upStatus !== 0) {
     console.error('docker compose up failed')
+    dumpLogs()
     teardown()
     process.exitCode = upStatus
     return
@@ -134,23 +157,26 @@ async function main() {
   const ready = await waitUntilReady(120_000)
   if (!ready) {
     console.error('Stack did not become ready within 120s')
-    run('docker', [...composeArgs, 'logs'])
+    dumpLogs()
     teardown()
     process.exitCode = 1
     return
   }
 
   console.log('> Running Playwright tests')
-  const testStatus = run(
-    isWindows ? 'npx.cmd' : 'npx',
-    ['playwright', 'test', ...extraTestArgs],
-    e2eDir,
-    {
+  const testStatus = run(isWindows ? 'npx.cmd' : 'npx', ['playwright', 'test', ...extraTestArgs], {
+    cwd: e2eDir,
+    env: {
       ...process.env,
+      E2E_BASE_URL: baseUrl,
       E2E_USERNAME: readE2eEnvVar('OPAA_AUTH_BASIC_USERNAME'),
       E2E_PASSWORD: readE2eEnvVar('OPAA_AUTH_BASIC_PASSWORD'),
     },
-  )
+  })
+
+  if (testStatus !== 0) {
+    dumpLogs()
+  }
 
   teardown()
   process.exitCode = testStatus
@@ -158,6 +184,7 @@ async function main() {
 
 main().catch((error) => {
   console.error(error)
+  dumpLogs()
   teardown()
   process.exitCode = 1
 })

--- a/e2e/scripts/run-e2e.mjs
+++ b/e2e/scripts/run-e2e.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Orchestrates a full E2E run: bring the stack up from a clean slate via
+// Docker Compose, wait until it answers, run Playwright, then always tear
+// the stack back down (`down -v`) so the next run starts from the same
+// defined baseline. Used both locally (`npm test` in e2e/) and in CI
+// (.github/workflows/e2e.yml), so both environments behave identically.
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, copyFileSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const e2eDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = resolve(e2eDir, '..')
+const isWindows = process.platform === 'win32'
+const baseUrl = process.env.E2E_BASE_URL ?? 'http://localhost:3000'
+const readyUrl = `${baseUrl}/api/v1/auth/config`
+const composeArgs = ['compose', '-f', 'docker-compose.yml']
+const extraTestArgs = process.argv.slice(2)
+
+// docker-compose.yml pins fixed container_name values (opaa-postgres,
+// opaa-backend, opaa-frontend, opaa-keycloak), so `docker compose down`
+// scoped to a different Compose project (e.g. a stray container from
+// another worktree, or a plain `docker compose up` run outside of one of
+// the scripted flows) won't be cleaned up by our own `down -v` below, and
+// `up` then fails with a container-name conflict. Force-removing them by
+// name first guarantees the clean slate the E2E suite needs regardless of
+// where a same-named leftover container came from.
+const fixedContainerNames = ['opaa-postgres', 'opaa-backend', 'opaa-frontend', 'opaa-keycloak']
+
+// docker-compose.yml requires a root-level .env.docker file (env_file:) for
+// the postgres/backend services. To keep the E2E stack fully self-contained
+// (throwaway test credentials, placeholder AI key, no dependency on a
+// developer's own .env.docker), we temporarily install e2e/e2e.env as
+// .env.docker for the duration of the run and restore whatever was there
+// before, so this script never permanently overwrites a developer's own
+// configuration.
+const envDockerPath = join(repoRoot, '.env.docker')
+const envDockerBackupPath = join(repoRoot, '.env.docker.e2e-backup')
+const e2eEnvPath = join(e2eDir, 'e2e.env')
+
+function run(command, args, cwd = repoRoot, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: isWindows,
+    env,
+  })
+  if (result.error) {
+    throw result.error
+  }
+  return result.status ?? 1
+}
+
+// e2e/e2e.env is the single source of truth for the test user credentials
+// (OPAA_AUTH_BASIC_USERNAME/PASSWORD, consumed by the backend container).
+// Read them back here so Playwright (running on the host, not in a
+// container) logs in with the exact same credentials, instead of
+// duplicating them in a second place that could drift out of sync.
+function readE2eEnvVar(name) {
+  const contents = readFileSync(e2eEnvPath, 'utf8')
+  const match = contents.match(new RegExp(`^${name}=(.*)$`, 'm'))
+  return match?.[1]
+}
+
+function installE2eEnvFile() {
+  if (existsSync(envDockerPath) && !existsSync(envDockerBackupPath)) {
+    copyFileSync(envDockerPath, envDockerBackupPath)
+  }
+  copyFileSync(e2eEnvPath, envDockerPath)
+}
+
+function restoreEnvFile() {
+  if (existsSync(envDockerBackupPath)) {
+    copyFileSync(envDockerBackupPath, envDockerPath)
+    rmSync(envDockerBackupPath)
+  } else {
+    rmSync(envDockerPath, { force: true })
+  }
+}
+
+function removeStaleFixedNameContainers() {
+  run('docker', ['rm', '-f', ...fixedContainerNames])
+}
+
+function teardown() {
+  console.log('\n> Tearing down E2E stack (docker compose down -v)')
+  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'])
+  removeStaleFixedNameContainers()
+  restoreEnvFile()
+}
+
+async function waitUntilReady(timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(readyUrl)
+      if (response.ok) {
+        return true
+      }
+    } catch {
+      // Stack is not reachable yet; keep polling until the timeout.
+    }
+    await new Promise((r) => setTimeout(r, 2000))
+  }
+  return false
+}
+
+async function main() {
+  installE2eEnvFile()
+
+  console.log('> Starting from a clean slate (docker compose down -v)')
+  run('docker', [...composeArgs, 'down', '-v', '--remove-orphans'])
+  removeStaleFixedNameContainers()
+
+  console.log('> Starting E2E stack (postgres, backend, frontend)')
+  const upStatus = run('docker', [
+    ...composeArgs,
+    'up',
+    '-d',
+    '--build',
+    'postgres',
+    'backend',
+    'frontend',
+  ])
+  if (upStatus !== 0) {
+    console.error('docker compose up failed')
+    teardown()
+    process.exitCode = upStatus
+    return
+  }
+
+  console.log(`> Waiting for ${readyUrl} to become reachable`)
+  const ready = await waitUntilReady(120_000)
+  if (!ready) {
+    console.error('Stack did not become ready within 120s')
+    run('docker', [...composeArgs, 'logs'])
+    teardown()
+    process.exitCode = 1
+    return
+  }
+
+  console.log('> Running Playwright tests')
+  const testStatus = run(
+    isWindows ? 'npx.cmd' : 'npx',
+    ['playwright', 'test', ...extraTestArgs],
+    e2eDir,
+    {
+      ...process.env,
+      E2E_USERNAME: readE2eEnvVar('OPAA_AUTH_BASIC_USERNAME'),
+      E2E_PASSWORD: readE2eEnvVar('OPAA_AUTH_BASIC_PASSWORD'),
+    },
+  )
+
+  teardown()
+  process.exitCode = testStatus
+}
+
+main().catch((error) => {
+  console.error(error)
+  teardown()
+  process.exitCode = 1
+})

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '../fixtures/auth'
+
+test.describe('Rauchtest', () => {
+  test('Anwendung öffnen, Testnutzer anmelden, Startseite lädt', async ({ authenticatedPage }) => {
+    // The chat page is the landing page after login (see frontend/src/App.tsx).
+    // Its input placeholder is a stable, user-visible marker that the app
+    // shell rendered successfully.
+    await expect(
+      authenticatedPage.getByPlaceholder('Stellen Sie eine Frage …'),
+    ).toBeVisible()
+  })
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "**/*.mts"]
+}


### PR DESCRIPTION
## Zusammenfassung

Grundgerüst für die browserbasierte End-to-End-Suite (Playwright) unter `e2e/`. Startet den vollständigen Stack (Postgres, Backend, Frontend) reproduzierbar über Docker Compose, meldet den Testnutzer über das echte Login-Formular an, und enthält als Nachweis einen einzigen Rauchtest (Anwendung öffnen → anmelden → Startseite lädt). CI führt die Suite bei jedem Pull Request aus und lädt bei Fehlschlägen Trace/Screenshot als Artefakt hoch. Enthält keine fachlichen Testfälle — die kommen mit #232/#233 dazu.

## Zugehörige Issues

Closes #231

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [x] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Sonnet 5, Claude Code Developer-Agent)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst

## Details

**Werkzeugwahl:** Playwright (Begründung in `e2e/README.md`).

**Warum `basic`-Auth statt `mock` für die Suite?** `opaa.auth.mode: mock` ist im Backend nur ein Signal für das Frontend, die Login-Seite zu überspringen — es aktiviert kein eigenes Spring-Profil. Ohne aktives Profil `basic`/`oidc` existieren die Fach-Controller (`@Profile({"oidc","basic"})`) gar nicht, und Spring Boots generische Security-Auto-Konfiguration blockt alle Anfragen. Für den vollständig über Docker Compose laufenden Stack ist `mock` daher nicht nutzbar; `basic` ist der einfachste real funktionierende Modus (keine Keycloak-Abhängigkeit) und übt zugleich das echte Login-Formular aus. Ausführlich dokumentiert in `e2e/README.md`.

**Abnahmekriterien:**
- [x] Suite lässt sich lokal mit einem dokumentierten Befehl ausführen (`cd e2e && npm ci && npx playwright install --with-deps chromium && npm test`)
- [x] Rauchtest läuft grün und schlägt nachweislich fehl, wenn das Frontend nicht erreichbar ist (verifiziert: `npx playwright test` ohne laufenden Stack → `net::ERR_CONNECTION_REFUSED`, Trace/Screenshot abgelegt)
- [x] Anmeldung als wiederverwendbarer Baustein (`e2e/fixtures/auth.ts`, `authenticatedPage`-Fixture)
- [x] Definierte Ausgangslage pro Lauf (`docker compose down -v` vor und nach jedem Lauf, inkl. Bereinigung fest benannter Container); zweimal hintereinander lokal verifiziert, gleiches Ergebnis
- [x] Trace/Screenshot als CI-Artefakt bei Fehlschlag (`trace: 'retain-on-failure'`, `screenshot: 'only-on-failure'`, Upload-Schritte in `.github/workflows/e2e.yml`)
- [x] CI-Job mit `timeout-minutes: 10`
- [x] Werkzeugwahl mit Begründung dokumentiert (`e2e/README.md`)
- [x] Dokumentation aktualisiert: `AGENTS.md` (Befehle, Pfad), `CONTRIBUTING.md` (wann E2E-Test schreiben)

## Annahmen

- Der ursprüngliche Issue-Vorschlag "mock-Modus für E2E" ließ sich nicht umsetzen: `mock` ist im Backend nicht als eigenständiger Auth-Pfad implementiert (siehe Details oben). Stattdessen `basic`-Modus mit fest hinterlegten Wegwerf-Testnutzer-Zugangsdaten in `e2e/e2e.env` (kein echtes Secret, im Repo sicher committbar).
- `docker-compose.yml` pinnt feste `container_name`-Werte (`opaa-postgres` etc.), was bei parallelen Worktrees/Sessions auf derselben Maschine zu Namenskonflikten führen kann. Statt die Basisdatei zu ändern, entfernt `scripts/run-e2e.mjs` diese Container vor jedem Lauf gezielt per Name — ausreichend für dieses Grundgerüst, aber ein bekanntes Limit für echte parallele lokale Läufe auf derselben Maschine.
- CI baut die Docker-Images bei jedem Lauf neu (kein Layer-Cache über Runs hinweg), um das Grundgerüst einfach zu halten; lokal dauerte ein Lauf mit warmem Docker-Cache ca. 20s, ein Kaltstart mit Image-Build mehrere Minuten. Bei Bedarf lässt sich das später mit `type=gha`-Build-Cache beschleunigen.
- Playwright-Projekt nur mit Chromium (nicht Firefox/WebKit) — ausreichend für ein Grundgerüst, in `playwright.config.ts` leicht erweiterbar.
