### PR TITLE
docs(eval): Demo-Instanz auf OpenAI und Account-Bindung korrigieren

### DIFF
--- a/docs/decisions/0008-search-quality-evaluation-harness.md
+++ b/docs/decisions/0008-search-quality-evaluation-harness.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Akzeptiert
+Akzeptiert — ergänzt um den [Nachtrag vom 2026-08-02](#nachtrag-korrigierte-tatsachenlage-zur-demo-instanz)
+(Tatsachenkorrektur; die Entscheidung selbst bleibt unverändert).
 
 ## Kontext
 
@@ -85,3 +86,67 @@ unterschreitet oder um mehr als eine definierte Toleranz unter die committete Ba
   Evaluierung konfigurierbar gemacht.
 - Die Baseline ist an Modellversion **und** Korpus gebunden. Jede Änderung an einem der beiden
   erfordert einen bewussten neuen Baseline-Lauf.
+
+---
+
+## Nachtrag: korrigierte Tatsachenlage zur Demo-Instanz
+
+> **Nachtrag vom 2026-08-02.** Dieser ADR ist bereits akzeptiert und wird deshalb nicht still
+> umgeschrieben. Der Abschnitt hält eine Tatsachenkorrektur fest, die nach der Annahme bekannt
+> wurde, und bewertet, was sie für die getroffene Entscheidung bedeutet.
+
+### Was falsch war
+
+Die Feature-Spezifikation `docs/features/search-quality-evaluation.md`, Epic #224 und Issue #230
+behaupteten, die öffentliche Instanz `opaa.ewerlin.com` laufe mit ihrer „bestehenden
+Ollama-Konfiguration (`phi3:mini`)", weshalb „kein Kostenrisiko" bestehe und „kein kommerzielles
+Modell" eingeführt werde.
+
+Der Maintainer hat auf Nachfrage klargestellt: **Die Instanz nutzt OpenAI.** Die Fehlannahme
+entstand aus einer Verwechslung zweier Ebenen — der *Anwendungs-Default* in
+`backend/src/main/resources/application.yml` ist `${OPAA_AI_CHAT_PROVIDER:ollama}`, die
+*empfohlene Compose-Belegung* in `.env.example` dagegen `OPAA_AI_CHAT_PROVIDER=openai`. Die zweite
+Ebene beschreibt den tatsächlichen Betrieb, die erste nur das Verhalten ohne jede Konfiguration.
+Ein Folge-Issue klärt diese Zweideutigkeit auch in `docs/deployment.md`.
+
+Zweite Korrektur derselben Runde, ohne Bezug zu diesem ADR, aber der Vollständigkeit halber: Die
+Instanz erhält **keinen anonymen Lesezugriff**; sie bleibt account-gebunden hinter Keycloak. Für
+diese Entscheidung wird auf ausdrücklichen Wunsch des Maintainers **kein eigener ADR** angelegt;
+sie steht in der Feature-Spezifikation.
+
+### Trägt die Entscheidung noch?
+
+**Ja — vollständig, und ohne Abstriche an einer einzigen der sechs Festlegungen.** Die falsche
+Prämisse lag nicht in diesem ADR, sondern in der Demo-Beschreibung der Spezifikation. Im Einzelnen:
+
+- Keine der Entscheidungen 1 bis 6 nimmt auf den Chat-Anbieter der Demo-Instanz Bezug. Der ADR
+  hält im Gegenteil ausdrücklich fest, dass der Harness „kein laufendes System, keine Demo-Instanz
+  und kein LLM" braucht. Die Demo und der Regressionstest teilen den Korpus, sonst nichts.
+- Entscheidung 4 (Ollama als Einbettungsmodell in CI) stützt sich zwar unter anderem auf „kostenlos
+  und ohne Secret", trägt aber auch ohne dieses Argument: Ausschlaggebend ist die
+  **Baseline-Stabilität**. Ein Anbieter kann ein gehostetes Modell still ändern, womit die Baseline
+  ohne Code-Änderung driftet; ein festgenageltes lokales Modell kann das nicht. Dieses Argument ist
+  von Kosten unabhängig. Hinzu kommt, dass ein Secret in Forks ohnehin nicht verfügbar ist — auch
+  das ist keine Kostenfrage.
+
+Es besteht also **kein Anlass, ADR-0008 neu zu bewerten oder zu ersetzen.**
+
+### Was sich dennoch ändert
+
+Eine Konsequenz kommt hinzu, die vor der Korrektur nicht sichtbar war und die den ADR nicht
+umstößt, aber seine Aussagekraft begrenzt:
+
+- **Der CI-Harness misst eine andere Konfiguration als die Demo-Instanz fährt.** Die Baseline
+  entsteht mit `nomic-embed-text` über Ollama, die Instanz bettet laut `.env.example` mit
+  `text-embedding-3-small` über OpenAI ein. Ein grüner Regressionslauf sagt damit nichts über die
+  Trefferqualität, die ein Besucher auf `opaa.ewerlin.com` erlebt. Das ist vertretbar — der
+  Harness ist ein Regressionsdetektor für die Pipeline, keine Vorhersage für eine bestimmte
+  Installation —, muss aber benannt werden, damit niemand die Baseline als Aussage über die Demo
+  liest.
+- Daraus folgt eine Präzisierung, keine Änderung: Der in Entscheidung 4 vorgesehene **optionale
+  OpenAI-Vergleichslauf sollte mindestens einmal gegen die Konfiguration der Demo-Instanz laufen**,
+  damit der Abstand zwischen beiden Anbietern beziffert ist. Er bleibt ausdrücklich außerhalb der
+  Baseline.
+- Für den Betrieb der Demo — nicht für diesen ADR — folgt aus der Korrektur, dass Kosten aktiv zu
+  begrenzen sind: Ausgabenlimit beim Anbieter und Rate Limiting pro Konto. Das ist in der
+  Feature-Spezifikation und in den Abnahmekriterien von #230 verankert.

--- a/docs/features/search-quality-evaluation.md
+++ b/docs/features/search-quality-evaluation.md
@@ -297,7 +297,7 @@ Kein LLM ist beteiligt. Retrieval-Metriken sind reine Ranking-Metriken; die Gene
 
 | Option | Für | Gegen |
 |---|---|---|
-| 1. Ollama-Container mit `nomic-embed-text` | kostenlos, kein Secret, entspricht der Standardkonfiguration von OPAA, über die Modellversion reproduzierbar | Modell-Pull (~275 MB) und Einbettung von ~1.450 Dokumenten kosten Laufzeit |
+| 1. Ollama-Container mit `nomic-embed-text` | kostenlos, kein Secret, entspricht dem Anwendungs-Default von OPAA (`application.yml`), über die Modellversion reproduzierbar | Modell-Pull (~275 MB) und Einbettung von ~1.450 Dokumenten kosten Laufzeit |
 | 2. OpenAI `text-embedding-3-small` | schnell, folgt dem bestehenden `backend-integration`-Job | kostet Geld, braucht ein Secret (in Forks nicht verfügbar), Anbieter kann das Modell still ändern → Baseline driftet ohne Code-Änderung |
 | 3. Vorberechnete Embeddings im Repo | schnell und deterministisch | misst nur noch den Ranking-Code, nicht die Pipeline — nutzlos für Modellvergleiche |
 
@@ -357,23 +357,56 @@ Entwicklungsumgebung ihn nicht startet.
 **Sie existiert bereits: `opaa.ewerlin.com`.** Es ist also kein Hosting aufzubauen, sondern der
 Korpus auf eine laufende Instanz auszurollen. Das verkleinert Phase 2 erheblich.
 
-Zwei Folgerungen:
+> **Korrektur (aus dem Review zu PR #247).** Zwei Aussagen in diesem Abschnitt waren falsch und
+> sind nachfolgend berichtigt: Die Instanz läuft **nicht** auf Ollama, sondern auf **OpenAI**, und
+> es wird **kein anonymer Lesezugriff** eingeführt. Beide Punkte hat der Maintainer klargestellt.
+> Was das für die Begründung von ADR-0008 bedeutet, steht dort im
+> [Nachtrag](../decisions/0008-search-quality-evaluation-harness.md#nachtrag-korrigierte-tatsachenlage-zur-demo-instanz).
 
-- **Kein kommerzielles Modell.** Der Stack nutzt `OPAA_AI_CHAT_PROVIDER` mit Vorgabe `ollama` und
-  `phi3:mini`; die bestehende Konfiguration der Instanz gilt unverändert. Damit ist das
-  Kostenrisiko einer öffentlich erreichbaren Suche vom Tisch, und die Demo zeigt OPAA in genau der
-  selbstgehosteten Betriebsart, für die es gebaut ist.
+Drei Folgerungen:
+
+- **Die Instanz läuft auf OpenAI.** Der Maintainer hat bestätigt, dass `opaa.ewerlin.com` ein
+  kommerzielles Modell über OpenAI nutzt. Das deckt sich mit `.env.example`, das für den
+  Compose-Betrieb `OPAA_AI_CHAT_PROVIDER=openai` und `OPAA_AI_EMBEDDING_PROVIDER=openai` setzt;
+  lediglich der *Anwendungs-Default* in `application.yml` lautet `ollama`. Die frühere Aussage
+  („bestehende Ollama-Konfiguration mit `phi3:mini`, kein Kostenrisiko") verwechselte diese beiden
+  Ebenen und ist zurückgezogen.
+- **Damit besteht ein echtes Kostenrisiko.** Jede Demo-Anfrage erzeugt Token-Kosten beim Anbieter.
+  Der Zugriff ist zwar account-gebunden (siehe unten), anonymer Massenzugriff also ausgeschlossen —
+  aber ein einzelnes berechtigtes Konto kann laufende Kosten in unbegrenzter Höhe auslösen, und die
+  Zahl der Konten wächst mit dem Erfolg der Demo. Kostenbegrenzung ist deshalb eine
+  Betriebsanforderung, kein optionaler Schutz.
 - **Die Instanz ist nirgends dokumentiert.** Weder `docs/deployment.md` noch `docker-compose.yml`
-  erwähnen sie. Das ist eine eigenständige Lücke und wird als eigenes Dokumentations-Issue geführt;
-  ohne diese Beschreibung kann ein Entwickler den Rollout gar nicht durchführen.
+  erwähnen sie. Das ist eine eigenständige Lücke und wird als eigenes Dokumentations-Issue geführt
+  (#244); ohne diese Beschreibung kann ein Entwickler den Rollout gar nicht durchführen.
+
+### Zugangsmodell: account-gebunden, kein Gastzugang
+
+**Entscheidung des Maintainers:** Die Instanz bleibt hinter Keycloak; jeder Zugriff setzt ein Konto
+voraus. Ein Gast- oder Read-only-Zugang wird **nicht** eingeführt. Der Maintainer hat außerdem
+ausdrücklich entschieden, dafür **keinen ADR anzulegen** (der Review zu PR #247 hatte ein ADR-0009
+vorgeschlagen); die Entscheidung wird stattdessen hier festgehalten und gilt für Epic #224 als
+verbindlich.
+
+Der damit verbundene Zielkonflikt wird nicht verdeckt: Die Demo verliert ihren stärksten Effekt,
+das Ausprobieren ohne jede Hürde. Übrig bleibt eine Instanz, die man Interessenten gezielt
+zugänglich macht — der Nutzen ist real, tritt aber erst nach einer Kontoanlage ein, nicht beim
+ersten Klick. Die Begründung „ohne Installation ausprobieren" trägt entsprechend nur eingeschränkt:
+ohne *Installation* ja, ohne *Anmeldung* nein. Wer den niedrigschwelligen Effekt später doch will,
+braucht dafür eine neue Entscheidung samt Kosten- und Missbrauchsbetrachtung; als Idee bleibt sie
+unter [Offene Fragen](#offene-fragen--zukünftige-erweiterungen) stehen.
 
 Anforderungen an den Betrieb der Instanz:
 
-- **Anonymer Lesezugriff** auf die Suche, keine Schreib- oder Admin-Endpunkte von außen. Der
-  Indizierungs-Endpunkt ist bereits auf `SYSTEM_ADMIN` beschränkt und darf so bleiben.
-- **Rate Limiting** ist vorhanden (`opaa.rate-limit`) und muss für die Demo scharf gestellt sein.
-  Auch ohne Token-Kosten bleibt es nötig: Ein selbstgehostetes Modell ist die knappere Ressource,
-  nicht die billigere.
+- **Zugriff nur mit Konto.** Authentifizierung über Keycloak für alle Endpunkte, auch für die
+  Suche; keine anonymen Lesepfade. Der Indizierungs-Endpunkt ist bereits auf `SYSTEM_ADMIN`
+  beschränkt und bleibt es.
+- **Harter Kostendeckel beim Anbieter.** Ein Ausgabenlimit auf dem OpenAI-Konto, damit ein Fehler
+  oder Missbrauch nicht in eine offene Rechnung läuft. Ein Deckel wirkt auch dann, wenn das Rate
+  Limiting falsch konfiguriert ist — deshalb beides, nicht eines davon.
+- **Rate Limiting** ist vorhanden (`opaa.rate-limit`) und muss für die Demo scharf gestellt sein —
+  pro Konto *und* global. Es ist jetzt die primäre Kostenbremse und nicht mehr nur der Schutz einer
+  knappen lokalen Rechenressource.
 - **Quellenhinweis** sichtbar in der Oberfläche. CC0 verlangt ihn nicht; er wird trotzdem geführt,
   weil ein Besucher wissen soll, woher die Daten stammen.
 - **Hinweis auf den Demo-Charakter**: synthetisch formulierte Texte, keine Faktenautorität.
@@ -417,9 +450,10 @@ Vom Maintainer entschieden:
 |---|---|
 | 1 | **Phase-1-Quelle:** `jrtec/Superheroes` (CC0-1.0). Der FiveThirtyEight-Datensatz entfällt. |
 | 2 | **Multi-Tenancy:** ein gemeinsamer Index, Domänentrennung über Dateinamen-Präfix. Die Workspace-Variante wartet auf #115/#117, nicht auf Epic #198. |
-| 3 | **Demo-Hosting:** die bestehende Instanz `opaa.ewerlin.com`, mit ihrer bestehenden Ollama-Konfiguration (`phi3:mini`). Kein kommerzielles Modell. |
+| 3 | **Demo-Hosting:** die bestehende Instanz `opaa.ewerlin.com`. Sie läuft auf **OpenAI**, nicht auf Ollama — *korrigiert am 2026-08-02; die vorherige Angabe „bestehende Ollama-Konfiguration (`phi3:mini`), kein kommerzielles Modell" war falsch.* Daraus folgt ein reales Kostenrisiko pro Anfrage, das über Ausgabenlimit und Rate Limiting begrenzt wird. |
 | 4 | **Korpus-Ablage:** Hauptrepository mit SHA-256-Manifest; Neubewertung bei der Ausweitung auf vier Domänen. |
-| 5 | **ADR-0008** ist akzeptiert. |
+| 5 | **ADR-0008** ist akzeptiert. Zur korrigierten Kostenprämisse siehe den Nachtrag im ADR. |
+| 6 | **Zugangsmodell der Demo:** account-gebunden hinter Keycloak. Kein Gast- und kein Read-only-Zugang. *Korrigiert am 2026-08-02; die vorherige Anforderung „anonymer Lesezugriff" ist gestrichen.* Für diese Entscheidung wird ausdrücklich **kein ADR** angelegt. |
 
 Vom Product Manager gesetzt, mangels Rückfrage, weiterhin widerrufbar:
 
@@ -443,16 +477,21 @@ Vom Product Manager gesetzt, mangels Rückfrage, weiterhin widerrufbar:
 Die Fragen zu Lizenz, Demo-Hosting, Korpus-Ablage und Multi-Tenancy sind entschieden und stehen
 oben unter [Festlegungen](#festlegungen). Offen bleibt:
 
-1. **Antwortqualität mit `phi3:mini`:** Das Modell ist klein. Für Retrieval-Metriken spielt es
-   keine Rolle (der Harness nutzt kein LLM), für den Eindruck der öffentlichen Demo schon. Falls
-   die Antworten auf dem Korpus zu schwach ausfallen, ist ein größeres lokales Modell auf der
-   Instanz die naheliegende Reaktion — zu bewerten, sobald der Korpus dort liegt.
-2. **Ablage bei vier Domänen:** Prüfpunkt in der Ausweitung — bleibt das Repository auch bei
+1. **Laufende Kosten der Demo:** Die Instanz nutzt OpenAI, jede Anfrage kostet Geld. Wie hoch die
+   Kosten pro Monat tatsächlich ausfallen, lässt sich erst beziffern, wenn der Korpus dort liegt
+   und Anfragen laufen. Offen bleibt, ab welchem Betrag der Maintainer gegensteuert und womit —
+   engeres Rate Limit, kleineres Modell (z. B. `gpt-4o-mini`) oder ein Wechsel der Demo auf ein
+   lokales Modell. Erst messen, dann entscheiden.
+2. **Niedrigschwelliger Zugang:** Die Anmeldepflicht kostet die Demo ihren stärksten Effekt. Ein
+   Gastzugang bliebe die wirksamste Variante, ist aber vom Maintainer abgelehnt, solange die
+   Kostenfrage nicht geklärt ist. Falls sie geklärt wird, wäre der Punkt neu zu bewerten — mit
+   Kostendeckel, engem Rate Limit und ggf. einem eigenen, günstigeren Modell für den Gastpfad.
+3. **Ablage bei vier Domänen:** Prüfpunkt in der Ausweitung — bleibt das Repository auch bei
    10–20 MB die richtige Ablage?
-3. **Zurückgestellt:** Generationsmetriken (`RelevancyEvaluator`, `FactCheckingEvaluator`),
+4. **Zurückgestellt:** Generationsmetriken (`RelevancyEvaluator`, `FactCheckingEvaluator`),
    RAGAS-Sidecar, Paired-Bootstrap-Vergleichsläufe, ein eigener deutscher Benchmark. Alles bereits
    in `discussion-rag-evaluation.md` beschrieben; kommt in Phase 4.
-4. **Zurückgestellt:** Ein Nutzer-Feedback-Kanal in der Demo („war das hilfreich?") wäre eine
+5. **Zurückgestellt:** Ein Nutzer-Feedback-Kanal in der Demo („war das hilfreich?") wäre eine
    billige Quelle für echte Anfragen und damit für ein besseres Golden Dataset. Eigenes Feature.
 
 ---
@@ -463,5 +502,9 @@ oben unter [Festlegungen](#festlegungen). Offen bleibt:
   Mensch danach sucht.
 - Die Frage „ist Konfiguration A besser als B?" wird mit einer Zahl und einem Verfahren
   beantwortet, nicht mit einer Meinung.
-- Ein Interessent kann OPAA ohne Installation ausprobieren und bekommt auf eine Anfrage an den
-  Demo-Korpus eine belegte Antwort mit Quellenangabe.
+- Ein Interessent mit einem Konto auf der Demo-Instanz kann OPAA ohne eigene Installation
+  ausprobieren und bekommt auf eine Anfrage an den Demo-Korpus eine belegte Antwort mit
+  Quellenangabe. Der Wegfall der Installationshürde bleibt; die Anmeldehürde bleibt bestehen und
+  begrenzt die Reichweite dieser Metrik bewusst.
+- Die laufenden Modellkosten der Demo sind bekannt und gedeckelt: Es gibt ein Ausgabenlimit beim
+  Anbieter und ein wirksames Rate Limit pro Konto.


### PR DESCRIPTION
## Zusammenfassung

Zwei Falschaussagen richtigstellen, die über PR #247 auf `main` gelangt sind. Beide gehen auf eine fehlerhafte Weitergabe von Maintainer-Entscheidungen zurück, nicht auf eine eigene Annahme der Spezifikation.

**Korrektur 1 — die Demo-Instanz läuft auf OpenAI, nicht auf Ollama.**
`docs/features/search-quality-evaluation.md` behauptete, `opaa.ewerlin.com` nutze seine „bestehende Ollama-Konfiguration (`phi3:mini`)", weshalb „kein Kostenrisiko" bestehe. Der Maintainer hat klargestellt: Die Instanz nutzt OpenAI. Die Fehlannahme verwechselte den *Anwendungs-Default* in `application.yml` (`${OPAA_AI_CHAT_PROVIDER:ollama}`) mit der *Compose-Belegung* in `.env.example` (`openai`). Die Spezifikation stellt das richtig und leitet die Folge daraus ab: Jede Demo-Anfrage kostet Geld, Ausgabenlimit und Rate Limiting pro Konto werden Betriebsanforderung.

**Korrektur 2 — kein anonymer Lesezugriff.**
Die Anforderung „anonymer Lesezugriff auf die Suche" ist gestrichen. Die Instanz bleibt account-gebunden hinter Keycloak; ein Gast- oder Read-only-Zugang wird nicht eingeführt. Der Zielkonflikt mit der Begründung „ohne Installation ausprobieren" wird in Spezifikation, Epic und #230 offen benannt statt geglättet: ohne *Installation* ja, ohne *Anmeldung* nein. Auf ausdrückliche Entscheidung des Maintainers wird dafür **kein ADR** angelegt (der Review hatte ein ADR-0009 vorgeschlagen); die Entscheidung steht in der Spezifikation.

**ADR-0008: Nachtrag statt stiller Änderung.**
Der ADR ist akzeptiert und wird deshalb nicht umgeschrieben, sondern um einen sichtbar gekennzeichneten Nachtrag ergänzt, der die korrigierte Tatsachenlage und ihre Folgen festhält.

Bewertung, ausdrücklich: **Die Entscheidung trägt unverändert.** Keine ihrer sechs Festlegungen nimmt auf den Chat-Anbieter der Demo-Instanz Bezug — der ADR hält im Gegenteil fest, dass der Harness „kein laufendes System, keine Demo-Instanz und kein LLM" braucht. Auch Entscheidung 4 (Ollama in CI) trägt ohne das Kostenargument, weil ihr ausschlaggebender Grund die Baseline-Stabilität ist: Ein gehostetes Modell kann der Anbieter still ändern, ein festgenageltes lokales nicht. Eine Neubewertung ist nicht erforderlich.

Was der Nachtrag dennoch neu benennt: Der CI-Harness misst mit `nomic-embed-text` über Ollama, die Instanz bettet mit `text-embedding-3-small` über OpenAI ein. Ein grüner Regressionslauf sagt damit nichts über die Trefferqualität auf der Demo. Das stürzt den ADR nicht um, begrenzt aber seine Aussagekraft und sollte nicht unausgesprochen bleiben; der optionale OpenAI-Vergleichslauf sollte mindestens einmal gegen die Konfiguration der Instanz laufen.

### Nachgezogene Issues

- **#224** — Korrekturhinweis, Entscheidungstabelle (Zeile 4 berichtigt, Zeile 6 zum Zugangsmodell ergänzt), Abnahmekriterien um Account-Bindung und Kostendeckel erweitert, #250/#252 in Phase 2 aufgenommen
- **#230** — Kontext und Begründung berichtigt, vier neue Abnahmekriterien (keine anonyme Suche, Rate Limit pro Konto und global, hartes Ausgabenlimit, einmalige Kostenmessung), verkleinerter Nutzen offengelegt
- **#244** — der Hinweis „Vorgabewert ist `ollama` mit `phi3:mini`" führte in dieselbe Verwechslung und ist präzisiert

### Neue Issues

- **#250** `docs(security)`: Härtungsanforderungen für erreichbare Compose-Deployments dokumentieren
- **#252** `docs`: Standardwerte in `docs/deployment.md` gegen `application.yml` abgleichen

## Zugehörige Issues

Teil von #224. Bereitet #230 und #244 vor. Erzeugt #250 und #252.

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal (reine Dokumentationsänderung — die Pre-Push-Checkliste entfällt laut `AGENTS.md`)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _Claude Opus 5, Rolle `product-manager`_)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst

### Hinweis

Nicht mergen — zur Prüfung durch den Maintainer.
