### PR TITLE
fix(ci): Zielbranch des Tagesreports zuverlässig setzen

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -61,11 +61,18 @@ jobs:
         working-directory: site
         run: |
           if [ ! -d .git ]; then
-            git init -b gh-pages
+            git init -q
             git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Existiert gh-pages noch nicht, scheitert der vorangehende Checkout am
+          # fehlenden Ref, legt das Repository aber bereits an. HEAD zeigt dann
+          # auf dessen Standardbranch, weshalb der Zielbranch hier in jedem Fall
+          # gesetzt wird. symbolic-ref funktioniert auch ohne ersten Commit.
+          if [ "$(git symbolic-ref --short HEAD 2>/dev/null)" != "gh-pages" ]; then
+            git symbolic-ref HEAD refs/heads/gh-pages
+          fi
           git add -A
           if git diff --staged --quiet; then
             echo "Keine Änderungen zu veröffentlichen."


### PR DESCRIPTION
## Zusammenfassung

Der erste Lauf des Report-Workflows erzeugte den Report korrekt, konnte ihn aber nicht veröffentlichen:

```
error: src refspec gh-pages does not match any
```

**Ursache:** Der Schritt „Veröffentlichte Seite auschecken" läuft mit `continue-on-error`, weil `gh-pages` beim ersten Lauf noch nicht existiert. Der Checkout scheitert am fehlenden Ref, legt das Arbeitsverzeichnis aber bereits als Git-Repository an. Die anschließende Prüfung `if [ ! -d .git ]` übersprang deshalb die Initialisierung samt `-b gh-pages`, der Commit landete auf `master` und der Push fand keinen passenden Branch.

**Behebung:** Der Zielbranch wird jetzt unabhängig davon gesetzt, ob das Repository vom Checkout oder vom Workflow selbst angelegt wurde. `git symbolic-ref` wurde gewählt, weil es auch ohne ersten Commit funktioniert — anders als ein Checkout auf einem Repository ohne Historie.

## Prüfung

Die Schrittlogik lokal in vier Zuständen durchgespielt:

| Fall | Ergebnis |
| --- | --- |
| Frisch initialisiertes Repository ohne Commit | landet auf `gh-pages` |
| Folgelauf mit vorhandener Historie | bleibt auf `gh-pages`, Historie erhalten (2 Commits) |
| Lauf ohne Änderungen | bricht sauber ohne Commit ab |
| HEAD auf `master`, wie im echten Fehlerfall | wird auf `gh-pages` korrigiert |

## Zugehörige Issues

Closes #261

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (reine Workflow-Änderung; Schrittlogik in vier Zuständen geprüft)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF