### PR TITLE
docs: ADR-Nummernkollision 0008 auflösen

### DIFF
--- a/docs/decisions/0010-ein-chunk-invariante-evaluierungskorpus.md
+++ b/docs/decisions/0010-ein-chunk-invariante-evaluierungskorpus.md
@@ -6,7 +6,7 @@ Vorgeschlagen
 
 ## Kontext
 
-Der gesamte Evaluierungskorpus (`eval/corpus/<domäne>/`, siehe ADR-0008 und
+Der gesamte Evaluierungskorpus (`eval/corpus/<domäne>/`, siehe ADR-0011 und
 `docs/features/search-quality-evaluation.md`) beruht auf einer einzigen Invariante: Ein generiertes
 Dokument entspricht beim Indizieren genau einem Chunk. Nur dadurch ist ein gefundener Chunk
 eindeutig einer Entität zuordenbar — die Voraussetzung für die Ground Truth des Golden Dataset
@@ -15,7 +15,7 @@ eindeutig einer Entität zuordenbar — die Voraussetzung für die Ground Truth 
 Diese Invariante koppelt zwei Komponenten, die sonst nichts miteinander verbindet:
 
 1. den Python-Generator unter `eval/generator/` (Issue #225, bewusst außerhalb von Gradle und CI,
-   siehe ADR-0008, Entscheidung 2), und
+   siehe ADR-0011, Entscheidung 2), und
 2. `opaa.indexing.chunk-size` im Backend, konfiguriert für Spring AIs `TokenTextSplitter`.
 
 Der `TokenTextSplitter` zählt **Tokens** in der `cl100k_base`-Kodierung, nicht Zeichen oder Bytes,
@@ -44,7 +44,7 @@ Drei Optionen standen zur Wahl:
   Backend-Konfiguration entkoppelt bleibt: Ändert sich das Embedding-Modell oder der Splitter im
   Backend künftig auf eine andere Tokenisierung, veraltet die Prüfung im Generator lautlos, während
   Option (c) automatisch mit der echten Konfiguration mitzieht. Zusätzlich kostet es die
-  Standardbibliothek-only-Eigenschaft, die ADR-0008 für den Generator bewusst festgelegt hat.
+  Standardbibliothek-only-Eigenschaft, die ADR-0011 für den Generator bewusst festgelegt hat.
   **Verworfen.**
 - **(b) Der Generator behält eine konservative Byte-Vorabprüfung** (`MAX_DOCUMENT_BYTES`, aktuell
   3.000 — unterhalb des gemessenen Kipppunkts von ~3.164 Bytes bei der höchsten im Korpus
@@ -76,11 +76,11 @@ ist nicht automatisch an `chunk-size` gekoppelt — sie ist eine manuell gepfleg
 Konstante. Wird `chunk-size` künftig geändert (kleiner oder größer), muss sie erneut gegen die
 dann gemessene Tokendichte des Korpus überprüft und ggf. angepasst werden; das ist keine
 automatische Ableitung, sondern ein bewusster, reviewter Schritt, denselben Charakter wie eine
-Baseline-Aktualisierung (siehe ADR-0008, Entscheidung 5). Der eingefrorene Korpus selbst
+Baseline-Aktualisierung (siehe ADR-0011, Entscheidung 5). Der eingefrorene Korpus selbst
 (Markdown-Dateien, Manifest) ändert sich durch eine `chunk-size`-Änderung nicht — nur ob die
 Ein-Chunk-Invariante für ihn noch hält, was ausschließlich der Java-Harness in #227 verbindlich
 beantwortet. Schlägt der Harness nach einer `chunk-size`-Änderung fehl, ist das kein Korpus-Bug,
-sondern der erwartete Signalweg: Baseline und `chunk-size` sind gekoppelt (ADR-0008, Konsequenzen),
+sondern der erwartete Signalweg: Baseline und `chunk-size` sind gekoppelt (ADR-0011, Konsequenzen),
 und eine Änderung an einem der beiden erfordert einen bewussten neuen Baseline-Lauf.
 
 ## Konsequenzen

--- a/docs/decisions/0011-search-quality-evaluation-harness.md
+++ b/docs/decisions/0011-search-quality-evaluation-harness.md
@@ -1,4 +1,4 @@
-# ADR-0008: Aufbau der Suchqualitäts-Evaluierung und Ablage des Testkorpus
+# ADR-0011: Aufbau der Suchqualitäts-Evaluierung und Ablage des Testkorpus
 
 ## Status
 
@@ -129,7 +129,7 @@ Prämisse lag nicht in diesem ADR, sondern in der Demo-Beschreibung der Spezifik
   von Kosten unabhängig. Hinzu kommt, dass ein Secret in Forks ohnehin nicht verfügbar ist — auch
   das ist keine Kostenfrage.
 
-Es besteht also **kein Anlass, ADR-0008 neu zu bewerten oder zu ersetzen.**
+Es besteht also **kein Anlass, ADR-0011 neu zu bewerten oder zu ersetzen.**
 
 ### Was sich dennoch ändert
 

--- a/docs/features/search-quality-evaluation.md
+++ b/docs/features/search-quality-evaluation.md
@@ -1,7 +1,7 @@
 # Suchqualität messbar machen: Demo-Korpus und Retrieval-Regression
 
 > **Status: Abgestimmt für Phase 1 und 2.** Die strukturellen Entscheidungen sind in
-> [ADR-0008](../decisions/0008-search-quality-evaluation-harness.md) (Status: Akzeptiert)
+> [ADR-0011](../decisions/0011-search-quality-evaluation-harness.md) (Status: Akzeptiert)
 > festgehalten. Verbleibende Punkte stehen unter
 > [Offene Fragen](#offene-fragen--zukünftige-erweiterungen).
 
@@ -216,7 +216,7 @@ Ohne diesen Punkt ist die gesamte Regression wertlos:
 | 2. Git LFS | Repo-Historie bleibt schlank | Zusätzliches Tooling für alle Beitragenden, LFS-Kontingent, CI-Komplexität |
 | 3. GitHub-Release-Artefakt, im Test heruntergeladen | Repo bleibt sauber | CI braucht Netz; Artefakt kann ersetzt werden → Einfrieren nur noch durch Konvention gesichert |
 
-**Entschieden: Option 1** (ADR-0008), solange der Gesamtkorpus unter etwa 25 MB bleibt. Wird diese
+**Entschieden: Option 1** (ADR-0011), solange der Gesamtkorpus unter etwa 25 MB bleibt. Wird diese
 Grenze bei der Ausweitung auf vier Domänen überschritten, wird pro Domäne auf Option 3 gewechselt,
 mit dem SHA-256-Manifest weiterhin im Repository. Die Neubewertung ist als Prüfpunkt in der
 Ausweitung verankert.
@@ -360,8 +360,8 @@ Korpus auf eine laufende Instanz auszurollen. Das verkleinert Phase 2 erheblich.
 > **Korrektur (aus dem Review zu PR #247).** Zwei Aussagen in diesem Abschnitt waren falsch und
 > sind nachfolgend berichtigt: Die Instanz läuft **nicht** auf Ollama, sondern auf **OpenAI**, und
 > es wird **kein anonymer Lesezugriff** eingeführt. Beide Punkte hat der Maintainer klargestellt.
-> Was das für die Begründung von ADR-0008 bedeutet, steht dort im
-> [Nachtrag](../decisions/0008-search-quality-evaluation-harness.md#nachtrag-korrigierte-tatsachenlage-zur-demo-instanz).
+> Was das für die Begründung von ADR-0011 bedeutet, steht dort im
+> [Nachtrag](../decisions/0011-search-quality-evaluation-harness.md#nachtrag-korrigierte-tatsachenlage-zur-demo-instanz).
 
 Drei Folgerungen:
 
@@ -452,7 +452,7 @@ Vom Maintainer entschieden:
 | 2 | **Multi-Tenancy:** ein gemeinsamer Index, Domänentrennung über Dateinamen-Präfix. Die Workspace-Variante wartet auf #115/#117, nicht auf Epic #198. |
 | 3 | **Demo-Hosting:** die bestehende Instanz `opaa.ewerlin.com`. Sie läuft auf **OpenAI**, nicht auf Ollama — *korrigiert am 2026-08-02; die vorherige Angabe „bestehende Ollama-Konfiguration (`phi3:mini`), kein kommerzielles Modell" war falsch.* Daraus folgt ein reales Kostenrisiko pro Anfrage, das über Ausgabenlimit und Rate Limiting begrenzt wird. |
 | 4 | **Korpus-Ablage:** Hauptrepository mit SHA-256-Manifest; Neubewertung bei der Ausweitung auf vier Domänen. |
-| 5 | **ADR-0008** ist akzeptiert. Zur korrigierten Kostenprämisse siehe den Nachtrag im ADR. |
+| 5 | **ADR-0011** ist akzeptiert. Zur korrigierten Kostenprämisse siehe den Nachtrag im ADR. |
 | 6 | **Zugangsmodell der Demo:** account-gebunden hinter Keycloak. Kein Gast- und kein Read-only-Zugang. *Korrigiert am 2026-08-02; die vorherige Anforderung „anonymer Lesezugriff" ist gestrichen.* Für diese Entscheidung wird ausdrücklich **kein ADR** angelegt. |
 
 Vom Product Manager gesetzt, mangels Rückfrage, weiterhin widerrufbar:

--- a/eval/README.md
+++ b/eval/README.md
@@ -2,7 +2,7 @@
 
 Enthält die Testkorpora für die Suchqualitäts-Evaluierung (siehe
 [`docs/features/search-quality-evaluation.md`](../docs/features/search-quality-evaluation.md) und
-[ADR-0008](../docs/decisions/0008-search-quality-evaluation-harness.md)). Dieses Verzeichnis liegt
+[ADR-0011](../docs/decisions/0011-search-quality-evaluation-harness.md)). Dieses Verzeichnis liegt
 bewusst außerhalb des Gradle-Builds und der CI — die Generatoren laufen nur bei bewussten
 Korpus-Änderungen, nie automatisch.
 

--- a/eval/corpus/comic-characters/SOURCE.md
+++ b/eval/corpus/comic-characters/SOURCE.md
@@ -44,7 +44,7 @@ das bei jedem Lauf automatisch (`verify_manifest_completeness` in `generate_corp
 
 1.448 Markdown-Dateien, größtes Dokument 2.573 Bytes, kleinstes 670 Bytes, Gesamtgröße rund 1,9 MB
 (deutlich unter der 5-MB-Obergrenze aus den Abnahmekriterien von Issue #225 und der
-25-MB-Prüfschwelle aus ADR-0008).
+25-MB-Prüfschwelle aus ADR-0011).
 
 ## Bekannte Eigenheiten der Bewertungsfelder
 

--- a/eval/generator/README.md
+++ b/eval/generator/README.md
@@ -4,10 +4,10 @@ Erzeugt den Evaluierungskorpus unter `eval/corpus/comic-characters/` aus dem
 HuggingFace-Datensatz [`jrtec/Superheroes`](https://huggingface.co/datasets/jrtec/Superheroes)
 (CC0-1.0). Details zum Gesamtvorhaben stehen in
 [`docs/features/search-quality-evaluation.md`](../../docs/features/search-quality-evaluation.md)
-(Abschnitt „Der Testkorpus") und [ADR-0008](../../docs/decisions/0008-search-quality-evaluation-harness.md).
+(Abschnitt „Der Testkorpus") und [ADR-0011](../../docs/decisions/0011-search-quality-evaluation-harness.md).
 
 Dieses Werkzeug ist bewusst **außerhalb** des Gradle-Builds und der CI angesiedelt (siehe
-ADR-0008, Entscheidung 2). Es läuft nie automatisch, sondern nur, wenn der Korpus bewusst
+ADR-0011, Entscheidung 2). Es läuft nie automatisch, sondern nur, wenn der Korpus bewusst
 neu erzeugt werden soll — die Ausgabe wird dann als reguläre Änderung committet und reviewt.
 
 ## Voraussetzungen


### PR DESCRIPTION
## Zusammenfassung

Auf `main` existierten zwei Architecture Decision Records mit der Nummer 0008. Diese PR macht die Nummerierung wieder eindeutig.

Das **ältere** ADR behält die Nummer: `0008-space-and-asset-model.md` wurde um 15:55 angelegt (`4f3400e`), `0008-search-quality-evaluation-harness.md` erst um 17:02 (`4095ca9`). Letzteres wird zu **ADR-0011**, da 0009 (E2E-Teststrategie) und 0010 (Ein-Chunk-Invariante) bereits vergeben sind.

Angepasst wurden Dateiname, Überschrift und sämtliche Querverweise in `docs/features/search-quality-evaluation.md`, `docs/decisions/0010-ein-chunk-invariante-evaluierungskorpus.md`, `eval/README.md`, `eval/generator/README.md` und `eval/corpus/comic-characters/SOURCE.md`.

Verifiziert: Alle im Repository verbliebenen "ADR-0008"-Erwähnungen beziehen sich auf das Space- und Asset-Modell. `SOURCE.md` ist nicht Teil von `MANIFEST.sha256`, die Korpus-Prüfsummen bleiben also gültig.

## Zugehörige Issues

Closes #263

## Art der Änderung

- [x] Dokumentation

## Checkliste

- [x] Änderung folgt den Projektkonventionen
- [x] Dokumentation aktualisiert
- [ ] Tests ergänzt — entfällt, reine Dokumentationsänderung
- [x] Pre-Push-Checkliste: laut `AGENTS.md` bei reinen Dokumentationsänderungen übersprungen

## Offenlegung KI-Agenten

Diese Änderung wurde von Claude Opus 5 (Orchestrator-Rolle) erstellt.