### PR TITLE
docs: Betriebsfakten der Testinstanz ergänzen und Modellkonfiguration berichtigen

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,9 +34,90 @@ Unter **https://opaa.ewerlin.com** betreibt der Maintainer eine öffentliche **T
 - **Betreiber:** Der Maintainer (`criew`), auf privater VPS-Infrastruktur außerhalb dieses Repositorys.
 - **Zweck:** Öffentlich erreichbare Instanz zum Ausprobieren und Vorzeigen des aktuellen `main`-Stands.
 - **Zugriff:** Die Instanz läuft mit `OPAA_AUTH_MODE=oidc` hinter Keycloak (siehe [Authentifizierung](#authentifizierung)). Der Zugang ist bewusst account-gebunden — ein anonymer Zugang oder Gastzugang ist **nicht** vorgesehen; jede Nutzung erfordert eine Anmeldung. Wer welchen Zugang erhält, ist außerhalb dieses Dokuments geregelt und hier nicht beschrieben. Eine Konsequenz dieser Festlegung: Inhalte auf der Instanz — etwa ein dort ausgerollter Demo-Korpus (siehe #230) — sind nur für angemeldete Nutzer sichtbar, nicht öffentlich ohne Anmeldung einsehbar.
-- **Aktualisierung:** Der Workflow [`publish-images.yml`](../.github/workflows/publish-images.yml) baut bei jedem Push auf `main` neue `ghcr.io/criew/opaa-backend`- und `ghcr.io/criew/opaa-frontend`-Images und veröffentlicht sie mit den Tags `main` und `sha-<commit>` in der GHCR-Registry (siehe [Deployment aus vorgebauten Images](#deployment-aus-vorgebauten-images-ghcr) oben). Die Testinstanz aktualisiert sich bewusst **automatisch mit diesen Images** — ein Push auf `main` reicht aus, damit die Instanz zeitnah den neuen Stand ausliefert. Der genaue Mechanismus, mit dem der VPS neue Images zieht (z. B. Watchtower, Cronjob, Webhook), ist nicht Teil dieses Repositorys und hier **nicht dokumentiert**.
-- **Konfigurationsabweichungen vom Compose-Standard:** Nur der Auth-Modus (`oidc` statt `mock`) ist belegt. Welche LLM- und Embedding-Anbieter (`OPAA_AI_CHAT_PROVIDER`, `OPAA_AI_EMBEDDING_PROVIDER`) sowie welche Rate-Limit-, Bind-Adress- und Port-Einstellungen die Instanz tatsächlich verwendet, ist **nicht dokumentiert und ungeklärt** — nicht mit dem Stack-Default aus der Tabelle unten verwechseln. Der Stack-Default ohne explizite Konfiguration wäre `OPAA_AI_CHAT_PROVIDER=ollama` mit Modell `phi3:mini` und `OPAA_AI_EMBEDDING_PROVIDER=ollama` mit Modell `nomic-embed-text`; ob die Instanz diesen Default oder eine andere Konfiguration (z. B. OpenAI) verwendet, ist offen und muss beim Betreiber erfragt werden.
+- **Administration:** Genau ein Konto trägt die Rolle `SYSTEM_ADMIN` — das persönliche Konto des Maintainers, auf das `OPAA_INITIAL_ADMIN_EMAIL` zeigt. Alle administrativen Vorgänge auf der Instanz (insbesondere das Auslösen der Indizierung) führt dieses Konto über den Admin-Bereich der Oberfläche aus. Weitere Konten mit dieser Rolle gibt es derzeit nicht.
+- **Konfigurationsabweichungen vom Compose-Standard:** Belegt ist der Auth-Modus (`oidc` statt `mock`). Welche LLM- und Embedding-Anbieter (`OPAA_AI_CHAT_PROVIDER`, `OPAA_AI_EMBEDDING_PROVIDER`) sowie welche Rate-Limit-, Bind-Adress- und Port-Einstellungen die Instanz tatsächlich verwendet, ist **nicht dokumentiert und ungeklärt** — nicht mit dem Stack-Default aus der Tabelle unten verwechseln. Der Stack-Default ohne explizite Konfiguration wäre `OPAA_AI_CHAT_PROVIDER=ollama` mit Modell `phi3:mini` und `OPAA_AI_EMBEDDING_PROVIDER=ollama` mit Modell `nomic-embed-text`; die Instanz nutzt nach Aussage des Maintainers **OpenAI**, die konkreten Modellnamen und Grenzwerte sind aber offen und müssen beim Betreiber erfragt werden.
 - **Daten:** Es dürfen dort **keine personenbezogenen, vertraulichen oder produktiven Organisationsdaten** abgelegt werden. Die Instanz ist ausschließlich für Demo- und Testzwecke mit unkritischen Beispieldaten vorgesehen.
+
+### Korpus einspielen und indizieren
+
+Der Dokumentenbestand der Instanz liegt **nicht** im Repository, sondern in einem Verzeichnis auf dem VPS, das über `OPAA_INDEXING_DOCUMENT_PATH_HOST` in den Backend-Container unter `/app/documents` gemountet wird (siehe [Dokumente](#dokumente)). Das Verzeichnis wird manuell befüllt.
+
+1. Dateien vom Arbeitsrechner in das gemountete Verzeichnis auf dem VPS übertragen:
+
+   ```bash
+   rsync -av --delete ./corpus/ <benutzer>@<vps>:<PFAD-DES-GEMOUNTETEN-VERZEICHNISSES>/
+   ```
+
+   > **Lücke:** Der konkrete Pfad des gemounteten Verzeichnisses auf dem VPS ist noch nicht dokumentiert. Der Maintainer reicht ihn nach; bis dahin ist er beim Betreiber zu erfragen. Er ist **nicht** zu raten — ein falscher Pfad führt dazu, dass die Indizierung ein leeres Verzeichnis sieht.
+
+2. Ein Neustart des Backends ist nicht nötig: Das Verzeichnis ist ein Bind-Mount, neue Dateien sind sofort im Container sichtbar.
+3. Die Indizierung löst der Inhaber der Rolle `SYSTEM_ADMIN` über den **Admin-Bereich der Oberfläche** aus. Das Feld „URL" bleibt dabei **leer** — nur dann indiziert OPAA das gemountete Verzeichnis. Ein ausgefülltes URL-Feld schaltet stattdessen auf das Crawlen einer entfernten Verzeichnisauflistung um.
+4. Der Fortschritt ist im Admin-Bereich sichtbar (dahinter `GET /api/v1/indexing/status`).
+
+Unveränderte Dateien werden anhand ihrer SHA-256-Prüfsumme übersprungen; ein erneuter Lauf über denselben Bestand ist deshalb billig und gefahrlos.
+
+### Aktualisierung auf einen neuen `main`-Stand
+
+Der Workflow [`publish-images.yml`](../.github/workflows/publish-images.yml) baut bei jedem Push auf `main` neue `ghcr.io/criew/opaa-backend`- und `ghcr.io/criew/opaa-frontend`-Images und veröffentlicht sie mit den Tags `main` und `sha-<commit>` in der GHCR-Registry (siehe [Deployment aus vorgebauten Images](#deployment-aus-vorgebauten-images-ghcr) oben).
+
+Auf dem VPS zieht ein **Cron-Job** diese Images und startet den Stack neu. Derselbe Ablauf lässt sich jederzeit von Hand ausführen — im Verzeichnis, in dem die `docker-compose.yml` der Instanz liegt:
+
+```bash
+docker compose pull          # neue Images aus GHCR holen
+docker compose up -d         # Container mit den neuen Images neu erstellen
+docker image prune -f        # optional: verdrängte Images aufräumen
+```
+
+`docker compose up -d` ersetzt nur die Container, deren Image sich geändert hat; die übrigen laufen weiter. Ein `docker compose restart` genügt **nicht** — es verwendet den vorhandenen Container samt altem Image erneut.
+
+Zustand danach prüfen:
+
+```bash
+docker compose ps
+docker compose logs -f backend
+```
+
+> **Container-Namen:** Der Compose-Stack vergibt keine festen `container_name` mehr. Die Container heißen `<projektname>-<service>-<nummer>`, wobei der Projektname aus dem Verzeichnisnamen bzw. `COMPOSE_PROJECT_NAME` stammt — auf der Instanz also z. B. `opaa-postgres-1`, `opaa-backend-1`, `opaa-frontend-1`. Befehle wie `docker compose logs backend` sind gegenüber `docker logs <name>` vorzuziehen, weil sie vom Projektnamen unabhängig sind.
+
+> **Zeitplan:** Wie oft der Cron-Job läuft, ist Teil der VPS-Konfiguration und hier nicht festgehalten.
+
+#### Was ein Update mit dem Index macht
+
+Kurz: Ein Update über `docker compose pull` + `docker compose up -d` **gefährdet den Index nicht** und macht **keine Neuindizierung erforderlich**. Im Einzelnen:
+
+- **Der Korpus** liegt in einem Bind-Mount auf dem Host und ist von Container-Neustarts unberührt.
+- **Der Index** liegt in PostgreSQL, dessen Daten im benannten Volume `opaa-postgres-data` liegen. Das Volume überlebt das Neuerstellen der Container; nur `docker compose down -v` löscht es.
+- **Liquibase** wendet beim Backend-Start ausschließlich noch nicht angewendete Changesets vorwärts an. Keines der Changesets löscht Dokument- oder Vektordaten — die `dropTable`-Anweisungen in `db/changelog/changes/` stehen ausnahmslos in `rollback`-Blöcken und laufen im Normalbetrieb nie.
+- **Die Vektortabelle** wird nicht von Liquibase, sondern von Spring AI selbst angelegt (`spring.ai.vectorstore.pgvector.initialize-schema: true`). Sie wird nur erzeugt, wenn sie fehlt, und bei einem Update nicht verändert.
+
+Eine Neuindizierung wird erst durch Änderungen nötig, die nichts mit dem Image-Update zu tun haben:
+
+| Auslöser | Folge |
+|---|---|
+| `OPAA_OPENAI_EMBEDDING_MODEL` bzw. `OPAA_AI_EMBEDDING_PROVIDER` gewechselt | Bestehende Vektoren stammen aus einem anderen Modell und sind nicht mehr vergleichbar — vollständige Neuindizierung nötig |
+| `OPAA_PGVECTOR_DIMENSIONS` geändert | Passt nicht mehr zur bestehenden Vektortabelle — Tabelle muss neu aufgebaut werden |
+| `docker compose down -v` ausgeführt | Datenbank inklusive Index ist weg — vollständige Neuindizierung nötig |
+| PostgreSQL-Hauptversion gewechselt (Image-Tag von `pg18` auf eine höhere Version) | Das Datenverzeichnis im Volume ist nicht aufwärtskompatibel; ein solcher Wechsel ist ein eigener Migrationsvorgang, kein `docker compose pull` |
+
+> **Falle bei einer Neuindizierung:** OPAA überspringt Dateien, deren SHA-256-Prüfsumme unverändert ist **und** deren Datensatz in der Tabelle `documents` den Status `INDEXED` trägt. Wird die Vektortabelle geleert, ohne auch `documents` zu bereinigen, meldet ein neuer Lauf lauter übersprungene Dateien und der Index bleibt leer. Beide Tabellen liegen in derselben Datenbank — wer den Index verwirft, muss `documents` mitverwerfen.
+
+### Sicherheitshinweis: `POST /api/v1/indexing/trigger` ist von außen erreichbar
+
+Der Endpunkt ist auf der Testinstanz aus dem Internet erreichbar. Er ist durch Keycloak authentifiziert und zusätzlich auf die Rolle `SYSTEM_ADMIN` beschränkt (`@PreAuthorize("hasRole('SYSTEM_ADMIN')")` in `IndexingController`); zusätzlich greift das Rate Limiting mit einem eigenen, engen Kontingent für diesen Pfad (`OPAA_RATE_LIMIT_INDEXING_*`, standardmäßig eine Anfrage pro IP und Minute).
+
+Wer den Endpunkt aufrufen darf, kann im Feld `url` eine beliebige Adresse angeben, die der Server dann abruft und crawlt. Das schließt Ziele ein, die nur aus dem Netz des VPS erreichbar sind und nicht aus dem Internet. Fachlich ist das serverseitige Anfragefälschung (Server-Side Request Forgery, SSRF) — hier allerdings als **Eigenschaft der Funktion**, nicht als Fehler: Der Endpunkt existiert genau dafür, entfernte Dokumentenquellen zu erschließen, und er verlangt Anmeldung plus Adminrolle.
+
+**Ist-Zustand der Einschränkungen** (Stand dieser Datei, geprüft an `IndexingController`, `UrlIndexingExecutor` und `AutoindexCrawlerService`):
+
+- Das Schema ist faktisch auf `http` und `https` begrenzt, weil der verwendete `java.net.http.HttpClient` andere Schemata ablehnt. Eine eigene Schema-Prüfung im OPAA-Code gibt es **nicht**.
+- Eine **Blockliste privater oder lokaler Adressbereiche existiert nicht**. `localhost`, `127.0.0.1`, `10.0.0.0/8`, `192.168.0.0/16` und Link-Local-Adressen wie `169.254.169.254` werden nicht gesondert behandelt.
+- Weiterleitungen werden gefolgt (`HttpClient.Redirect.NORMAL`).
+- Mit `insecureSsl: true` lässt sich die Zertifikatsprüfung für den Aufruf abschalten.
+- Fehlermeldungen des Crawls landen im Jobstatus und sind über `GET /api/v1/indexing/status` lesbar; sie unterscheiden erreichbare von nicht erreichbaren Zielen.
+
+**Risikoeinordnung.** Heute klein: Nur der Maintainer besitzt die Rolle `SYSTEM_ADMIN`, und er ist zugleich Betreiber des VPS — er kann über SSH ohnehin alles, was der Endpunkt ermöglicht. Größer wird das Risiko, sobald **weitere Konten die Rolle `SYSTEM_ADMIN` erhalten**, insbesondere Konten von Personen, die keinen Zugriff auf den Server selbst haben sollen. Ein anonymer Zugang oder Gastzugang würde das Risiko deutlich vergrößern, ist für diese Instanz aber ausdrücklich ausgeschlossen (siehe `docs/features/search-quality-evaluation.md`, Abschnitt „Zugangsmodell").
+
+**Konsequenz für den Betrieb:** Die Rolle `SYSTEM_ADMIN` ist auf der Testinstanz wie ein Serverzugang zu behandeln und entsprechend sparsam zu vergeben. Eine Zielprüfung im Code (Blockliste privater Adressbereiche) wird als Härtung für den Fall weiterer Adminkonten in #267 geführt.
 
 ## Schnellstart
 


### PR DESCRIPTION
## Zusammenfassung

Ergänzt die bestätigten Betriebsfakten zur Testinstanz `opaa.ewerlin.com` in `docs/deployment.md` und **berichtigt die Modellkonfiguration**, die bisher an drei Stellen falsch beschrieben war. PR #247 hatte die Instanz beschrieben, dabei aber mehrere Punkte als „nicht dokumentiert" markieren müssen; diese Änderung schließt sie.

### Berichtigung: das Chat-Modell ist Anthropic, nicht OpenAI

Die Instanz nutzt **`claude-haiku-4-5` von Anthropic**, angebunden über Anthropics **OpenAI-kompatible Schicht**. `OPAA_AI_CHAT_PROVIDER=openai` bezeichnet dort das **Protokoll, nicht den Anbieter** — genau daraus entstand die Fehllesart „die Instanz läuft auf OpenAI", die ihrerseits schon eine Korrektur einer noch früheren Falschaussage („Ollama mit `phi3:mini`, kein Kostenrisiko") war. Eingebettet wird **lokal über Ollama mit `nomic-embed-text`** (768 Dimensionen); Anthropic bietet keine Embeddings-API an, die Zweiteilung ist deshalb dauerhaft.

**Ein Befund wird damit vollständig zurückgenommen.** Im Nachtrag des ADR stand, der CI-Harness messe eine andere Konfiguration als die Instanz fahre (`nomic-embed-text` gegen `text-embedding-3-small`), ein grüner Regressionslauf sage daher nichts über die Demo. Das war falsch — die Angabe stützte sich auf `.env.example` statt auf die tatsächliche Belegung. **CI und Instanz betten identisch ein.** Der gemessene Teil der Pipeline (Chunking, Einbettung, Vektorsuche, Ranking) ist auf beiden Seiten gleich konfiguriert; die Regression sagt also sehr wohl etwas über die Retrieval-Qualität auf der Demo aus. Die Grenze verläuft zwischen **Retrieval und Generierung**, nicht zwischen zwei Einbettungskonfigurationen. Hinfällig ist damit auch die daran gehängte Empfehlung, den optionalen OpenAI-Vergleichslauf „mindestens einmal gegen die Konfiguration der Demo-Instanz" laufen zu lassen — es gibt keinen Abstand zu beziffern.

Die zurückgenommene Aussage steht im ADR im Wortlaut zitiert, damit sie niemand aus älteren Notizen erneut aufgreift.

### Weitere Inhalte

- **Korpus einspielen und indizieren** — Verfahren: ein per `OPAA_INDEXING_DOCUMENT_PATH_HOST` gemountetes Verzeichnis, manuell per `rsync`/`scp` befüllt. Die Indizierung löst der Inhaber der Rolle `SYSTEM_ADMIN` über den Admin-Bereich aus, mit **leerem** URL-Feld — sonst crawlt OPAA eine entfernte Quelle statt des Verzeichnisses.
- **Aktualisierung** — Betrieb ausschließlich aus GHCR-Images, kein Repo-Checkout auf dem Server. Ein Deployment-Skript wird **täglich um 2 Uhr per Cron** aufgerufen, ohne den zurücksetzenden Schalter; Ausgabe protokolliert, wöchentlich rotiert. Der Ablauf ist zusätzlich als von Hand ausführbare Befehlsfolge beschrieben, inklusive des Hinweises, dass `docker compose restart` dafür nicht genügt. Damit ist das Abnahmekriterium aus #244 erfüllt.
- **Was ein Update mit dem Index macht** — geprüftes Ergebnis: kein Risiko, keine Neuindizierung nötig. Mit Tabelle der Fälle, in denen sie doch nötig wird, und dem Hinweis auf die Prüfsummen-Falle.
- **Netzwerk** — alle Container-Ports binden auf `127.0.0.1`, nach außen führt nur nginx; Keycloak unter `/idp`, ausdrücklich nicht unter `/auth`, weil das Frontend `/auth/callback` selbst als OIDC-Redirect nutzt.
- **Sicherheitshinweis zu `POST /api/v1/indexing/trigger`** — von außen erreichbar und soll es sein. Beschrieben als Eigenschaft der Funktion, mit belegtem Ist-Zustand der Ziel-URL-Prüfung und Risikoeinordnung. Die `127.0.0.1`-Bindung relativiert das nicht: nginx reicht die API-Pfade durch.

### Zwei Korrekturen an meiner eigenen ersten Fassung

- **Container-Namen entfernt.** Die erste Fassung dieses PRs dokumentierte `opaa-postgres-1` usw. „nach #251". Für die Instanz stimmt das nicht — sie betreibt eine eigene Compose-Datei mit festen `container_name`. Statt Containernamen sprechen alle Betriebsbefehle jetzt **Servicenamen** an (`docker compose logs backend`); das funktioniert auf der Instanz, in lokalen Stacks und in der E2E-Suite gleichermaßen und vermeidet Instanz-Interna ganz.
- **Keine konkreten Serverpfade.** Auf Entscheidung des Maintainers beschreibt die öffentliche Dokumentation das Verfahren, nicht die Belegung — keine Pfade, keine Benutzernamen, keine Skript- oder Logdateinamen.

### Zusätzlich: generelle Sentinel-Regel für die Ground Truth

Mitgenommen, weil dieselbe Datei betroffen ist. Aus dem Review zu #273: Der Korpus führt Werte außerhalb der definierten Skala — bei den Comichelden `overall_score: null` (105 Dokumente, unbewertet, Prosa formuliert trotzdem „scores 0 …") und `overall_score: "∞"` (18 Dokumente, Prosa sagt wörtlich „his overall score is ∞"). Beide erfüllen im Fließtext Bereichsbedingungen, die sie in der Ground Truth nicht erfüllen sollen.

Neuer Abschnitt „Sentinel-Werte: Entitäten außerhalb der Skala ausschließen", domänenunabhängig formuliert als Vorgabe für #234:

- Wo ein Feld Werte außerhalb seiner Skala führt (fehlend, unendlich, Platzhalter), werden die betroffenen Entitäten aus numerischen Golden Queries auf **diesem** Feld ausgeschlossen — weder als erwartet noch als still übergangen.
- Der Ausschluss gilt **feldbezogen, nicht dokumentbezogen**: dieselbe Entität bleibt auf anderen Feldern regulär verwendbar.
- Er greift **vor** der Bestimmung der Treffermenge, sonst verschiebt sich deren Größe unbemerkt aus dem Fenster von 2–15 Dokumenten.
- Auch die **Prosa** ist zu prüfen: Formuliert der Generator einen Sentinel als scheinbar gültigen Wert aus, repariert kein Ausschluss in der Ground Truth mehr den Widerspruch.
- Eine Tabelle hält die Sentinel-Werte je Domäne fest; sie ist bei der Ausweitung fortzuschreiben, wobei auch das Ergebnis „keine" einzutragen ist, damit ein Feld nicht als ungeprüft durchrutscht.

Begründung der Regel im Text: Ein Sentinel spielt zwei unvereinbare Rollen — für die Ground Truth ein Nichtwert, für das Retrieval ein ganz normaler Textbestandteil. Wer ihn in der Ground Truth ignoriert, misst das Retrieval an einer Erwartung, die dem Korpus widerspricht, und bekommt eine Baseline, deren Schwankungen sich nicht mehr auf Retrieval-Qualität zurückführen lassen.

**Kein eigener ADR** — ich teile die Einschätzung des Reviewers. Ablage, Versionierung und Einfrieren des Golden Dataset sind im ADR zur Suchqualitäts-Evaluierung entschieden; die Sentinel-Behandlung präzisiert die dort festgelegte Ground Truth und trifft keine eigenständige Strukturentscheidung. Das ist im Abschnitt selbst begründet, damit die Frage nicht erneut aufkommt.

## Nicht im Repository, sondern in GitHub geändert

- **#230** — Kontext um die Betriebsfakten und das Ergebnis der Index-Prüfung ergänzt, Abnahmekriterien an das reale Vorgehen angepasst. Vier Kriterien sind gegenstandslos und stehen sichtbar durchgestrichen im Ticket, statt still zu verschwinden.
- **#267** — neu: Zielprüfung für die URL-Indizierung (private Adressbereiche, explizite Schema-Prüfung), ausdrücklich als Härtung für den Fall weiterer Adminkonten, nicht als akute Lücke.

## Bewusst offen

- **Wo der konkrete Pfad des Dokumentenverzeichnisses hingehört**, ist als offene Frage in #230 vermerkt statt entschieden. Vorgesehen war, ihn aus der Dokumentation herauszuhalten und stattdessen im Issue zu nennen — nur sind Issues eines öffentlichen Repositorys genauso öffentlich wie `docs/`. Die Verlagerung würde die Sichtbarkeit nicht verringern, sondern nur verschleiern, wo die Information steht. Vorschlag: beim Maintainer belassen und direkt an denjenigen weitergeben, der den Rollout ausführt. Der Maintainer entscheidet.
- **Rate-Limit-Werte, Ports und Bind-Adressen** der Instanz sind weiterhin nicht im Repository festgehalten.

## Hinweis zum Merge-Konflikt mit #264

Diese Änderung bearbeitet `docs/features/search-quality-evaluation.md` und den ADR-Nachtrag inhaltlich; der noch offene PR #264 nummeriert dieselben Dateien von ADR-0008 auf ADR-0011 um. Beide berühren teils dieselben Absätze — der zweite der beiden PRs braucht einen Rebase. Inhaltlich widersprechen sie sich nicht.

## Zugehörige Issues

Betrifft #230, #244, #267. Kein `Closes` — #230 bleibt offen, weil der Korpus-Rollout selbst noch aussteht.

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal — **entfällt.** Reine Dokumentations- und Issue-Änderung; die Pre-Push-Checkliste wird laut `AGENTS.md` bei reinen Dokumentationsänderungen übersprungen. Es wurde keine Zeile Code angefasst.
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet — keine E-Mail-Adresse (das Administrationskonto ist über seine Rolle beschrieben), keine Serverpfade, keine Zugangsdaten.
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _Claude Opus 5, Rolle Product Manager_)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst

Die Betriebsfakten stammen vollständig vom Maintainer. Der Agent hat sie eingeordnet und alle Aussagen zum Code — Ziel-URL-Prüfung, Liquibase-Verhalten, Volume-Persistenz, Überspringen unveränderter Dateien, Rate-Limit-Pfade — an `IndexingController`, `UrlIndexingExecutor`, `AutoindexCrawlerService`, `FileProcessingService`, `RateLimitConfiguration`, `docker-compose.yml`, `application.yml` und den Changesets in `db/changelog/changes/` belegt, statt sie anzunehmen.
