### PR TITLE
docs: PR-Regeln an Merge ohne Approval anpassen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,9 @@ Jeder Branch ist über seine ID mit einem GitHub-Issue verknüpft.
 ### Pull Requests
 
 - Keine direkten Pushes zu `main` — alle Änderungen gehen über PRs
-- PRs müssen vor dem Merge überprüft werden
+- Der Code Reviewer prüft jeden PR vor dem Merge; seine Befunde gehen zurück an den Autor
+- Ein formales Approval in GitHub ist nicht erforderlich. Es genügt, dass einer der Maintainer (`criew` oder `bigpuritz`) den PR merged, sobald CI grün ist
+- Kein Agent merged jemals einen PR
 - Beim Erstellen eines PRs IMMER passende Labels basierend auf dem Inhalt zuweisen
 - PR-Titel und -Beschreibungen MÜSSEN auf Deutsch verfasst werden (siehe [Projektsprache](#projektsprache))
 - IMMER das PR-Template (Zusammenfassung, Zugehörige Issues, Art der Änderung, Checkliste, KI-Agenten-Offenlegung) in [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) für neue Pull Requests verwenden

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,15 @@ docs: update architecture decision records
 - Alle Änderungen gehen über PRs — keine direkten Pushes zu `main`
 - PR-Template vollständig ausfüllen
 - Zugehörige GitHub-Issues mit `Closes #N` verknüpfen
-- Sicherstellen, dass Tests bestehen, bevor ein Review angefordert wird
+- Sicherstellen, dass Tests bestehen, bevor der PR zum Merge angeboten wird
+
+### Wie ein PR nach `main` kommt
+
+1. CI muss grün sein — die Prüfungen `backend`, `backend-integration` und `frontend` sind Voraussetzung für den Merge
+2. Der Code Reviewer prüft die Änderung; offene Befunde und Konversationen werden vorher aufgelöst
+3. Einer der Maintainer merged den PR
+
+Ein formales Approval in GitHub ist dafür nicht erforderlich. Maintainer mit Merge-Recht sind [@criew](https://github.com/criew) und [@bigpuritz](https://github.com/bigpuritz).
 
 ## Wann einen E2E-Test schreiben?
 
@@ -92,7 +100,7 @@ Dieses Projekt begrüßt ausdrücklich Beiträge von KI-Coding-Agenten (Claude C
 
 ### Erwartungen an KI-generierten Code
 
-- Alle KI-Beiträge durchlaufen denselben PR-Review-Prozess wie menschlicher Code
+- Alle KI-Beiträge durchlaufen denselben Weg nach `main` wie menschlicher Code: CI, Code Review, Merge durch einen Maintainer
 - Conventional-Commits-Format verwenden
 - `Co-Authored-By`-Trailer in Commits einfügen (z. B. `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`)
 - KI-Beteiligung im Abschnitt „AI Agent Disclosure" des PR-Templates kennzeichnen

--- a/docs/AGENT-ORGANIZATION.md
+++ b/docs/AGENT-ORGANIZATION.md
@@ -81,7 +81,7 @@ flowchart TD
     D --> E[Developer: Worktree + Feature-Branch\n→ Implementierung + Tests + Docs → PR]
     E --> F[Code Reviewer + CI]
     F -- Befunde --> E
-    F -- genehmigt --> G[Maintainer merged]
+    F -- bestanden --> G[Maintainer merged\ncriew oder bigpuritz]
     G -.-> H[QA Engineer: geplante Läufe auf main\nE2E, RAG-Evaluierung, Coverage]
     H -. Befunde werden neue Issues .-> C
 ```
@@ -90,8 +90,10 @@ flowchart TD
 2. **Definition** — Der Product Manager recherchiert Repository-Kontext, stellt seine Klärungsfragen **einmal, gebündelt, im Voraus** (durch den Orchestrator weitergeleitet), schreibt dann die Feature-Spezifikation in `docs/features/` und erstellt beschriftete GitHub-Issues.
 3. **Genehmigung** — Der Maintainer prüft die Issues, bevor die Implementierung beginnt.
 4. **Implementierung** — Für jedes genehmigte Issue arbeitet ein Entwickler-Agent in einem isolierten Worktree auf einem `feature/<issue-id>_<desc>`-Branch und öffnet einen PR unter Verwendung des PR-Templates (einschließlich KI-Agenten-Offenlegung).
-5. **Review** — Der Code Reviewer und CI agieren als Schranken. Befunde gehen zurück zum Entwickler; der PR ist nur bereit, wenn beide bestehen.
-6. **Merge** — **Nur Menschen mergen.** Kein Agent mergt jemals einen PR. (Diese Richtlinie kann schrittweise gelockert werden, wenn Vertrauen aufgebaut ist — jede Änderung daran muss hier festgehalten werden.)
+5. **Review** — Der Code Reviewer und CI agieren als Schranken. Befunde gehen zurück zum Entwickler; der PR ist nur bereit, wenn beide bestehen. Ein formales Approval in GitHub ist nicht erforderlich — die Schranke ist der Reviewer selbst, nicht der Klick darauf.
+6. **Merge** — **Nur Menschen mergen**, und zwar einer der Maintainer `criew` oder `bigpuritz`. Kein Agent mergt jemals einen PR. (Diese Richtlinie kann schrittweise gelockert werden, wenn Vertrauen aufgebaut ist — jede Änderung daran muss hier festgehalten werden.)
+
+Technisch durchgesetzt sind auf `main` die Status-Checks `backend`, `backend-integration` und `frontend`, das Auflösen offener Konversationen sowie der Schutz gegen Force-Push und Löschen. Schreibzugriff haben ausschließlich die beiden Maintainer; dass niemand sonst mergen kann, folgt daraus und braucht keine zusätzliche Regel.
 
 ### Wo QA passt: zwei Qualitätsschleifen
 


### PR DESCRIPTION
## Zusammenfassung

Ein formales Approval in GitHub ist für einen Merge nach `main` nicht mehr erforderlich. Es genügt, dass einer der Maintainer den PR merged, sobald CI grün ist. Dieser PR zieht die Dokumentation nach.

**Bereits umgesetzt** (Repository-Einstellung, nicht Teil dieses Diffs): Die Anforderung `required_pull_request_reviews` wurde aus dem Branch-Schutz von `main` entfernt.

## Was sich ändert

| | vorher | nachher |
| --- | --- | --- |
| Approval in GitHub | 1 erforderlich | nicht erforderlich |
| Code Reviewer | verpflichtend | verpflichtend (unverändert) |
| Status-Checks | `backend`, `backend-integration`, `frontend` | unverändert |
| Konversationen auflösen | erforderlich | unverändert |
| Force-Push / Löschen von `main` | blockiert | unverändert |
| Wer merged | Maintainer | Maintainer, jetzt namentlich benannt |

## Warum keine Regel „nur criew oder bigpuritz dürfen mergen"

Schreibzugriff auf das Repository haben ausschließlich diese beiden. Dass niemand sonst mergen kann, folgt bereits aus den Zugriffsrechten. Eine zusätzliche Branch-Schutz-Regel wäre eine zweite Wahrheit, die auseinanderlaufen kann — und Push-Beschränkungen stehen bei Repositories im Besitz eines Benutzerkontos ohnehin nicht zur Verfügung. Die Dokumentation benennt die beiden nun explizit.

## Geänderte Dateien

- `AGENTS.md` — Abschnitt zu Pull Requests
- `CONTRIBUTING.md` — neuer Abschnitt „Wie ein PR nach `main` kommt", Maintainer verlinkt
- `docs/AGENT-ORGANIZATION.md` — Workflow-Schritte 5 und 6, Ablaufdiagramm, sowie ein Absatz über die tatsächlich durchgesetzten Schutzregeln

## Zugehörige Issues

Closes #268

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal (reine Dokumentationsänderung — Pre-Push-Checkliste entfällt)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF