### PR TITLE
docs: Modellkonfiguration der Testinstanz berichtigen und Sentinel-Regel für die Ground Truth ergänzen

### DIFF
--- a/docs/decisions/0011-search-quality-evaluation-harness.md
+++ b/docs/decisions/0011-search-quality-evaluation-harness.md
@@ -102,12 +102,20 @@ behaupteten, die öffentliche Instanz `opaa.ewerlin.com` laufe mit ihrer „best
 Ollama-Konfiguration (`phi3:mini`)", weshalb „kein Kostenrisiko" bestehe und „kein kommerzielles
 Modell" eingeführt werde.
 
-Der Maintainer hat auf Nachfrage klargestellt: **Die Instanz nutzt OpenAI.** Die Fehlannahme
-entstand aus einer Verwechslung zweier Ebenen — der *Anwendungs-Default* in
+Der Maintainer hat auf Nachfrage klargestellt, dass die Instanz nicht mit dem Ollama-Anwendungsdefault
+läuft. Die Fehlannahme entstand aus einer Verwechslung zweier Ebenen — der *Anwendungs-Default* in
 `backend/src/main/resources/application.yml` ist `${OPAA_AI_CHAT_PROVIDER:ollama}`, die
 *empfohlene Compose-Belegung* in `.env.example` dagegen `OPAA_AI_CHAT_PROVIDER=openai`. Die zweite
 Ebene beschreibt den tatsächlichen Betrieb, die erste nur das Verhalten ohne jede Konfiguration.
 Ein Folge-Issue klärt diese Zweideutigkeit auch in `docs/deployment.md`.
+
+> **Zweite Berichtigung (2026-08-02, PR #269).** Die daraus abgeleitete Aussage „Die Instanz nutzt
+> OpenAI" war ihrerseits ungenau und ist zurückgenommen. Die Betriebsdokumentation des Maintainers
+> belegt: **Das Chat-Modell ist `claude-haiku-4-5` von Anthropic**, angebunden über Anthropics
+> OpenAI-kompatible Schicht — `OPAA_AI_CHAT_PROVIDER=openai` bezeichnet dort das Protokoll, nicht
+> den Anbieter. **Eingebettet wird mit `nomic-embed-text` lokal über Ollama** (768 Dimensionen),
+> weil Anthropic keine Embeddings-API anbietet. Diese Aufteilung ist dauerhaft. Der Abschnitt
+> „Was sich dennoch ändert" weiter unten ist wegen dieser Korrektur neu gefasst.
 
 Zweite Korrektur derselben Runde, ohne Bezug zu diesem ADR, aber der Vollständigkeit halber: Die
 Instanz erhält **keinen anonymen Lesezugriff**; sie bleibt account-gebunden hinter Keycloak. Für
@@ -133,20 +141,37 @@ Es besteht also **kein Anlass, ADR-0011 neu zu bewerten oder zu ersetzen.**
 
 ### Was sich dennoch ändert
 
-Eine Konsequenz kommt hinzu, die vor der Korrektur nicht sichtbar war und die den ADR nicht
-umstößt, aber seine Aussagekraft begrenzt:
+> **Neu gefasst am 2026-08-02 (PR #269).** Die ursprüngliche Fassung dieses Abschnitts stützte sich
+> auf die inzwischen widerlegte Annahme, die Instanz bette mit `text-embedding-3-small` über OpenAI
+> ein. Der daraus gezogene Schluss war falsch und ist **vollständig zurückgenommen**; die
+> zurückgenommene Aussage steht unten im Wortlaut, damit niemand sie aus älteren Notizen erneut
+> aufgreift.
 
-- **Der CI-Harness misst eine andere Konfiguration als die Demo-Instanz fährt.** Die Baseline
-  entsteht mit `nomic-embed-text` über Ollama, die Instanz bettet laut `.env.example` mit
-  `text-embedding-3-small` über OpenAI ein. Ein grüner Regressionslauf sagt damit nichts über die
-  Trefferqualität, die ein Besucher auf `opaa.ewerlin.com` erlebt. Das ist vertretbar — der
-  Harness ist ein Regressionsdetektor für die Pipeline, keine Vorhersage für eine bestimmte
-  Installation —, muss aber benannt werden, damit niemand die Baseline als Aussage über die Demo
-  liest.
-- Daraus folgt eine Präzisierung, keine Änderung: Der in Entscheidung 4 vorgesehene **optionale
-  OpenAI-Vergleichslauf sollte mindestens einmal gegen die Konfiguration der Demo-Instanz laufen**,
-  damit der Abstand zwischen beiden Anbietern beziffert ist. Er bleibt ausdrücklich außerhalb der
-  Baseline.
-- Für den Betrieb der Demo — nicht für diesen ADR — folgt aus der Korrektur, dass Kosten aktiv zu
-  begrenzen sind: Ausgabenlimit beim Anbieter und Rate Limiting pro Konto. Das ist in der
-  Feature-Spezifikation und in den Abnahmekriterien von #230 verankert.
+Zwei Punkte, von denen der erste die Aussagekraft des Harness **stärkt** statt sie zu begrenzen:
+
+- **Der CI-Harness misst dieselbe Einbettung wie die Demo-Instanz.** Beide verwenden
+  `nomic-embed-text` über Ollama mit 768 Dimensionen. Ein grüner Regressionslauf sagt damit sehr
+  wohl etwas über die Retrieval-Qualität, die ein Besucher auf `opaa.ewerlin.com` erlebt: Der
+  gemessene Teil der Pipeline — Chunking, Einbettung, Vektorsuche, Ranking — ist in CI und auf der
+  Instanz identisch konfiguriert. Nicht gemessen wird weiterhin die **Generierung**, weil kein LLM
+  am Harness beteiligt ist und das Chat-Modell der Instanz (`claude-haiku-4-5` von Anthropic) in CI
+  nicht vorkommt. Die Grenze verläuft also zwischen Retrieval und Generierung, nicht zwischen zwei
+  Einbettungskonfigurationen.
+- Für den Betrieb der Demo — nicht für diesen ADR — bleibt es dabei, dass Kosten aktiv zu begrenzen
+  sind: Ausgabenlimit beim Chat-Anbieter und Rate Limiting pro Konto. Neu ist die Einsicht, dass
+  **die Indizierung selbst kostenlos ist**, weil lokal eingebettet wird; das Kostenrisiko liegt
+  vollständig auf der Anfrageseite. Verankert ist das in der Feature-Spezifikation und in den
+  Abnahmekriterien von #230.
+
+**Zurückgenommene Aussage (galt vom 2026-08-02 bis zur Berichtigung desselben Tages):**
+
+> „Der CI-Harness misst eine andere Konfiguration als die Demo-Instanz fährt. Die Baseline entsteht
+> mit `nomic-embed-text` über Ollama, die Instanz bettet laut `.env.example` mit
+> `text-embedding-3-small` über OpenAI ein. Ein grüner Regressionslauf sagt damit nichts über die
+> Trefferqualität, die ein Besucher auf `opaa.ewerlin.com` erlebt." — **Falsch.** Die Angabe stützte
+> sich auf `.env.example` statt auf die tatsächliche Belegung der Instanz. Ebenfalls hinfällig ist
+> die daran gehängte Empfehlung, den optionalen OpenAI-Vergleichslauf „mindestens einmal gegen die
+> Konfiguration der Demo-Instanz" laufen zu lassen: Es gibt keinen Abstand zwischen zwei
+> Einbettungsanbietern zu beziffern, weil beide Seiten dasselbe Modell verwenden. Der optionale
+> Vergleichslauf aus Entscheidung 4 behält seinen ursprünglichen Zweck — Modellvergleich —, aber
+> nicht mehr diese Begründung.

--- a/docs/decisions/0011-search-quality-evaluation-harness.md
+++ b/docs/decisions/0011-search-quality-evaluation-harness.md
@@ -109,7 +109,7 @@ läuft. Die Fehlannahme entstand aus einer Verwechslung zweier Ebenen — der *A
 Ebene beschreibt den tatsächlichen Betrieb, die erste nur das Verhalten ohne jede Konfiguration.
 Ein Folge-Issue klärt diese Zweideutigkeit auch in `docs/deployment.md`.
 
-> **Zweite Berichtigung (2026-08-02, PR #269).** Die daraus abgeleitete Aussage „Die Instanz nutzt
+> **Zweite Berichtigung (2026-08-02).** Die daraus abgeleitete Aussage „Die Instanz nutzt
 > OpenAI" war ihrerseits ungenau und ist zurückgenommen. Die Betriebsdokumentation des Maintainers
 > belegt: **Das Chat-Modell ist `claude-haiku-4-5` von Anthropic**, angebunden über Anthropics
 > OpenAI-kompatible Schicht — `OPAA_AI_CHAT_PROVIDER=openai` bezeichnet dort das Protokoll, nicht
@@ -141,7 +141,7 @@ Es besteht also **kein Anlass, ADR-0011 neu zu bewerten oder zu ersetzen.**
 
 ### Was sich dennoch ändert
 
-> **Neu gefasst am 2026-08-02 (PR #269).** Die ursprüngliche Fassung dieses Abschnitts stützte sich
+> **Neu gefasst am 2026-08-02.** Die ursprüngliche Fassung dieses Abschnitts stützte sich
 > auf die inzwischen widerlegte Annahme, die Instanz bette mit `text-embedding-3-small` über OpenAI
 > ein. Der daraus gezogene Schluss war falsch und ist **vollständig zurückgenommen**; die
 > zurückgenommene Aussage steht unten im Wortlaut, damit niemand sie aus älteren Notizen erneut

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,20 +35,40 @@ Unter **https://opaa.ewerlin.com** betreibt der Maintainer eine öffentliche **T
 - **Zweck:** Öffentlich erreichbare Instanz zum Ausprobieren und Vorzeigen des aktuellen `main`-Stands.
 - **Zugriff:** Die Instanz läuft mit `OPAA_AUTH_MODE=oidc` hinter Keycloak (siehe [Authentifizierung](#authentifizierung)). Der Zugang ist bewusst account-gebunden — ein anonymer Zugang oder Gastzugang ist **nicht** vorgesehen; jede Nutzung erfordert eine Anmeldung. Wer welchen Zugang erhält, ist außerhalb dieses Dokuments geregelt und hier nicht beschrieben. Eine Konsequenz dieser Festlegung: Inhalte auf der Instanz — etwa ein dort ausgerollter Demo-Korpus (siehe #230) — sind nur für angemeldete Nutzer sichtbar, nicht öffentlich ohne Anmeldung einsehbar.
 - **Administration:** Genau ein Konto trägt die Rolle `SYSTEM_ADMIN` — das persönliche Konto des Maintainers, auf das `OPAA_INITIAL_ADMIN_EMAIL` zeigt. Alle administrativen Vorgänge auf der Instanz (insbesondere das Auslösen der Indizierung) führt dieses Konto über den Admin-Bereich der Oberfläche aus. Weitere Konten mit dieser Rolle gibt es derzeit nicht.
-- **Konfigurationsabweichungen vom Compose-Standard:** Belegt ist der Auth-Modus (`oidc` statt `mock`). Welche LLM- und Embedding-Anbieter (`OPAA_AI_CHAT_PROVIDER`, `OPAA_AI_EMBEDDING_PROVIDER`) sowie welche Rate-Limit-, Bind-Adress- und Port-Einstellungen die Instanz tatsächlich verwendet, ist **nicht dokumentiert und ungeklärt** — nicht mit dem Stack-Default aus der Tabelle unten verwechseln. Der Stack-Default ohne explizite Konfiguration wäre `OPAA_AI_CHAT_PROVIDER=ollama` mit Modell `phi3:mini` und `OPAA_AI_EMBEDDING_PROVIDER=ollama` mit Modell `nomic-embed-text`; die Instanz nutzt nach Aussage des Maintainers **OpenAI**, die konkreten Modellnamen und Grenzwerte sind aber offen und müssen beim Betreiber erfragt werden.
+- **Netzwerk:** Alle Container-Ports binden ausschließlich auf `127.0.0.1`. Nach außen führt ausschließlich ein nginx auf dem Host, der TLS terminiert und weiterleitet. Keycloak ist unter dem Pfad **`/idp`** eingehängt — ausdrücklich **nicht** unter `/auth`, weil das Frontend `/auth/callback` selbst als OIDC-Redirect verwendet und die beiden sich sonst überlagern.
+- **Betriebsart:** Die Instanz läuft ausschließlich aus vorgebauten GHCR-Images (`ghcr.io/criew/opaa-backend:main`, `ghcr.io/criew/opaa-frontend:main`). Auf dem Server gibt es **keinen Repository-Checkout** und keinen Build — nur eine `docker-compose.yml`, die `image:` statt `build:` verwendet.
 - **Daten:** Es dürfen dort **keine personenbezogenen, vertraulichen oder produktiven Organisationsdaten** abgelegt werden. Die Instanz ist ausschließlich für Demo- und Testzwecke mit unkritischen Beispieldaten vorgesehen.
+
+#### Modellkonfiguration der Instanz
+
+Hier ist eine Verwechslung angelegt, die bereits mehrfach zu falschen Aussagen geführt hat und deshalb ausdrücklich benannt wird:
+
+| | Anbieter | Modell | Anmerkung |
+|---|---|---|---|
+| **Chat** | Anthropic | `claude-haiku-4-5` | Angebunden über Anthropics **OpenAI-kompatible Schicht**. `OPAA_AI_CHAT_PROVIDER` steht deshalb formal auf `openai`; nur `OPAA_OPENAI_BASE_URL`, der API-Schlüssel und `OPAA_OPENAI_CHAT_MODEL` zeigen auf Anthropic. |
+| **Embedding** | Ollama, lokal | `nomic-embed-text` | 768 Dimensionen, entsprechend `OPAA_PGVECTOR_DIMENSIONS=768` statt des Stack-Defaults 1536. |
+
+Drei Punkte dazu:
+
+- **Der Wert `openai` in `OPAA_AI_CHAT_PROVIDER` bezeichnet hier das Protokoll, nicht den Anbieter.** Wer ihn als Anbieterangabe liest, kommt zu einem falschen Ergebnis — genau das ist in der Vergangenheit passiert.
+- **Die Aufteilung Chat bei Anthropic, Embedding lokal ist dauerhaft, nicht provisorisch.** Anthropic bietet keine Embeddings-API an; ein einheitlicher Anbieter für beides ist mit dieser Wahl gar nicht möglich.
+- Anthropic bezeichnet die OpenAI-kompatible Schicht ausdrücklich als Werkzeug zum Testen und Vergleichen, nicht als produktionsreifen Zugang. Für eine Testinstanz ist das angemessen; für einen Dauerbetrieb wäre die native Anbindung zu wählen.
+
+**Kostenseite:** Token-Kosten entstehen ausschließlich beim Chat. Die Einbettung läuft lokal über Ollama und kostet nichts — eine Neuindizierung des Korpus ist deshalb kostenlos, unabhängig von seiner Größe.
+
+Die Rate-Limit-Werte der Instanz sind hier nicht festgehalten.
 
 ### Korpus einspielen und indizieren
 
 Der Dokumentenbestand der Instanz liegt **nicht** im Repository, sondern in einem Verzeichnis auf dem VPS, das über `OPAA_INDEXING_DOCUMENT_PATH_HOST` in den Backend-Container unter `/app/documents` gemountet wird (siehe [Dokumente](#dokumente)). Das Verzeichnis wird manuell befüllt.
 
-1. Dateien vom Arbeitsrechner in das gemountete Verzeichnis auf dem VPS übertragen:
+1. Dateien vom Arbeitsrechner in das gemountete Verzeichnis auf dem VPS übertragen, per `rsync` oder `scp`:
 
    ```bash
-   rsync -av --delete ./corpus/ <benutzer>@<vps>:<PFAD-DES-GEMOUNTETEN-VERZEICHNISSES>/
+   rsync -av --delete ./corpus/ <benutzer>@<host>:<dokumentenverzeichnis>/
    ```
 
-   > **Lücke:** Der konkrete Pfad des gemounteten Verzeichnisses auf dem VPS ist noch nicht dokumentiert. Der Maintainer reicht ihn nach; bis dahin ist er beim Betreiber zu erfragen. Er ist **nicht** zu raten — ein falscher Pfad führt dazu, dass die Indizierung ein leeres Verzeichnis sieht.
+   > **Bewusst ohne konkrete Angaben:** `criew/opaa` ist ein öffentliches Repository. Host, Benutzername und der Pfad des Dokumentenverzeichnisses auf dem Server stehen deshalb nicht hier, sondern in der Betriebsdokumentation des Maintainers. Wer den Rollout ausführen soll, bekommt sie von ihm. Beschrieben ist hier das Verfahren, nicht die Belegung.
 
 2. Ein Neustart des Backends ist nicht nötig: Das Verzeichnis ist ein Bind-Mount, neue Dateien sind sofort im Container sichtbar.
 3. Die Indizierung löst der Inhaber der Rolle `SYSTEM_ADMIN` über den **Admin-Bereich der Oberfläche** aus. Das Feld „URL" bleibt dabei **leer** — nur dann indiziert OPAA das gemountete Verzeichnis. Ein ausgefülltes URL-Feld schaltet stattdessen auf das Crawlen einer entfernten Verzeichnisauflistung um.
@@ -60,7 +80,11 @@ Unveränderte Dateien werden anhand ihrer SHA-256-Prüfsumme übersprungen; ein 
 
 Der Workflow [`publish-images.yml`](../.github/workflows/publish-images.yml) baut bei jedem Push auf `main` neue `ghcr.io/criew/opaa-backend`- und `ghcr.io/criew/opaa-frontend`-Images und veröffentlicht sie mit den Tags `main` und `sha-<commit>` in der GHCR-Registry (siehe [Deployment aus vorgebauten Images](#deployment-aus-vorgebauten-images-ghcr) oben).
 
-Auf dem VPS zieht ein **Cron-Job** diese Images und startet den Stack neu. Derselbe Ablauf lässt sich jederzeit von Hand ausführen — im Verzeichnis, in dem die `docker-compose.yml` der Instanz liegt:
+Auf dem Server liegt ein **Deployment-Skript**, das genau das tut: die aktuellen Images ziehen und den Stack auf den neuen Stand bringen. Es kennt zusätzlich einen Schalter, der auch die Volumes verwirft — damit ist die Datenbank und mit ihr der gesamte Index weg. Dieser Schalter ist deshalb kein Aktualisierungs-, sondern ein Neuaufsetzschritt; danach ist zwingend eine vollständige Neuindizierung nötig.
+
+Ein **Cron-Job ruft dieses Skript täglich um 2 Uhr morgens auf** — ohne den zurücksetzenden Schalter, die Daten bleiben also erhalten. Die Ausgabe der Läufe wird protokolliert und wöchentlich rotiert. Die Instanz folgt dem `main`-Stand damit mit höchstens einem Tag Verzug; ein Push auf `main` erscheint nicht sofort, sondern beim nächsten nächtlichen Lauf. Wer schneller sein will, ruft das Skript von Hand auf.
+
+Ohne das Skript entspricht der Ablauf diesen Schritten, ausgeführt im Verzeichnis mit der `docker-compose.yml` der Instanz:
 
 ```bash
 docker compose pull          # neue Images aus GHCR holen
@@ -77,9 +101,7 @@ docker compose ps
 docker compose logs -f backend
 ```
 
-> **Container-Namen:** Der Compose-Stack vergibt keine festen `container_name` mehr. Die Container heißen `<projektname>-<service>-<nummer>`, wobei der Projektname aus dem Verzeichnisnamen bzw. `COMPOSE_PROJECT_NAME` stammt — auf der Instanz also z. B. `opaa-postgres-1`, `opaa-backend-1`, `opaa-frontend-1`. Befehle wie `docker compose logs backend` sind gegenüber `docker logs <name>` vorzuziehen, weil sie vom Projektnamen unabhängig sind.
-
-> **Zeitplan:** Wie oft der Cron-Job läuft, ist Teil der VPS-Konfiguration und hier nicht festgehalten.
+> **Service- statt Containernamen verwenden.** Alle Befehle oben sprechen den **Servicenamen** aus der Compose-Datei an (`backend`, `frontend`, `postgres`), nicht einen Containernamen. Das ist der robustere Weg: Wie die Container tatsächlich heißen, hängt davon ab, ob die jeweilige Compose-Datei `container_name` setzt und wie das Compose-Projekt heißt — beides unterscheidet sich zwischen der Testinstanz, lokalen Entwicklungsstacks und der E2E-Suite. `docker compose logs backend` funktioniert in allen dreien, `docker logs <name>` nur in einem.
 
 #### Was ein Update mit dem Index macht
 
@@ -94,16 +116,20 @@ Eine Neuindizierung wird erst durch Änderungen nötig, die nichts mit dem Image
 
 | Auslöser | Folge |
 |---|---|
-| `OPAA_OPENAI_EMBEDDING_MODEL` bzw. `OPAA_AI_EMBEDDING_PROVIDER` gewechselt | Bestehende Vektoren stammen aus einem anderen Modell und sind nicht mehr vergleichbar — vollständige Neuindizierung nötig |
-| `OPAA_PGVECTOR_DIMENSIONS` geändert | Passt nicht mehr zur bestehenden Vektortabelle — Tabelle muss neu aufgebaut werden |
-| `docker compose down -v` ausgeführt | Datenbank inklusive Index ist weg — vollständige Neuindizierung nötig |
+| Embedding-Modell oder -Anbieter gewechselt | Bestehende Vektoren stammen aus einem anderen Modell und sind nicht mehr vergleichbar — vollständige Neuindizierung nötig. **`OPAA_PGVECTOR_DIMENSIONS` muss mitgezogen werden**, sonst passt die Vektorbreite nicht zum neuen Modell |
+| `OPAA_PGVECTOR_DIMENSIONS` geändert | Passt nicht mehr zur bestehenden Vektortabelle — die Datenbank muss zurückgesetzt und der Korpus neu indiziert werden |
+| `docker compose down -v` bzw. das Deployment-Skript mit zurücksetzendem Schalter ausgeführt | Datenbank inklusive Index ist weg — vollständige Neuindizierung nötig |
 | PostgreSQL-Hauptversion gewechselt (Image-Tag von `pg18` auf eine höhere Version) | Das Datenverzeichnis im Volume ist nicht aufwärtskompatibel; ein solcher Wechsel ist ein eigener Migrationsvorgang, kein `docker compose pull` |
+
+Auf der Testinstanz sind `nomic-embed-text` und `OPAA_PGVECTOR_DIMENSIONS=768` fest aneinander gekoppelt: Wer das Embedding-Modell wechselt, muss beide Werte gemeinsam ändern und die Datenbank zurücksetzen. Ein Wechsel des **Chat**-Modells berührt den Index dagegen nicht — Chat und Einbettung sind auf der Instanz ohnehin getrennte Anbieter.
 
 > **Falle bei einer Neuindizierung:** OPAA überspringt Dateien, deren SHA-256-Prüfsumme unverändert ist **und** deren Datensatz in der Tabelle `documents` den Status `INDEXED` trägt. Wird die Vektortabelle geleert, ohne auch `documents` zu bereinigen, meldet ein neuer Lauf lauter übersprungene Dateien und der Index bleibt leer. Beide Tabellen liegen in derselben Datenbank — wer den Index verwirft, muss `documents` mitverwerfen.
 
 ### Sicherheitshinweis: `POST /api/v1/indexing/trigger` ist von außen erreichbar
 
-Der Endpunkt ist auf der Testinstanz aus dem Internet erreichbar. Er ist durch Keycloak authentifiziert und zusätzlich auf die Rolle `SYSTEM_ADMIN` beschränkt (`@PreAuthorize("hasRole('SYSTEM_ADMIN')")` in `IndexingController`); zusätzlich greift das Rate Limiting mit einem eigenen, engen Kontingent für diesen Pfad (`OPAA_RATE_LIMIT_INDEXING_*`, standardmäßig eine Anfrage pro IP und Minute).
+Der Endpunkt ist auf der Testinstanz aus dem Internet erreichbar. Dass alle Container-Ports nur auf `127.0.0.1` binden, ändert daran nichts — der nach außen gerichtete nginx reicht die API-Pfade durch, und der Indizierungspfad ist davon nicht ausgenommen. Die Bindung auf `127.0.0.1` verhindert lediglich, dass jemand die Container unter Umgehung des nginx direkt anspricht.
+
+Er ist durch Keycloak authentifiziert und zusätzlich auf die Rolle `SYSTEM_ADMIN` beschränkt (`@PreAuthorize("hasRole('SYSTEM_ADMIN')")` in `IndexingController`); zusätzlich greift das Rate Limiting mit einem eigenen, engen Kontingent für diesen Pfad (`OPAA_RATE_LIMIT_INDEXING_*`, standardmäßig eine Anfrage pro IP und Minute).
 
 Wer den Endpunkt aufrufen darf, kann im Feld `url` eine beliebige Adresse angeben, die der Server dann abruft und crawlt. Das schließt Ziele ein, die nur aus dem Netz des VPS erreichbar sind und nicht aus dem Internet. Fachlich ist das serverseitige Anfragefälschung (Server-Side Request Forgery, SSRF) — hier allerdings als **Eigenschaft der Funktion**, nicht als Fehler: Der Endpunkt existiert genau dafür, entfernte Dokumentenquellen zu erschließen, und er verlangt Anmeldung plus Adminrolle.
 

--- a/docs/features/search-quality-evaluation.md
+++ b/docs/features/search-quality-evaluation.md
@@ -258,6 +258,51 @@ Dokumente) — sonst ist die Metrik nicht aussagekräftig. Die rund 60 boolesche
 Fähigkeits-Merkmale des Datensatzes lassen sich dafür kombinieren, bis die Treffermenge in diesem
 Fenster liegt.
 
+### Sentinel-Werte: Entitäten außerhalb der Skala ausschließen
+
+**Regel (verbindlich, domänenübergreifend).** Führt ein Feld Werte, die außerhalb seiner
+definierten Skala liegen — fehlend, unendlich, ein Platzhalter wie `-1`, `"unknown"` oder `"N/A"` —,
+dann werden die betroffenen Entitäten aus jeder numerischen Golden Query auf **diesem** Feld
+**ausgeschlossen**. Sie erscheinen dort weder in der erwarteten Treffermenge noch als stillschweigend
+übergangener Sonderfall. Auf anderen Feldern bleiben dieselben Entitäten regulär verwendbar; der
+Ausschluss gilt feldbezogen, nicht dokumentbezogen.
+
+Der Grund ist, dass ein Sentinel-Wert zwei unvereinbare Rollen spielt. Für die Ground Truth ist er
+ein Nichtwert — die Entität hat auf diesem Feld keine Ausprägung. Für den generierten Fließtext und
+damit für das Retrieval ist er dagegen ein ganz normaler Textbestandteil: Das Dokument sagt wörtlich
+etwas über den Wert und wird deshalb zu einer Bereichsfrage gefunden. Wer den Sentinel in der Ground
+Truth ignoriert, misst das Retrieval an einer Erwartung, die dem Korpus widerspricht, und bestraft
+oder belohnt Treffer, die inhaltlich nicht zu bewerten sind. Das Ergebnis ist eine Baseline, deren
+Schwankungen sich nicht mehr auf Retrieval-Qualität zurückführen lassen.
+
+Drei Folgerungen für den Generator:
+
+1. **Die Sentinel-Werte jeder Domäne sind ausdrücklich zu benennen**, bevor Golden Queries daraus
+   entstehen — sie ergeben sich aus der Quelle und sind nicht erratbar.
+2. **Der Ausschluss geschieht vor der Bestimmung der Treffermenge**, nicht als nachträglicher Filter
+   auf dem Ergebnis. Sonst verschiebt sich die Größe der Treffermenge unbemerkt aus dem Fenster von
+   2–15 Dokumenten.
+3. **Auch die Prosa ist zu prüfen.** Formuliert der Generator einen Sentinel als scheinbar gültigen
+   Wert aus („scores 0 for intelligence" für einen fehlenden Wert), entsteht ein Widerspruch
+   zwischen Frontmatter und Fließtext, den kein Ausschluss in der Ground Truth mehr repariert.
+
+**Sentinel-Werte je Domäne:**
+
+| Domäne | Feld | Sentinel | Umfang | Verhalten im Fließtext |
+|---|---|---|---|---|
+| Comichelden | `overall_score` | `null` (unbewertet) | 105 Dokumente | Prosa formuliert den fehlenden Wert als `0` aus — der Widerspruch ist Gegenstand von #226 |
+| Comichelden | `overall_score` | `"∞"` | 18 Dokumente | Prosa sagt wörtlich „his overall score is ∞"; erfüllt jede „größer als"-Bedingung |
+
+Für die Ausweitung auf weitere Domänen (#234 — Filme, Reiseziele, Tiere) ist diese Tabelle
+fortzuschreiben. Eine Domäne gilt erst dann als aufnahmefähig, wenn für jedes numerisch verwendete
+Feld geklärt ist, ob es Sentinel-Werte führt, und die gefundenen hier eingetragen sind — auch das
+Ergebnis „keine" gehört festgehalten, damit es später nicht als ungeprüft gilt.
+
+Die Regel bleibt bewusst in dieser Spezifikation und bekommt keinen eigenen ADR: Ablage,
+Versionierung und Einfrieren des Golden Dataset sind bereits im ADR zur Suchqualitäts-Evaluierung
+entschieden, und die Sentinel-Behandlung ist eine Präzisierung der dort festgelegten Ground Truth,
+keine eigenständige Strukturentscheidung.
+
 ### Kuratierung
 
 Vollautomatisch generierte Fälle sind ein „Silver Dataset". Vor der Aufnahme in die Baseline wird

--- a/docs/features/search-quality-evaluation.md
+++ b/docs/features/search-quality-evaluation.md
@@ -357,28 +357,40 @@ Entwicklungsumgebung ihn nicht startet.
 **Sie existiert bereits: `opaa.ewerlin.com`.** Es ist also kein Hosting aufzubauen, sondern der
 Korpus auf eine laufende Instanz auszurollen. Das verkleinert Phase 2 erheblich.
 
-> **Korrektur (aus dem Review zu PR #247).** Zwei Aussagen in diesem Abschnitt waren falsch und
-> sind nachfolgend berichtigt: Die Instanz läuft **nicht** auf Ollama, sondern auf **OpenAI**, und
-> es wird **kein anonymer Lesezugriff** eingeführt. Beide Punkte hat der Maintainer klargestellt.
+> **Korrektur (aus dem Review zu PR #247), zweite Fassung (2026-08-02).** Dieser Abschnitt wurde
+> zweimal berichtigt. Aus dem Review zu #247 stammt, dass **kein anonymer Lesezugriff** eingeführt
+> wird und dass die Instanz nicht mit dem Ollama-Anwendungsdefault läuft. Die damalige Ersatzangabe
+> „die Instanz läuft auf **OpenAI**" war jedoch selbst ungenau und ist inzwischen präzisiert:
+> **Das Chat-Modell stammt von Anthropic, die Einbettung läuft lokal über Ollama.** Alle Punkte hat
+> der Maintainer klargestellt.
 > Was das für die Begründung von ADR-0011 bedeutet, steht dort im
 > [Nachtrag](../decisions/0011-search-quality-evaluation-harness.md#nachtrag-korrigierte-tatsachenlage-zur-demo-instanz).
 
 Drei Folgerungen:
 
-- **Die Instanz läuft auf OpenAI.** Der Maintainer hat bestätigt, dass `opaa.ewerlin.com` ein
-  kommerzielles Modell über OpenAI nutzt. Das deckt sich mit `.env.example`, das für den
-  Compose-Betrieb `OPAA_AI_CHAT_PROVIDER=openai` und `OPAA_AI_EMBEDDING_PROVIDER=openai` setzt;
-  lediglich der *Anwendungs-Default* in `application.yml` lautet `ollama`. Die frühere Aussage
-  („bestehende Ollama-Konfiguration mit `phi3:mini`, kein Kostenrisiko") verwechselte diese beiden
-  Ebenen und ist zurückgezogen.
-- **Damit besteht ein echtes Kostenrisiko.** Jede Demo-Anfrage erzeugt Token-Kosten beim Anbieter.
-  Der Zugriff ist zwar account-gebunden (siehe unten), anonymer Massenzugriff also ausgeschlossen —
-  aber ein einzelnes berechtigtes Konto kann laufende Kosten in unbegrenzter Höhe auslösen, und die
-  Zahl der Konten wächst mit dem Erfolg der Demo. Kostenbegrenzung ist deshalb eine
-  Betriebsanforderung, kein optionaler Schutz.
-- **Die Instanz ist nirgends dokumentiert.** Weder `docs/deployment.md` noch `docker-compose.yml`
-  erwähnen sie. Das ist eine eigenständige Lücke und wird als eigenes Dokumentations-Issue geführt
-  (#244); ohne diese Beschreibung kann ein Entwickler den Rollout gar nicht durchführen.
+- **Das Chat-Modell ist ein kommerzielles Modell von Anthropic** (`claude-haiku-4-5`), angebunden
+  über Anthropics OpenAI-kompatible Schicht. Deshalb steht `OPAA_AI_CHAT_PROVIDER` formal auf
+  `openai`, obwohl kein OpenAI-Modell im Spiel ist — der Wert bezeichnet hier das Protokoll, nicht
+  den Anbieter. Genau daraus entstand die frühere Fehllesart. Zurückgezogen sind damit **beide**
+  bisherigen Angaben: die ursprüngliche („bestehende Ollama-Konfiguration mit `phi3:mini`, kein
+  Kostenrisiko") und die erste Korrektur („die Instanz läuft auf OpenAI"). Anthropic bezeichnet die
+  Kompatibilitätsschicht selbst als Werkzeug zum Testen und Vergleichen, nicht als produktionsreifen
+  Zugang; für eine Testinstanz ist das vertretbar, für einen Dauerbetrieb wäre die native Anbindung
+  zu wählen.
+- **Die Einbettung läuft lokal über Ollama mit `nomic-embed-text`** (768 Dimensionen,
+  `OPAA_PGVECTOR_DIMENSIONS=768`). Das ist keine Übergangslösung: Anthropic bietet keine
+  Embeddings-API an, die Zweiteilung Chat-Anbieter / lokales Embedding-Modell ist deshalb dauerhaft.
+- **Das Kostenrisiko besteht, betrifft aber nur den Chat.** Jede Demo-Anfrage erzeugt Token-Kosten
+  beim Chat-Anbieter. Der Zugriff ist zwar account-gebunden (siehe unten), anonymer Massenzugriff
+  also ausgeschlossen — aber ein einzelnes berechtigtes Konto kann laufende Kosten in unbegrenzter
+  Höhe auslösen, und die Zahl der Konten wächst mit dem Erfolg der Demo. Kostenbegrenzung bleibt
+  eine Betriebsanforderung. Die **Indizierung ist dagegen kostenlos**, weil sie lokal einbettet; ein
+  Rollout oder eine Neuindizierung des Korpus kostet unabhängig von seiner Größe nichts.
+- **Der CI-Harness und die Instanz betten identisch ein.** Beide verwenden `nomic-embed-text` über
+  Ollama. Ein grüner Regressionslauf misst damit dieselbe Retrieval-Konfiguration, die ein Besucher
+  auf `opaa.ewerlin.com` erlebt — siehe den Nachtrag im ADR.
+- **Die Instanz ist inzwischen dokumentiert.** `docs/deployment.md` beschreibt sie seit #244; die
+  Betriebsdetails zu Korpus-Rollout, Indizierung und Aktualisierung sind mit #269 ergänzt.
 
 ### Zugangsmodell: account-gebunden, kein Gastzugang
 
@@ -401,8 +413,8 @@ Anforderungen an den Betrieb der Instanz:
 - **Zugriff nur mit Konto.** Authentifizierung über Keycloak für alle Endpunkte, auch für die
   Suche; keine anonymen Lesepfade. Der Indizierungs-Endpunkt ist bereits auf `SYSTEM_ADMIN`
   beschränkt und bleibt es.
-- **Harter Kostendeckel beim Anbieter.** Ein Ausgabenlimit auf dem OpenAI-Konto, damit ein Fehler
-  oder Missbrauch nicht in eine offene Rechnung läuft. Ein Deckel wirkt auch dann, wenn das Rate
+- **Harter Kostendeckel beim Anbieter.** Ein Ausgabenlimit auf dem Konto des Chat-Anbieters, damit
+  ein Fehler oder Missbrauch nicht in eine offene Rechnung läuft. Ein Deckel wirkt auch dann, wenn das Rate
   Limiting falsch konfiguriert ist — deshalb beides, nicht eines davon.
 - **Rate Limiting** ist vorhanden (`opaa.rate-limit`) und muss für die Demo scharf gestellt sein —
   pro Konto *und* global. Es ist jetzt die primäre Kostenbremse und nicht mehr nur der Schutz einer
@@ -450,7 +462,7 @@ Vom Maintainer entschieden:
 |---|---|
 | 1 | **Phase-1-Quelle:** `jrtec/Superheroes` (CC0-1.0). Der FiveThirtyEight-Datensatz entfällt. |
 | 2 | **Multi-Tenancy:** ein gemeinsamer Index, Domänentrennung über Dateinamen-Präfix. Die Workspace-Variante wartet auf #115/#117, nicht auf Epic #198. |
-| 3 | **Demo-Hosting:** die bestehende Instanz `opaa.ewerlin.com`. Sie läuft auf **OpenAI**, nicht auf Ollama — *korrigiert am 2026-08-02; die vorherige Angabe „bestehende Ollama-Konfiguration (`phi3:mini`), kein kommerzielles Modell" war falsch.* Daraus folgt ein reales Kostenrisiko pro Anfrage, das über Ausgabenlimit und Rate Limiting begrenzt wird. |
+| 3 | **Demo-Hosting:** die bestehende Instanz `opaa.ewerlin.com`. **Chat: `claude-haiku-4-5` von Anthropic** über dessen OpenAI-kompatible Schicht (`OPAA_AI_CHAT_PROVIDER=openai` bezeichnet das Protokoll, nicht den Anbieter). **Einbettung: `nomic-embed-text` lokal über Ollama**, 768 Dimensionen. *Zweimal korrigiert am 2026-08-02: zuerst war „bestehende Ollama-Konfiguration (`phi3:mini`), kein kommerzielles Modell" falsch, dann die Ersatzangabe „läuft auf OpenAI" ungenau.* Ein reales Kostenrisiko pro Anfrage besteht nur beim Chat und wird über Ausgabenlimit und Rate Limiting begrenzt; die Indizierung ist kostenlos. |
 | 4 | **Korpus-Ablage:** Hauptrepository mit SHA-256-Manifest; Neubewertung bei der Ausweitung auf vier Domänen. |
 | 5 | **ADR-0011** ist akzeptiert. Zur korrigierten Kostenprämisse siehe den Nachtrag im ADR. |
 | 6 | **Zugangsmodell der Demo:** account-gebunden hinter Keycloak. Kein Gast- und kein Read-only-Zugang. *Korrigiert am 2026-08-02; die vorherige Anforderung „anonymer Lesezugriff" ist gestrichen.* Für diese Entscheidung wird ausdrücklich **kein ADR** angelegt. |
@@ -477,11 +489,13 @@ Vom Product Manager gesetzt, mangels Rückfrage, weiterhin widerrufbar:
 Die Fragen zu Lizenz, Demo-Hosting, Korpus-Ablage und Multi-Tenancy sind entschieden und stehen
 oben unter [Festlegungen](#festlegungen). Offen bleibt:
 
-1. **Laufende Kosten der Demo:** Die Instanz nutzt OpenAI, jede Anfrage kostet Geld. Wie hoch die
-   Kosten pro Monat tatsächlich ausfallen, lässt sich erst beziffern, wenn der Korpus dort liegt
-   und Anfragen laufen. Offen bleibt, ab welchem Betrag der Maintainer gegensteuert und womit —
-   engeres Rate Limit, kleineres Modell (z. B. `gpt-4o-mini`) oder ein Wechsel der Demo auf ein
-   lokales Modell. Erst messen, dann entscheiden.
+1. **Laufende Kosten der Demo:** Jede Chat-Anfrage kostet Geld beim Anbieter des Chat-Modells; die
+   Einbettung ist kostenlos, weil sie lokal läuft. Wie hoch die Kosten pro Monat tatsächlich
+   ausfallen, lässt sich erst beziffern, wenn der Korpus dort liegt und Anfragen laufen. Offen
+   bleibt, ab welchem Betrag der Maintainer gegensteuert und womit — engeres Rate Limit, ein
+   nochmals kleineres Chat-Modell oder ein Wechsel der Demo auf ein lokales Chat-Modell. Mit
+   `claude-haiku-4-5` ist bereits das kleinste Modell seiner Familie im Einsatz, der Spielraum nach
+   unten ist also begrenzt. Erst messen, dann entscheiden.
 2. **Niedrigschwelliger Zugang:** Die Anmeldepflicht kostet die Demo ihren stärksten Effekt. Ein
    Gastzugang bliebe die wirksamste Variante, ist aber vom Maintainer abgelehnt, solange die
    Kostenfrage nicht geklärt ist. Falls sie geklärt wird, wäre der Punkt neu zu bewerten — mit

--- a/docs/features/search-quality-evaluation.md
+++ b/docs/features/search-quality-evaluation.md
@@ -435,7 +435,7 @@ Drei Folgerungen:
   Ollama. Ein grüner Regressionslauf misst damit dieselbe Retrieval-Konfiguration, die ein Besucher
   auf `opaa.ewerlin.com` erlebt — siehe den Nachtrag im ADR.
 - **Die Instanz ist inzwischen dokumentiert.** `docs/deployment.md` beschreibt sie seit #244; die
-  Betriebsdetails zu Korpus-Rollout, Indizierung und Aktualisierung sind mit #269 ergänzt.
+  Betriebsdetails zu Korpus-Rollout, Indizierung und Aktualisierung sind dort ergänzt.
 
 ### Zugangsmodell: account-gebunden, kein Gastzugang
 


### PR DESCRIPTION
## Zusammenfassung

Nachfolger von #269. Von jenem PR wurde nur der erste Commit gemergt (die Betriebsfakten in `docs/deployment.md`); die inhaltliche **Berichtigung der Modellkonfiguration** und die **Sentinel-Regel** waren zum Merge-Zeitpunkt noch nicht darin enthalten. Dieser PR bringt beides nach, rebased auf den aktuellen `main` nach dem Merge von #264 (ADR-Umnummerierung) und #273 (Golden Dataset).

### 1. Berichtigung: das Chat-Modell ist Anthropic, nicht OpenAI

Die Instanz nutzt **`claude-haiku-4-5` von Anthropic**, angebunden über Anthropics **OpenAI-kompatible Schicht**. `OPAA_AI_CHAT_PROVIDER=openai` bezeichnet dort das **Protokoll, nicht den Anbieter** — genau daraus entstand die Fehllesart „die Instanz läuft auf OpenAI", die ihrerseits schon die Korrektur einer noch früheren Falschaussage („Ollama mit `phi3:mini`, kein Kostenrisiko") war. Eingebettet wird **lokal über Ollama mit `nomic-embed-text`** (768 Dimensionen); Anthropic bietet keine Embeddings-API an, die Zweiteilung ist deshalb dauerhaft.

**Ein Befund wird vollständig zurückgenommen.** Im ADR-Nachtrag stand, der CI-Harness messe eine andere Konfiguration als die Instanz fahre (`nomic-embed-text` gegen `text-embedding-3-small`), ein grüner Regressionslauf sage daher nichts über die Demo. Das war falsch — die Angabe stützte sich auf `.env.example` statt auf die tatsächliche Belegung. **CI und Instanz betten identisch ein.** Der gemessene Teil der Pipeline (Chunking, Einbettung, Vektorsuche, Ranking) ist auf beiden Seiten gleich konfiguriert; die Regression sagt also sehr wohl etwas über die Retrieval-Qualität auf der Demo aus. Die Grenze verläuft zwischen **Retrieval und Generierung**, nicht zwischen zwei Einbettungskonfigurationen. Hinfällig ist damit auch die Empfehlung, den optionalen OpenAI-Vergleichslauf „mindestens einmal gegen die Konfiguration der Demo-Instanz" laufen zu lassen — es gibt keinen Abstand zu beziffern.

Die zurückgenommene Aussage steht im ADR im Wortlaut zitiert, damit sie niemand aus älteren Notizen erneut aufgreift.

Weiter in `docs/deployment.md`: Modelltabelle der Instanz, Kostenaussage (Token-Kosten nur beim Chat, Indizierung kostenlos), Netzwerkbild (Ports nur auf `127.0.0.1`, nach außen nur nginx, Keycloak unter `/idp` wegen der Kollision mit `/auth/callback`), Betrieb ausschließlich aus GHCR-Images ohne Repo-Checkout, tägliche Aktualisierung um 2 Uhr per Cron ohne Zurücksetzen. Beim Index ist ergänzt, dass `OPAA_PGVECTOR_DIMENSIONS=768` an `nomic-embed-text` gekoppelt ist und beide nur gemeinsam geändert werden können.

### 2. Generelle Sentinel-Regel für die Ground Truth

Aus dem Review zu #273: Der Korpus führt Werte außerhalb der definierten Skala — bei den Comichelden `overall_score: null` (105 Dokumente, Prosa formuliert trotzdem „scores 0 …") und `overall_score: "∞"` (18 Dokumente, Prosa sagt wörtlich „his overall score is ∞"). Beide Zahlen sind gegen `eval/corpus/comic-characters/` nachgezählt.

Neuer Abschnitt „Sentinel-Werte: Entitäten außerhalb der Skala ausschließen", domänenunabhängig als Vorgabe für #234:

- Wo ein Feld Werte außerhalb seiner Skala führt, werden die betroffenen Entitäten aus numerischen Golden Queries auf **diesem** Feld ausgeschlossen — weder als erwartet noch als still übergangen.
- Der Ausschluss gilt **feldbezogen, nicht dokumentbezogen**: dieselbe Entität bleibt auf anderen Feldern regulär verwendbar. Dokumentbezogen gelesen hätte die Regel 123 von rund 1.450 Entitäten aus dem gesamten Dataset gedrängt.
- Er greift **vor** der Bestimmung der Treffermenge, sonst verschiebt sich deren Größe unbemerkt aus dem Fenster von 2–15 Dokumenten.
- Auch die **Prosa** ist zu prüfen: Formuliert der Generator einen Sentinel als scheinbar gültigen Wert aus, repariert kein Ausschluss in der Ground Truth mehr den Widerspruch.
- Eine Tabelle hält die Sentinels je Domäne fest und ist bei der Ausweitung fortzuschreiben — auch das Ergebnis „keine" wird eingetragen, damit ein Feld nicht als ungeprüft durchrutscht.

**Kein eigener ADR**, in Übereinstimmung mit dem Reviewer: Ablage, Versionierung und Einfrieren des Golden Dataset sind in ADR-0011 entschieden; die Sentinel-Behandlung präzisiert die dort festgelegte Ground Truth. Die Begründung steht im Abschnitt selbst, damit die Frage bei der nächsten Domäne nicht erneut aufkommt.

### 3. Verweise nach dem Merge von #264 richtiggestellt

- Der Korrekturkasten in der Feature-Spezifikation verwies auf `ADR-0008` und die Datei `0008-search-quality-evaluation-harness.md`. Beides existiert so nicht mehr: Der ADR heißt **ADR-0011**, unter 0008 steht ausschließlich das **Space- und Asset-Modell**. Korrigiert.
- Der einzige weitere `ADR-0008`-Verweis in `docs/` steht in `docs/features/access-control.md` und meint tatsächlich das Space- und Asset-Modell — bleibt unverändert.
- Drei Stellen nannten „PR #269" als Quelle der Modellkorrektur. Da von #269 nur der erste Commit gemergt wurde, hätten sie auf einen PR gezeigt, der die Korrektur nicht enthält; sie sind jetzt datiert statt nummeriert.

## Zugehörige Issues

Betrifft #230, #234, #244, #267. Kein `Closes`.

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal — **entfällt.** Reine Dokumentationsänderung; die Pre-Push-Checkliste wird laut `AGENTS.md` bei reinen Dokumentationsänderungen übersprungen. Es wurde keine Zeile Code angefasst.
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet — keine E-Mail-Adresse (das Administrationskonto ist über seine Rolle beschrieben), keine Serverpfade, keine Zugangsdaten.
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _Claude Opus 5, Rolle Product Manager_)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst

Die Betriebsfakten stammen vollständig vom Maintainer. Der Agent hat sie eingeordnet und die Aussagen zum Code und zum Korpus — Liquibase-Verhalten, Volume-Persistenz, Rate-Limit-Pfade, Zahl der Sentinel-Dokumente — gegen die jeweiligen Quellen im Repository belegt, statt sie anzunehmen.
