### PR TITLE
fix(ci): Eigenes Secret für den Tagesreport statt des Anwendungsschlüssels

### DIFF
--- a/.github/scripts/daily_report.py
+++ b/.github/scripts/daily_report.py
@@ -12,6 +12,9 @@ Aufruf:
 
 Benötigt die GitHub-CLI (`gh`) mit gültigem Token. Ein API-Schlüssel für die
 Zusammenfassung ist optional; fehlt er, entsteht der Report ohne Fließtext.
+Der Schlüssel wird bewusst aus OPAA_REPORT_API_KEY gelesen und nicht aus dem
+Anwendungsschlüssel OPAA_OPENAI_API_KEY, damit sich das Aktivieren der
+Zusammenfassung nicht auf die Integrationstests in der CI auswirkt.
 """
 
 from __future__ import annotations
@@ -274,13 +277,18 @@ def build_summary_prompt(data: dict) -> str:
 
 def summarize(data: dict) -> str:
     """Erzeugt die Zusammenfassung. Bei jedem Fehler bleibt sie leer."""
-    api_key = os.environ.get("OPAA_OPENAI_API_KEY", "").strip()
+    api_key = os.environ.get("OPAA_REPORT_API_KEY", "").strip()
     if not api_key:
         print("Kein API-Schlüssel gesetzt — Report ohne Zusammenfassung.", file=sys.stderr)
         return ""
 
-    model = os.environ.get("OPAA_REPORT_MODEL", "gpt-4o").strip()
-    base_url = os.environ.get("OPAA_OPENAI_BASE_URL", "https://api.openai.com").rstrip("/")
+    # Nicht gesetzte Repository-Variablen erreichen den Prozess als leerer
+    # String, nicht als fehlender Eintrag. Der Vorgabewert von `get` würde
+    # deshalb nie greifen.
+    model = os.environ.get("OPAA_REPORT_MODEL", "").strip() or "gpt-4o"
+    base_url = (
+        os.environ.get("OPAA_REPORT_BASE_URL", "").strip() or "https://api.openai.com"
+    ).rstrip("/")
     payload = {
         "model": model,
         "messages": [

--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -48,8 +48,13 @@ jobs:
       - name: Report erzeugen
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPAA_OPENAI_API_KEY: ${{ secrets.OPAA_OPENAI_API_KEY }}
+          # Bewusst ein eigenes Secret und nicht der Anwendungsschlüssel
+          # OPAA_OPENAI_API_KEY: dieser steuert in ci.yml, ob die
+          # OpenAI-Integrationstests laufen. Beides zu koppeln würde das
+          # Aktivieren der Zusammenfassung zu einer Änderung an der CI machen.
+          OPAA_REPORT_API_KEY: ${{ secrets.OPAA_REPORT_API_KEY }}
           OPAA_REPORT_MODEL: ${{ vars.OPAA_REPORT_MODEL }}
+          OPAA_REPORT_BASE_URL: ${{ vars.OPAA_REPORT_BASE_URL }}
         run: |
           python .github/scripts/daily_report.py \
             --repo "${{ github.repository }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ documents/
 **/.claude/agent-memory/
 
 tmp
+
+# Python (Hilfsskripte unter .github/scripts/)
+__pycache__/
+*.pyc

--- a/docs/tagesreport.md
+++ b/docs/tagesreport.md
@@ -68,19 +68,37 @@ Ohne API-Schlüssel entsteht der Report vollständig, nur ohne den Fließtext.
 Zum Aktivieren einen Schlüssel als Repository-Secret hinterlegen:
 
 ```bash
-gh secret set OPAA_OPENAI_API_KEY
+gh secret set OPAA_REPORT_API_KEY
 ```
 
-Das Modell lässt sich über eine Repository-Variable wechseln, standardmäßig
-wird `gpt-4o` verwendet:
+Das Modell und der Endpunkt lassen sich über Repository-Variablen wechseln;
+ohne sie werden `gpt-4o` und die OpenAI-API verwendet:
 
 ```bash
 gh variable set OPAA_REPORT_MODEL --body "gpt-4o-mini"
+gh variable set OPAA_REPORT_BASE_URL --body "https://mein-endpunkt.example"
 ```
 
-Über `OPAA_OPENAI_BASE_URL` ist auch ein anderer OpenAI-kompatibler Endpunkt
-ansprechbar. Schlägt der Aufruf fehl, erscheint der Report ohne Zusammenfassung
-statt gar nicht.
+Schlägt der Aufruf fehl, erscheint der Report ohne Zusammenfassung statt gar
+nicht.
+
+### Warum ein eigenes Secret
+
+Der Report verwendet bewusst **nicht** den Anwendungsschlüssel
+`OPAA_OPENAI_API_KEY`. Dieser steuert in [`ci.yml`](../.github/workflows/ci.yml),
+ob der Job `backend-integration` die OpenAI-Integrationstests ausführt —
+`OpenAiIntegrationTest` ist über `@EnabledIfEnvironmentVariable` an dieselbe
+Variable gebunden.
+
+Wären beide gekoppelt, hätte das Aktivieren der Zusammenfassung zur Folge, dass
+bei jedem Push und jedem Pull Request echte Aufrufe gegen die OpenAI-API laufen.
+Da `backend-integration` ein erforderlicher Status-Check ist, würde zudem eine
+Störung beim Anbieter Merges blockieren.
+
+| Secret | Zweck |
+| --- | --- |
+| `OPAA_REPORT_API_KEY` | Zusammenfassung im Tagesreport |
+| `OPAA_OPENAI_API_KEY` | Anwendung und ihre Integrationstests in der CI |
 
 ## Einmalige Einrichtung
 


### PR DESCRIPTION
## Zusammenfassung

Der Report nutzte für die Zusammenfassung dasselbe Secret `OPAA_OPENAI_API_KEY`, das auch die CI verwendet. Das Aktivieren der Zusammenfassung hätte dadurch unbeabsichtigt das Verhalten der Integrationstests verändert.

## Das Problem

In [`ci.yml`](.github/workflows/ci.yml) reicht der Job `backend-integration` das Secret durch und führt die OpenAI-Integrationstests nur aus, wenn es gesetzt ist:

```yaml
backend-integration:
    env:
      OPAA_OPENAI_API_KEY: ${{ secrets.OPAA_OPENAI_API_KEY }}
    ...
      - name: OpenAI Integration Tests
        if: env.OPAA_OPENAI_API_KEY != ''
```

`OpenAiIntegrationTest` hängt über `@EnabledIfEnvironmentVariable(named = "OPAA_OPENAI_API_KEY", matches = ".+")` an derselben Variable.

Folgen, sobald das Secret gesetzt worden wäre:

- Bei **jedem Push und jedem Pull Request** echte Aufrufe gegen die OpenAI-API
- `backend-integration` ist ein **erforderlicher Status-Check** — eine Störung oder ein Rate-Limit beim Anbieter hätte Merges blockiert
- Der Anwendungsschlüssel wäre für einen Zweck verwendet worden, der nichts mit der Anwendung zu tun hat

## Die Änderung

Der Report liest jetzt eigene Variablen. Beide Verwendungen sind damit unabhängig:

| Secret | Zweck |
| --- | --- |
| `OPAA_REPORT_API_KEY` | Zusammenfassung im Tagesreport |
| `OPAA_OPENAI_API_KEY` | Anwendung und ihre Integrationstests in der CI |

Passend dazu `OPAA_REPORT_BASE_URL` neben dem bereits vorhandenen `OPAA_REPORT_MODEL`. An `ci.yml` ändert sich nichts.

## Nebenbei behoben

Nicht gesetzte Repository-Variablen erreichen den Prozess als leerer String, nicht als fehlender Eintrag. Der Vorgabewert von `os.environ.get` griff dadurch nie — sobald `OPAA_REPORT_MODEL` nicht gesetzt ist, wäre ein leeres Modell an die API gegangen. Der Fehler war bereits in #259 enthalten und wäre beim ersten Aktivieren aufgetreten.

Ergänzt wurde außerdem ein `.gitignore`-Eintrag für `__pycache__`, das beim lokalen Ausführen des Skripts entsteht.

## Prüfung

Verhalten in allen Kombinationen durchgespielt:

| Fall | Ergebnis |
| --- | --- |
| Keine Variablen gesetzt | kein Schlüssel, Vorgaben `gpt-4o` und OpenAI-API greifen |
| Nur Schlüssel gesetzt | Vorgaben greifen |
| Alle gesetzt | eigene Werte greifen, abschließender Schrägstrich entfernt |
| Nur `OPAA_OPENAI_API_KEY` gesetzt | Zusammenfassung bleibt leer — der Anwendungsschlüssel hat keine Wirkung mehr |

## Zugehörige Issues

Closes #276

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (keine Anwendungsänderung; Skriptverhalten in vier Kombinationen geprüft, YAML validiert)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF