### PR TITLE
fix(space): Eindeutigkeit persönlicher Spaces und fehlender Index auf space_memberships.space_id

### DIFF
--- a/backend/src/main/java/io/opaa/space/SpaceService.java
+++ b/backend/src/main/java/io/opaa/space/SpaceService.java
@@ -13,9 +13,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
@@ -27,10 +31,17 @@ public class SpaceService {
 
   private final SpaceRepository spaceRepository;
   private final UserRepository userRepository;
+  private final TransactionTemplate requiresNewTransactionTemplate;
 
-  public SpaceService(SpaceRepository spaceRepository, UserRepository userRepository) {
+  public SpaceService(
+      SpaceRepository spaceRepository,
+      UserRepository userRepository,
+      PlatformTransactionManager transactionManager) {
     this.spaceRepository = spaceRepository;
     this.userRepository = userRepository;
+    this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
+    this.requiresNewTransactionTemplate.setPropagationBehavior(
+        TransactionDefinition.PROPAGATION_REQUIRES_NEW);
   }
 
   @Transactional
@@ -248,13 +259,36 @@ public class SpaceService {
   /**
    * Creates the automatic personal space for a user if it does not exist yet. Shares the same
    * validation path as {@link #createSpace}, so personal space creation no longer bypasses it.
+   *
+   * <p>Two concurrent first logins of the same user can both pass the {@code existsBy} check below
+   * before either has inserted a row - the check alone cannot prevent that. The partial unique
+   * index {@code uk_spaces_personal_owner} (migration 010) is the actual guard: it lets exactly one
+   * of the two inserts succeed and makes the other fail with a {@link
+   * DataIntegrityViolationException}. The insert attempt runs in its own {@code REQUIRES_NEW}
+   * transaction so that a failure there rolls back only that attempt - on Postgres, a failed
+   * statement aborts the entire enclosing transaction, so catching the violation inside the same
+   * transaction that performed the insert would leave every subsequent statement in that
+   * transaction failing too. The loser then simply reads the space the winner created instead of
+   * surfacing a 500.
    */
-  @Transactional
   public void ensurePersonalSpace(UUID userId, UUID organizationId) {
     if (spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)) {
       return;
     }
 
+    try {
+      requiresNewTransactionTemplate.executeWithoutResult(
+          status -> createPersonalSpace(userId, organizationId));
+    } catch (DataIntegrityViolationException raceLost) {
+      if (!spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)) {
+        // Some other constraint was violated, not the personal-space uniqueness index - do not
+        // swallow an unrelated failure.
+        throw raceLost;
+      }
+    }
+  }
+
+  private void createPersonalSpace(UUID userId, UUID organizationId) {
     Space personalSpace =
         buildValidatedSpace(
             "Meine Dokumente",
@@ -264,7 +298,9 @@ public class SpaceService {
             userId,
             organizationId);
     personalSpace.addMembership(new SpaceMembership(userId, SpaceRole.ADMIN, organizationId));
-    spaceRepository.save(personalSpace);
+    // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) inside this
+    // REQUIRES_NEW transaction, instead of being deferred to a later flush point outside of it.
+    spaceRepository.saveAndFlush(personalSpace);
   }
 
   private Space buildValidatedSpace(

--- a/backend/src/main/resources/db/changelog/changes/010-space-uniqueness-and-membership-index.yaml
+++ b/backend/src/main/resources/db/changelog/changes/010-space-uniqueness-and-membership-index.yaml
@@ -1,0 +1,104 @@
+databaseChangeLog:
+  # Two independent, small changeSets against the space tables (see #265, #266). They are
+  # unrelated to each other but land together because both are Liquibase changesets on the same
+  # tables and both were flagged as pre-existing gaps in the review of PR #254.
+
+  - changeSet:
+      id: 010-cleanup-duplicate-personal-spaces
+      author: opaa
+      comment: >
+        Delete duplicate personal spaces before the partial unique index below can be created
+        (see #265). Only kind = PERSONAL rows are considered - PROJECT and TEAM spaces are
+        unaffected, and a user may own any number of those. For every owner, the oldest personal
+        space (by created_at, with id as a stable tiebreaker for equal timestamps) is kept as the
+        canonical one; later duplicates are removed. Memberships of the removed duplicates
+        cascade-delete via fk_space_memberships_space (ON DELETE CASCADE), so no orphaned
+        membership rows remain. Deleting rather than merging duplicates is safe at this point in
+        the schema's history because no document or asset model references spaces yet - #201 and
+        #202, the features this migration must land ahead of, are what introduce those references.
+        A RAISE NOTICE reports how many rows were removed so operators can see it in the migration
+        log; splitStatements is disabled because the DO block below contains its own statement
+        terminators.
+      changes:
+        - sql:
+            splitStatements: false
+            sql: |
+              DO $$
+              DECLARE
+                duplicate_count integer;
+              BEGIN
+                SELECT count(*) INTO duplicate_count
+                FROM (
+                  SELECT id, row_number() OVER (
+                    PARTITION BY owner_id ORDER BY created_at ASC, id ASC
+                  ) AS rn
+                  FROM spaces
+                  WHERE kind = 'PERSONAL'
+                ) ranked
+                WHERE rn > 1;
+
+                IF duplicate_count > 0 THEN
+                  RAISE NOTICE 'uk_spaces_personal_owner migration: removing % duplicate personal space(s); the oldest personal space per owner is kept', duplicate_count;
+                END IF;
+
+                DELETE FROM spaces
+                WHERE id IN (
+                  SELECT id FROM (
+                    SELECT id, row_number() OVER (
+                      PARTITION BY owner_id ORDER BY created_at ASC, id ASC
+                    ) AS rn
+                    FROM spaces
+                    WHERE kind = 'PERSONAL'
+                  ) ranked
+                  WHERE rn > 1
+                );
+              END $$;
+      rollback:
+        - sql:
+            comment: >
+              Irreversible: the deleted duplicate personal spaces (and their cascaded
+              memberships) cannot be reconstructed from this migration. Restore from a
+              pre-migration backup if the removed rows are needed. This statement is a
+              deliberate no-op so that a rollback of this changeSet does not fail.
+            sql: "SELECT 1;"
+
+  - changeSet:
+      id: 010-create-personal-space-unique-index
+      author: opaa
+      comment: >
+        Enforce at most one personal space per owner at the database level (see #265). A plain
+        composite unique constraint on (owner_id, kind) would also cap PROJECT and TEAM spaces at
+        one per owner, which is wrong - users may own any number of those. A partial unique index
+        that only indexes kind = PERSONAL rows is the correct constraint. Requires
+        010-cleanup-duplicate-personal-spaces to have run first, or this index cannot be created
+        on a database with pre-existing duplicates.
+      changes:
+        - sql:
+            comment: "Partial unique index: at most one PERSONAL space per owner"
+            sql: >
+              CREATE UNIQUE INDEX uk_spaces_personal_owner
+              ON spaces (owner_id)
+              WHERE kind = 'PERSONAL';
+      rollback:
+        - sql:
+            sql: "DROP INDEX IF EXISTS uk_spaces_personal_owner;"
+
+  - changeSet:
+      id: 010-create-space-memberships-space-id-index
+      author: opaa
+      comment: >
+        Add a standalone index on space_memberships.space_id (see #266). The existing unique
+        index uk_space_memberships_user_space leads with user_id and does not serve lookups that
+        start from space_id, such as loading the members of a space
+        (SpaceMembershipRepository#findBySpaceId and the membership fetches in SpaceService).
+      changes:
+        - createIndex:
+            tableName: space_memberships
+            indexName: idx_space_memberships_space_id
+            columns:
+              - column:
+                  name: space_id
+      rollback:
+        - dropIndex:
+            tableName: space_memberships
+            indexName: idx_space_memberships_space_id

--- a/backend/src/test/java/io/opaa/migration/Migration010SpaceUniquenessTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration010SpaceUniquenessTest.java
@@ -1,0 +1,254 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 010 in isolation against a database pre-populated with legacy space
+ * data - not against an empty schema. Follows the pattern established by {@code
+ * Migration008RenameWorkspaceToSpaceTest}: apply the real, versioned changelog up to the changeSet
+ * immediately preceding the new one (via {@code test-master-through-008.yaml}), seed representative
+ * rows directly through JDBC, apply only the new changelog file, and assert on the resulting schema
+ * and data.
+ *
+ * <p>Unlike {@code Migration008RenameWorkspaceToSpaceTest}, this class has more than one test
+ * method. The shared static container is not reset between test methods by Testcontainers, and
+ * Liquibase records every changeSet it applies in DATABASECHANGELOG - so a second {@code
+ * liquibase.update(...)} call in a later test method would silently skip changelog 010 as "already
+ * applied" against data seeded by an earlier method, instead of running against that method's own
+ * fixture. {@link #resetSchema()} drops and recreates the public schema after every test so each
+ * method starts from a schema-less database and reapplies changelog 010 against only its own seed
+ * data. This is the gap flagged against {@code Migration008RenameWorkspaceToSpaceTest} for future
+ * data-migration tests (see #237, #238) - this class is the first to close it.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration010SpaceUniquenessTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    // Apply everything up to (and including) changeSet 008 - the schema exactly as it existed
+    // immediately before this migration - via the real, versioned changelog files.
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-008.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+
+    // Liquibase leaves auto-commit disabled on the connection after update(). Re-enable it so
+    // that every raw JDBC statement below (seeding, applying changelog 010, assertions) commits
+    // independently, matching how the application actually uses the database - one failing
+    // statement, such as the deliberate constraint violation asserted below, must not abort every
+    // later statement in the same test method.
+    connection.setAutoCommit(true);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    resetSchema();
+    if (connection != null && !connection.isClosed()) {
+      connection.close();
+    }
+  }
+
+  /**
+   * Drops and recreates the public schema so the next test method's {@link #setUp()} starts from a
+   * schema-less database, including an empty DATABASECHANGELOG - without this, Liquibase would
+   * treat changelog 010 as already applied in every test after the first.
+   *
+   * <p>Liquibase leaves the connection's auto-commit disabled after {@code update()} - without
+   * explicitly re-enabling it first, the DROP/CREATE below would run inside an uncommitted
+   * transaction that gets silently rolled back when the connection closes in {@link #tearDown()},
+   * leaving the previous test method's schema (including its unique index) in place for the next
+   * one.
+   */
+  private void resetSchema() throws SQLException {
+    connection.setAutoCommit(true);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+  }
+
+  @Test
+  void removesDuplicatePersonalSpacesAndEnforcesOnePersonalSpacePerOwner() throws Exception {
+    UUID owner = UUID.randomUUID();
+    UUID otherOwner = UUID.randomUUID();
+    insertUser(owner);
+    insertUser(otherOwner);
+
+    // Two personal spaces for the same owner - the exact scenario #265 describes, e.g. produced
+    // by two concurrent first logins before this migration existed. oldestPersonal must survive;
+    // newestDuplicate must be removed.
+    UUID oldestPersonal = UUID.randomUUID();
+    UUID newestDuplicate = UUID.randomUUID();
+    UUID otherOwnerPersonal = UUID.randomUUID();
+    Instant older = Instant.parse("2024-01-01T00:00:00Z");
+    Instant newer = Instant.parse("2024-01-01T00:05:00Z");
+    insertSpace(oldestPersonal, "Meine Dokumente", "PERSONAL", owner, older);
+    insertSpace(newestDuplicate, "Meine Dokumente", "PERSONAL", owner, newer);
+    insertSpace(otherOwnerPersonal, "Meine Dokumente", "PERSONAL", otherOwner, older);
+    insertMembership(oldestPersonal, owner);
+    insertMembership(newestDuplicate, owner);
+    insertMembership(otherOwnerPersonal, otherOwner);
+
+    applyChangelog010();
+
+    assertThat(spaceExists(oldestPersonal)).isTrue();
+    assertThat(spaceExists(newestDuplicate)).isFalse();
+    assertThat(spaceExists(otherOwnerPersonal)).isTrue();
+    assertThat(countRows("spaces")).isEqualTo(2);
+    // The membership of the removed duplicate must be gone too, via ON DELETE CASCADE - not left
+    // behind as an orphan pointing at a space that no longer exists.
+    assertThat(countRows("space_memberships")).isEqualTo(2);
+
+    assertThat(indexExists("uk_spaces_personal_owner")).isTrue();
+
+    // The index must actually be enforced: inserting a second personal space for an owner that
+    // already has one must fail, exactly the guarantee #265 requires.
+    UUID secondPersonalForOwner = UUID.randomUUID();
+    assertThatThrownBy(
+            () -> insertSpace(secondPersonalForOwner, "Zweiter Space", "PERSONAL", owner, newer))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uk_spaces_personal_owner");
+
+    // A user may still own any number of PROJECT spaces - the partial index must not restrict
+    // that.
+    insertSpace(UUID.randomUUID(), "Projekt A", "PROJECT", owner, newer);
+    insertSpace(UUID.randomUUID(), "Projekt B", "PROJECT", owner, newer);
+  }
+
+  @Test
+  void createsStandaloneIndexOnSpaceMembershipsSpaceId() throws Exception {
+    applyChangelog010();
+
+    assertThat(indexExists("idx_space_memberships_space_id")).isTrue();
+  }
+
+  private void applyChangelog010() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/010-space-uniqueness-and-membership-index.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    // See the comment in setUp() - Liquibase disables auto-commit again on every update() call.
+    connection.setAutoCommit(true);
+  }
+
+  private void insertUser(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO users (id, subject, issuer, system_role, organization_id, created_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + id
+              + "', 'test-issuer', 'USER', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', now())");
+    }
+  }
+
+  private void insertSpace(UUID id, String name, String kind, UUID ownerId, Instant createdAt)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO spaces "
+              + "(id, name, kind, visibility, owner_id, organization_id, created_at, updated_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + name
+              + "', '"
+              + kind
+              + "', 'PRIVATE', '"
+              + ownerId
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', '"
+              + createdAt
+              + "', '"
+              + createdAt
+              + "')");
+    }
+  }
+
+  private void insertMembership(UUID spaceId, UUID userId) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO space_memberships "
+              + "(id, user_id, space_id, role, organization_id, created_at) "
+              + "VALUES ('"
+              + UUID.randomUUID()
+              + "', '"
+              + userId
+              + "', '"
+              + spaceId
+              + "', 'ADMIN', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', now())");
+    }
+  }
+
+  private boolean spaceExists(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT 1 FROM spaces WHERE id = '" + id + "'")) {
+      return rs.next();
+    }
+  }
+
+  private long countRows(String table) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT count(*) FROM " + table)) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private boolean indexExists(String indexName) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT 1 FROM pg_indexes WHERE indexname = '" + indexName + "'")) {
+      return rs.next();
+    }
+  }
+}

--- a/backend/src/test/java/io/opaa/space/SpaceServiceTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceServiceTest.java
@@ -1,0 +1,89 @@
+package io.opaa.space;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opaa.auth.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+
+/**
+ * Simulates the two concurrent first-login race #265 describes, without relying on real threads or
+ * timing: {@link SpaceRepository#existsByOwnerIdAndKind} is stubbed to answer as it would for the
+ * loser of the race (false before the attempt, true after a concurrent winner has committed), and
+ * {@link SpaceRepository#saveAndFlush} is stubbed to throw the {@link
+ * DataIntegrityViolationException} that {@code uk_spaces_personal_owner} (migration 010) would
+ * raise for the losing insert.
+ */
+class SpaceServiceTest {
+
+  private SpaceRepository spaceRepository;
+  private PlatformTransactionManager transactionManager;
+  private SpaceService spaceService;
+
+  @BeforeEach
+  void setUp() {
+    spaceRepository = mock(SpaceRepository.class);
+    UserRepository userRepository = mock(UserRepository.class);
+    transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
+    spaceService = new SpaceService(spaceRepository, userRepository, transactionManager);
+  }
+
+  @Test
+  void ensurePersonalSpaceReadsTheWinnersSpaceInsteadOfThrowing() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+
+    // First call: this login has not created a personal space yet. Second call (the race-loss
+    // fallback check): a concurrent login already committed one while this insert was failing.
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL))
+        .thenReturn(false, true);
+    when(spaceRepository.saveAndFlush(any(Space.class)))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint \"uk_spaces_personal_owner\""));
+
+    assertThatCode(() -> spaceService.ensurePersonalSpace(userId, organizationId))
+        .doesNotThrowAnyException();
+
+    verify(spaceRepository, times(2)).existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL);
+  }
+
+  @Test
+  void ensurePersonalSpacePropagatesViolationsUnrelatedToTheRace() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+
+    // The personal space still does not exist after the failed insert - so the violation was not
+    // caused by a concurrent winner, and must not be swallowed.
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL))
+        .thenReturn(false, false);
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("some other constraint violation");
+    when(spaceRepository.saveAndFlush(any(Space.class))).thenThrow(violation);
+
+    assertThatThrownBy(() -> spaceService.ensurePersonalSpace(userId, organizationId))
+        .isSameAs(violation);
+  }
+
+  @Test
+  void ensurePersonalSpaceIsANoOpWhenAPersonalSpaceAlreadyExists() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)).thenReturn(true);
+
+    spaceService.ensurePersonalSpace(userId, organizationId);
+
+    verify(spaceRepository, times(0)).saveAndFlush(any(Space.class));
+  }
+}

--- a/backend/src/test/resources/db/changelog/test-master-through-008.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-008.yaml
@@ -1,3 +1,10 @@
+# Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
+# changeSet 008 - i.e. the schema exactly as it existed immediately before migration 010.
+#
+# Used by Migration010SpaceUniquenessTest to build a realistic pre-migration database (via the
+# real, versioned changelog files, not a hand-rolled schema) and then seed legacy data before
+# applying 010 in isolation. See test-master-through-007.yaml and
+# Migration008RenameWorkspaceToSpaceTest for the pattern this fixture follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml
@@ -15,5 +22,3 @@ databaseChangeLog:
       file: db/changelog/changes/007-create-workspaces-and-memberships.yaml
   - include:
       file: db/changelog/changes/008-rename-workspace-to-space.yaml
-  - include:
-      file: db/changelog/changes/010-space-uniqueness-and-membership-index.yaml

--- a/docs/migrations/010-space-uniqueness-and-membership-index.md
+++ b/docs/migrations/010-space-uniqueness-and-membership-index.md
@@ -1,0 +1,119 @@
+# Migration 010: Eindeutigkeit persönlicher Spaces und Index auf space_memberships.space_id
+
+Begleitdokument zu
+`backend/src/main/resources/db/changelog/changes/010-space-uniqueness-and-membership-index.yaml`
+([Issue #265](https://github.com/criew/opaa/issues/265),
+[Issue #266](https://github.com/criew/opaa/issues/266)). Zwei unabhängige, kleine Changesets an
+den Space-Tabellen, die zusammen in einem PR landen, weil beide vorbestehende Lücken aus dem
+Review zu PR #254 sind.
+
+## Was migriert wird
+
+| Changeset | Zweck |
+|---|---|
+| `010-cleanup-duplicate-personal-spaces` | Entfernt doppelte persönliche Spaces vor Anlage des Index unten |
+| `010-create-personal-space-unique-index` | Partieller Unique-Index `uk_spaces_personal_owner` auf `spaces (owner_id) WHERE kind = 'PERSONAL'` |
+| `010-create-space-memberships-space-id-index` | Eigenständiger Index `idx_space_memberships_space_id` auf `space_memberships (space_id)` |
+
+### Warum ein partieller Index statt einer zusammengesetzten Unique-Constraint (#265)
+
+Eine zusammengesetzte Unique-Constraint auf `(owner_id, kind)` würde auch `PROJECT`- und
+`TEAM`-Spaces auf einen pro Eigentümer begrenzen — das ist falsch, Nutzer dürfen beliebig viele
+davon besitzen. Nur `kind = 'PERSONAL'`-Zeilen dürfen der Eindeutigkeit unterliegen, deshalb ein
+partieller Index statt einer Tabellen-weiten Constraint.
+
+### Bereinigung vorhandener Duplikate
+
+Der partielle Index lässt sich nicht anlegen, solange bereits doppelte persönliche Spaces
+existieren (`CREATE UNIQUE INDEX` schlägt in diesem Fall fehl). `010-cleanup-duplicate-personal-spaces`
+löscht deshalb vor der Indexanlage für jeden Eigentümer alle bis auf den ältesten persönlichen
+Space (`created_at`, `id` als stabiler Tiebreaker). Mitgliedschaften der gelöschten Duplikate
+werden automatisch über `fk_space_memberships_space` (`ON DELETE CASCADE`) mit entfernt — es
+bleiben keine verwaisten Mitgliedschaftszeilen zurück. Ein `RAISE NOTICE` meldet die Anzahl der
+entfernten Zeilen im Migrationslog.
+
+**Warum Löschen statt Zusammenführen eine vertretbare Entscheidung ist:** Zum jetzigen Zeitpunkt
+in der Schema-Historie referenziert noch kein Dokument- oder Asset-Modell Spaces — das führen erst
+#201 (Wissensbibliothek) und #202 (Asset-Rechte) ein, und genau vor diesen beiden muss diese
+Migration liegen (siehe #265). Es gibt also nichts, was an einem doppelten persönlichen Space
+hängen könnte und beim Löschen verloren ginge. Ein Zusammenführen der Mitgliedschaften wäre für
+persönliche Spaces ohnehin trivial (immer nur der Eigentümer als `ADMIN`), fügt aber unnötige
+Komplexität hinzu, wenn Löschen bereits verlustfrei ist.
+
+### Race in `SpaceService.ensurePersonalSpace`
+
+`ensurePersonalSpace` prüfte bisher mit `existsByOwnerIdAndKind` und legte danach an — ohne
+Absicherung auf Datenbankebene. Der Index oben schließt die Lücke, verlagert das Problem aber auf
+den Anwendungscode: Der Verlierer eines gleichzeitigen ersten Logins erhält jetzt eine
+`DataIntegrityViolationException` beim Insert. `ensurePersonalSpace` fängt diese ab und liest den
+bereits vom Gewinner angelegten Space, statt einen 500 zu werfen. Der Insert-Versuch läuft dazu in
+einer eigenen `REQUIRES_NEW`-Transaktion: Auf Postgres bricht eine fehlgeschlagene Anweisung die
+gesamte umschließende Transaktion ab, sodass ein Auffangen der Verletzung innerhalb derselben
+Transaktion, die den Insert ausgeführt hat, jede nachfolgende Anweisung in dieser Transaktion
+ebenfalls scheitern ließe. Details siehe Klassenkommentar auf
+`SpaceService.ensurePersonalSpace`.
+
+### Fehlender Index auf `space_memberships.space_id` (#266)
+
+Der vorhandene Unique-Index `uk_space_memberships_user_space` führt mit `(user_id, space_id)` und
+bedient nur Abfragen, die über `user_id` einsteigen. Abfragen über `space_id` — insbesondere das
+Laden der Mitglieder eines Space (`SpaceMembershipRepository#findBySpaceId`) — profitieren nicht
+vom führenden Spaltenteil. `010-create-space-memberships-space-id-index` fügt einen
+eigenständigen Index auf `space_id` hinzu.
+
+## Reihenfolge der Changesets (Anwendung)
+
+1. `010-cleanup-duplicate-personal-spaces`
+2. `010-create-personal-space-unique-index`
+3. `010-create-space-memberships-space-id-index`
+
+Die Reihenfolge zwischen den ersten beiden ist zwingend — der Index kann nicht vor der Bereinigung
+angelegt werden. Der dritte Changeset ist von den ersten beiden unabhängig.
+
+## Rollback-Reihenfolge
+
+```bash
+liquibase --changelog-file=backend/src/main/resources/db/changelog/db.changelog-master.yaml \
+  --url=<jdbc-url> --username=<user> --password=<pass> \
+  rollback-count 3
+```
+
+Rollback in umgekehrter Anwendungsreihenfolge:
+
+1. `010-create-space-memberships-space-id-index` — löscht `idx_space_memberships_space_id`, verlustfrei
+2. `010-create-personal-space-unique-index` — löscht `uk_spaces_personal_owner`, verlustfrei
+3. `010-cleanup-duplicate-personal-spaces` — **irreversibel**
+
+**Der Rollback von `010-cleanup-duplicate-personal-spaces` ist ein bewusster No-op** (`SELECT 1;`),
+kein tatsächliches Wiederherstellen der gelöschten Zeilen. Gelöschte Duplikate und ihre
+kaskadierten Mitgliedschaften lassen sich aus dieser Migration heraus nicht rekonstruieren. Wer sie
+zwingend braucht, muss aus einem Backup vor dieser Migration wiederherstellen. Ein echter Rollback
+ohne Datenverlust ist bei einer Löschoperation grundsätzlich nicht möglich — die Alternative wäre,
+den Rollback fehlschlagen zu lassen, was den Rollback der beiden nachfolgenden, verlustfreien
+Changesets unnötig blockieren würde.
+
+## Test
+
+`Migration010SpaceUniquenessTest`
+(`backend/src/test/java/io/opaa/migration/Migration010SpaceUniquenessTest.java`) folgt dem in
+`docs/migrations/008-rename-workspace-to-space.md` beschriebenen Muster: Es wendet die echten,
+versionierten Changesets 001–008 über die Fixture `test-master-through-008.yaml` an, sät
+Alt-Zeilen mit zwei persönlichen Spaces für denselben Eigentümer, wendet Changelog 010 in Isolation
+an und prüft, dass der ältere Space erhalten bleibt, der jüngere entfernt wird, seine Mitgliedschaft
+mit entfernt wurde, der Index tatsächlich existiert und ein zweiter Insert-Versuch für denselben
+Eigentümer daran scheitert. Eine zweite Testmethode prüft den Index auf `space_memberships.space_id`.
+
+**Unterschied zu `Migration008RenameWorkspaceToSpaceTest`:** Diese Testklasse hat mehr als eine
+Testmethode. Der statische Testcontainer wird zwischen Testmethoden nicht zurückgesetzt, und
+Liquibase vermerkt jeden angewendeten Changeset in `DATABASECHANGELOG` — ein zweiter Testlauf hätte
+Changelog 010 sonst stillschweigend als "bereits angewendet" übersprungen, statt gegen die
+Alt-Zeilen der jeweiligen Testmethode zu laufen. `Migration010SpaceUniquenessTest` löst das, indem
+es das `public`-Schema nach jeder Testmethode droppt und neu anlegt (`resetSchema()`), sodass jede
+Methode bei einer leeren Datenbank inklusive leerem `DATABASECHANGELOG` startet. Dieses Muster ist
+für künftige Migrationstests mit mehreren Testmethoden zu übernehmen (siehe #237, #238).
+
+Der race-sichere Anwendungscode-Pfad in `SpaceService.ensurePersonalSpace` ist separat in
+`SpaceServiceTest` abgedeckt (reiner Mockito-Test, kein Testcontainer): Er simuliert den
+gleichzeitigen ersten Login, indem `existsByOwnerIdAndKind` und `saveAndFlush` so gestubbt werden,
+wie sie sich für den Verlierer des Rennens verhalten würden — deterministisch statt über echte
+Threads und Timing.


### PR DESCRIPTION
## Zusammenfassung

Zwei unabhängige, kleine Liquibase-Changesets an den Space-Tabellen, die zusammen in einem PR landen, weil beide dieselben Tabellen betreffen und beide im Review zu PR #254 als vorbestehend eingestuft wurden.

**#265 (dringlicher):** `SpaceService.ensurePersonalSpace` prüfte bislang nur mit `existsByOwnerIdAndKind` und legte danach an — ohne Absicherung auf Datenbankebene. Zwei gleichzeitige Erstanmeldungen desselben Nutzers konnten so zwei persönliche Spaces erzeugen. Ein partieller Unique-Index (`uk_spaces_personal_owner`, nur für `kind = 'PERSONAL'`) schließt die Lücke; eine zusammengesetzte Unique-Constraint hätte auch `PROJECT`- und `TEAM`-Spaces fälschlich auf einen pro Eigentümer begrenzt. Vor der Indexanlage bereinigt ein Changeset vorhandene Duplikate (ältester Space je Eigentümer bleibt erhalten, ein `RAISE NOTICE` meldet die Anzahl). `ensurePersonalSpace` fängt die Constraint-Verletzung des Verlierers eines gleichzeitigen Logins ab und liest stattdessen den bereits angelegten Space, statt einen 500 zu werfen.

**#266:** `space_memberships` hatte bisher nur den zusammengesetzten Unique-Index `uk_space_memberships_user_space` mit führendem `user_id`. Abfragen, die über `space_id` einsteigen (z. B. das Laden der Mitglieder eines Space), profitierten davon nicht. Ein eigenständiger Index auf `space_id` behebt das.

Details zu Reihenfolge, Rollback und der Testmethodik stehen in [`docs/migrations/010-space-uniqueness-and-membership-index.md`](docs/migrations/010-space-uniqueness-and-membership-index.md).

## Zugehörige Issues

Closes #265
Closes #266

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code, Developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst