### PR TITLE
feat(ci): Anthropic als Anbieter für die Report-Zusammenfassung unterstützen

### DIFF
--- a/.github/scripts/daily_report.py
+++ b/.github/scripts/daily_report.py
@@ -275,6 +275,81 @@ def build_summary_prompt(data: dict) -> str:
     return "\n".join(lines)
 
 
+ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_MODELS = {
+    "anthropic": "claude-haiku-4-5-20251001",
+    "openai": "gpt-4o",
+}
+DEFAULT_BASE_URLS = {
+    "anthropic": "https://api.anthropic.com",
+    "openai": "https://api.openai.com",
+}
+
+
+def detect_provider(api_key: str) -> str:
+    """Bestimmt den Anbieter, vorrangig aus der Konfiguration.
+
+    Ohne gesetzte Variable entscheidet das Präfix des Schlüssels. Anthropic
+    vergibt Schlüssel mit `sk-ant-`, alles andere wird als OpenAI-kompatibel
+    behandelt.
+    """
+    configured = os.environ.get("OPAA_REPORT_PROVIDER", "").strip().lower()
+    if configured in DEFAULT_MODELS:
+        return configured
+    if configured:
+        print(
+            f"Unbekannter Anbieter '{configured}' — erkenne anhand des Schlüssels.",
+            file=sys.stderr,
+        )
+    return "anthropic" if api_key.startswith("sk-ant-") else "openai"
+
+
+def build_request(provider: str, api_key: str, base_url: str, model: str, prompt: str):
+    """Baut die Anfrage im Format des jeweiligen Anbieters."""
+    if provider == "anthropic":
+        payload = {
+            "model": model,
+            "max_tokens": 900,
+            "temperature": 0.3,
+            "system": SUMMARY_SYSTEM_PROMPT,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        path = "/v1/messages"
+    else:
+        payload = {
+            "model": model,
+            "max_tokens": 900,
+            "temperature": 0.3,
+            "messages": [
+                {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        path = "/v1/chat/completions"
+
+    return urllib.request.Request(
+        f"{base_url}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+    )
+
+
+def extract_text(provider: str, body: dict) -> str:
+    """Liest den Antworttext aus der Struktur des jeweiligen Anbieters."""
+    if provider == "anthropic":
+        return body["content"][0]["text"].strip()
+    return body["choices"][0]["message"]["content"].strip()
+
+
 def summarize(data: dict) -> str:
     """Erzeugt die Zusammenfassung. Bei jedem Fehler bleibt sie leer."""
     api_key = os.environ.get("OPAA_REPORT_API_KEY", "").strip()
@@ -282,34 +357,30 @@ def summarize(data: dict) -> str:
         print("Kein API-Schlüssel gesetzt — Report ohne Zusammenfassung.", file=sys.stderr)
         return ""
 
+    provider = detect_provider(api_key)
     # Nicht gesetzte Repository-Variablen erreichen den Prozess als leerer
     # String, nicht als fehlender Eintrag. Der Vorgabewert von `get` würde
     # deshalb nie greifen.
-    model = os.environ.get("OPAA_REPORT_MODEL", "").strip() or "gpt-4o"
+    model = os.environ.get("OPAA_REPORT_MODEL", "").strip() or DEFAULT_MODELS[provider]
     base_url = (
-        os.environ.get("OPAA_REPORT_BASE_URL", "").strip() or "https://api.openai.com"
+        os.environ.get("OPAA_REPORT_BASE_URL", "").strip() or DEFAULT_BASE_URLS[provider]
     ).rstrip("/")
-    payload = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
-            {"role": "user", "content": build_summary_prompt(data)},
-        ],
-        "temperature": 0.3,
-        "max_tokens": 900,
-    }
-    request = urllib.request.Request(
-        f"{base_url}/v1/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
+
+    print(f"Zusammenfassung über {provider}, Modell {model}.", file=sys.stderr)
+    request = build_request(
+        provider, api_key, base_url, model, build_summary_prompt(data)
     )
     try:
         with urllib.request.urlopen(request, timeout=120) as response:
             body = json.loads(response.read().decode("utf-8"))
-        return body["choices"][0]["message"]["content"].strip()
+        return extract_text(provider, body)
+    except urllib.error.HTTPError as error:
+        # Der Fehlertext des Anbieters nennt die Ursache, etwa ein unbekanntes
+        # Modell oder einen abgelaufenen Schlüssel. Er enthält den Schlüssel
+        # selbst nicht und kann daher protokolliert werden.
+        detail = error.read().decode("utf-8", errors="replace")[:400]
+        print(f"Zusammenfassung fehlgeschlagen ({error.code}): {detail}", file=sys.stderr)
+        return ""
     except (urllib.error.URLError, KeyError, IndexError, TimeoutError) as error:
         print(f"Zusammenfassung fehlgeschlagen: {error}", file=sys.stderr)
         return ""

--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -53,6 +53,7 @@ jobs:
           # OpenAI-Integrationstests laufen. Beides zu koppeln würde das
           # Aktivieren der Zusammenfassung zu einer Änderung an der CI machen.
           OPAA_REPORT_API_KEY: ${{ secrets.OPAA_REPORT_API_KEY }}
+          OPAA_REPORT_PROVIDER: ${{ vars.OPAA_REPORT_PROVIDER }}
           OPAA_REPORT_MODEL: ${{ vars.OPAA_REPORT_MODEL }}
           OPAA_REPORT_BASE_URL: ${{ vars.OPAA_REPORT_BASE_URL }}
         run: |

--- a/docs/tagesreport.md
+++ b/docs/tagesreport.md
@@ -71,16 +71,29 @@ Zum Aktivieren einen Schlüssel als Repository-Secret hinterlegen:
 gh secret set OPAA_REPORT_API_KEY
 ```
 
-Das Modell und der Endpunkt lassen sich über Repository-Variablen wechseln;
-ohne sie werden `gpt-4o` und die OpenAI-API verwendet:
+Unterstützt werden **Anthropic** und **OpenAI**. Welcher Anbieter angesprochen
+wird, ergibt sich aus dem Präfix des Schlüssels: `sk-ant-` bedeutet Anthropic,
+alles andere wird als OpenAI-kompatibel behandelt. Explizit setzen lässt es sich
+über `OPAA_REPORT_PROVIDER` mit den Werten `anthropic` oder `openai`.
+
+Modell und Endpunkt sind über Repository-Variablen wählbar:
 
 ```bash
-gh variable set OPAA_REPORT_MODEL --body "gpt-4o-mini"
+gh variable set OPAA_REPORT_MODEL --body "claude-haiku-4-5-20251001"
 gh variable set OPAA_REPORT_BASE_URL --body "https://mein-endpunkt.example"
 ```
 
+Ohne diese Variablen gelten je Anbieter:
+
+| Anbieter | Vorgabemodell | Endpunkt |
+| --- | --- | --- |
+| Anthropic | `claude-haiku-4-5-20251001` | `https://api.anthropic.com` |
+| OpenAI | `gpt-4o` | `https://api.openai.com` |
+
 Schlägt der Aufruf fehl, erscheint der Report ohne Zusammenfassung statt gar
-nicht.
+nicht. Die Fehlermeldung des Anbieters steht im Protokoll des Workflows und
+nennt typische Ursachen wie ein unbekanntes Modell oder einen abgelaufenen
+Schlüssel.
 
 ### Warum ein eigenes Secret
 


### PR DESCRIPTION
## Zusammenfassung

Die Zusammenfassung des Tagesreports sprach ausschließlich das Chat-Completions-Format von OpenAI an. Für den Betrieb mit einem Anthropic-Schlüssel wird ein anderes Anfrageformat benötigt.

| | OpenAI | Anthropic |
| --- | --- | --- |
| Pfad | `/v1/chat/completions` | `/v1/messages` |
| Authentifizierung | `Authorization: Bearer …` | `x-api-key` plus `anthropic-version` |
| Systemanweisung | Nachricht mit `role: system` | eigenes Feld `system` |
| Antwort | `choices[0].message.content` | `content[0].text` |
| `max_tokens` | optional | erforderlich |

Der Anbieter ist über `OPAA_REPORT_PROVIDER` wählbar. Ohne Angabe entscheidet das Präfix des Schlüssels: `sk-ant-` bedeutet Anthropic, alles andere wird als OpenAI-kompatibel behandelt. Vorgabemodell und Endpunkt richten sich nach dem erkannten Anbieter.

Ergänzt wurde außerdem die Behandlung von `HTTPError`: Bisher wurde nur „Zusammenfassung fehlgeschlagen" protokolliert. Jetzt steht der Fehlertext des Anbieters im Protokoll, was ein unbekanntes Modell oder einen abgelaufenen Schlüssel sofort erkennbar macht. Der Report entsteht weiterhin ohne Zusammenfassung statt gar nicht.

## Prüfung

**Gegen die echte API getestet** mit `claude-haiku-4-5-20251001` und den Daten vom 2. August (17 abgeschlossene Issues, 22 gemergte PRs). Die Zusammenfassung wurde erzeugt, hält den vorgegebenen Stil ein und gruppiert nach Thema statt nach Issue-Reihenfolge.

Anbietererkennung in fünf Fällen:

| Schlüssel | `OPAA_REPORT_PROVIDER` | Ergebnis |
| --- | --- | --- |
| `sk-ant-…` | nicht gesetzt | anthropic |
| `sk-proj-…` | nicht gesetzt | openai |
| `sk-ant-…` | `openai` | openai — Variable schlägt Präfix |
| `sk-proj-…` | `anthropic` | anthropic — Variable schlägt Präfix |
| `sk-ant-…` | `quatsch` | anthropic mit Warnung im Protokoll |

## Zugehörige Issues

Closes #279

## Art der Änderung

- [ ] Bugfix
- [x] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (keine Anwendungsänderung; gegen die echte API und in fünf Erkennungsfällen geprüft, YAML validiert)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF