### PR TITLE
Gruppen als Rechtesubjekt einfuehren

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -108,6 +108,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SpaceKind" to "SpaceKind",
         "SpaceVisibility" to "SpaceVisibility",
         "SystemRole" to "SystemRole",
+        "GroupKind" to "GroupKind",
     ))
     importMappings.set(mapOf(
         "Instant" to "java.time.Instant",
@@ -115,6 +116,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SpaceKind" to "io.opaa.space.SpaceKind",
         "SpaceVisibility" to "io.opaa.space.SpaceVisibility",
         "SystemRole" to "io.opaa.auth.SystemRole",
+        "GroupKind" to "io.opaa.group.GroupKind",
     ))
 }
 
@@ -123,7 +125,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         // Remove generated enum files that are mapped to existing domain enums via typeMappings.
         // The generator still creates these files even with typeMappings configured.
         val generatedDir = layout.buildDirectory.dir("generated/openapi/src/main/java/io/opaa/api/dto").get().asFile
-        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java").forEach { fileName ->
+        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java").forEach { fileName ->
             file("$generatedDir/$fileName").delete()
         }
     }

--- a/backend/src/main/java/io/opaa/api/GroupController.java
+++ b/backend/src/main/java/io/opaa/api/GroupController.java
@@ -1,0 +1,120 @@
+package io.opaa.api;
+
+import io.opaa.api.dto.GroupAddMemberRequest;
+import io.opaa.api.dto.GroupListResponse;
+import io.opaa.api.dto.GroupMemberResponse;
+import io.opaa.api.dto.GroupRequest;
+import io.opaa.api.dto.GroupResponse;
+import io.opaa.api.dto.GroupUpdateRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserService;
+import io.opaa.group.GroupService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Profile({"oidc", "basic"})
+@RestController
+@RequestMapping("/api/v1/admin/groups")
+public class GroupController {
+
+  private static final String UNKNOWN_ISSUER = "unknown";
+
+  private final GroupService groupService;
+  private final UserService userService;
+
+  public GroupController(GroupService groupService, UserService userService) {
+    this.groupService = groupService;
+    this.userService = userService;
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @GetMapping
+  public List<GroupListResponse> listGroups(@AuthenticationPrincipal Jwt jwt) {
+    return groupService.listGroups(currentUser(jwt).getId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @PostMapping
+  public ResponseEntity<GroupResponse> createGroup(
+      @Valid @RequestBody GroupRequest request, @AuthenticationPrincipal Jwt jwt) {
+    GroupResponse response = groupService.createGroup(request, currentUser(jwt).getId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @GetMapping("/{groupId}")
+  public GroupResponse getGroup(@PathVariable UUID groupId, @AuthenticationPrincipal Jwt jwt) {
+    return groupService.getGroup(groupId, currentUser(jwt).getId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @PutMapping("/{groupId}")
+  public GroupResponse updateGroup(
+      @PathVariable UUID groupId,
+      @Valid @RequestBody GroupUpdateRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    return groupService.updateGroup(groupId, request, currentUser(jwt).getId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @DeleteMapping("/{groupId}")
+  public ResponseEntity<Void> deleteGroup(
+      @PathVariable UUID groupId, @AuthenticationPrincipal Jwt jwt) {
+    groupService.deleteGroup(groupId, currentUser(jwt).getId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @GetMapping("/{groupId}/members")
+  public List<GroupMemberResponse> listMembers(
+      @PathVariable UUID groupId, @AuthenticationPrincipal Jwt jwt) {
+    return groupService.listMembers(groupId, currentUser(jwt).getId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @PostMapping("/{groupId}/members")
+  public ResponseEntity<GroupMemberResponse> addMember(
+      @PathVariable UUID groupId,
+      @Valid @RequestBody GroupAddMemberRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    GroupMemberResponse response =
+        groupService.addMember(groupId, request.getUserId(), currentUser(jwt).getId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @DeleteMapping("/{groupId}/members/{userId}")
+  public ResponseEntity<Void> removeMember(
+      @PathVariable UUID groupId, @PathVariable UUID userId, @AuthenticationPrincipal Jwt jwt) {
+    groupService.removeMember(groupId, userId, currentUser(jwt).getId());
+    return ResponseEntity.noContent().build();
+  }
+
+  private User currentUser(Jwt jwt) {
+    String issuer = jwt.getClaimAsString("iss");
+    if (issuer == null || issuer.isBlank()) {
+      issuer = UNKNOWN_ISSUER;
+    }
+
+    return userService
+        .findBySubjectAndIssuer(jwt.getSubject(), issuer)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
+  }
+}

--- a/backend/src/main/java/io/opaa/group/Group.java
+++ b/backend/src/main/java/io/opaa/group/Group.java
@@ -1,0 +1,155 @@
+package io.opaa.group;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A permission subject that groups users together, scoped to exactly one organization. A grant can
+ * reference a group instead of a single user (see {@link PermissionSubject}); resolving which users
+ * a group grant reaches goes through {@link GroupMembershipResolver}.
+ */
+@Entity
+@Table(name = "groups")
+public class Group {
+
+  @Id private UUID id;
+
+  @Column(name = "organization_id", nullable = false)
+  private UUID organizationId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false, length = 20)
+  private GroupKind kind;
+
+  @Column(name = "name", nullable = false, length = 255)
+  private String name;
+
+  @Column(name = "description", length = 2000)
+  private String description;
+
+  /**
+   * Stable directory identifier (objectGUID or SCIM externalId) that directory synchronisation
+   * (#237) matches on instead of the name - a rename in the directory must never orphan grants.
+   * Null for {@link GroupKind#AD_HOC} groups, which have no directory counterpart.
+   */
+  @Column(name = "external_id", length = 255)
+  private String externalId;
+
+  /**
+   * Parent organizational unit; only meaningful for {@link GroupKind#ORG_UNIT} groups. Used to
+   * escalate curator responsibility upward when a unit has no curator of its own (see #208).
+   */
+  @Column(name = "parent_group_id")
+  private UUID parentGroupId;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<GroupMembership> memberships = new ArrayList<>();
+
+  protected Group() {}
+
+  public Group(
+      UUID organizationId,
+      GroupKind kind,
+      String name,
+      String description,
+      String externalId,
+      UUID parentGroupId) {
+    this.id = UUID.randomUUID();
+    this.organizationId = organizationId;
+    this.kind = kind;
+    this.name = name;
+    this.description = description;
+    this.externalId = externalId;
+    this.parentGroupId = parentGroupId;
+  }
+
+  @PrePersist
+  void onCreate() {
+    Instant now = Instant.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
+
+  public void addMembership(GroupMembership membership) {
+    memberships.add(membership);
+    membership.assignGroup(this);
+  }
+
+  public void removeMembership(GroupMembership membership) {
+    memberships.remove(membership);
+    membership.assignGroup(null);
+  }
+
+  public void updateDetails(String name, String description) {
+    this.name = name;
+    this.description = description;
+  }
+
+  public boolean isOrgUnit() {
+    return this.kind == GroupKind.ORG_UNIT;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public GroupKind getKind() {
+    return kind;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getExternalId() {
+    return externalId;
+  }
+
+  public UUID getParentGroupId() {
+    return parentGroupId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public List<GroupMembership> getMemberships() {
+    return Collections.unmodifiableList(memberships);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/GroupKind.java
+++ b/backend/src/main/java/io/opaa/group/GroupKind.java
@@ -1,0 +1,22 @@
+package io.opaa.group;
+
+/**
+ * What a group is for and where its membership comes from.
+ *
+ * <ul>
+ *   <li>{@link #ORG_UNIT} - synchronised from the directory (department, division, agency). Carries
+ *       a parent unit and can have curators bound to it (see #208). Membership is never invented
+ *       here - it is exactly what the directory places in the group (see #237).
+ *   <li>{@link #AD_HOC} - created in the system by an administrator (e.g. "Projektbeteiligte
+ *       Phoenix"). Has no curator and does not carry a distribution level of its own.
+ * </ul>
+ *
+ * <p>Curator approval for a grant is bound to the group's <em>reach</em> (its member count), not to
+ * its kind - a large AD_HOC group requires the same approval as an ORG_UNIT group of comparable
+ * size. That policy is implemented where grants are created (see #202, #208) and does not live on
+ * this enum.
+ */
+public enum GroupKind {
+  ORG_UNIT,
+  AD_HOC
+}

--- a/backend/src/main/java/io/opaa/group/GroupMembership.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembership.java
@@ -1,0 +1,69 @@
+package io.opaa.group;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "group_memberships")
+public class GroupMembership {
+
+  @Id private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "group_id", nullable = false)
+  private Group group;
+
+  @Column(name = "organization_id", nullable = false)
+  private UUID organizationId;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  protected GroupMembership() {}
+
+  public GroupMembership(UUID userId, UUID organizationId) {
+    this.id = UUID.randomUUID();
+    this.userId = userId;
+    this.organizationId = organizationId;
+  }
+
+  @PrePersist
+  void onCreate() {
+    this.createdAt = Instant.now();
+  }
+
+  void assignGroup(Group group) {
+    this.group = group;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public Group getGroup() {
+    return group;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
@@ -1,7 +1,6 @@
 package io.opaa.group;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,8 +10,6 @@ import org.springframework.data.repository.query.Param;
 public interface GroupMembershipRepository extends JpaRepository<GroupMembership, UUID> {
 
   List<GroupMembership> findByGroupId(UUID groupId);
-
-  Optional<GroupMembership> findByUserIdAndGroupId(UUID userId, UUID groupId);
 
   @Query("select m.group.id from GroupMembership m where m.userId = :userId")
   Set<UUID> findGroupIdsByUserId(@Param("userId") UUID userId);

--- a/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
@@ -1,0 +1,22 @@
+package io.opaa.group;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, UUID> {
+
+  List<GroupMembership> findByGroupId(UUID groupId);
+
+  Optional<GroupMembership> findByUserIdAndGroupId(UUID userId, UUID groupId);
+
+  @Query("select m.group.id from GroupMembership m where m.userId = :userId")
+  Set<UUID> findGroupIdsByUserId(@Param("userId") UUID userId);
+
+  @Query("select m.userId from GroupMembership m where m.group.id = :groupId")
+  Set<UUID> findUserIdsByGroupId(@Param("groupId") UUID groupId);
+}

--- a/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipRepository.java
@@ -17,6 +17,16 @@ public interface GroupMembershipRepository extends JpaRepository<GroupMembership
   @Query("select m.group.id from GroupMembership m where m.userId = :userId")
   Set<UUID> findGroupIdsByUserId(@Param("userId") UUID userId);
 
-  @Query("select m.userId from GroupMembership m where m.group.id = :groupId")
-  Set<UUID> findUserIdsByGroupId(@Param("groupId") UUID groupId);
+  /**
+   * The members of a group, scoped to the given organization - so a subject carrying the wrong
+   * {@code organizationId} (whether by bug or by a crafted request) resolves to nobody instead of
+   * leaking members across the organization boundary. Used by {@link
+   * GroupMembershipResolver#resolveUserIds}. There is no unscoped equivalent on purpose: a caller
+   * that skips the organization would reintroduce exactly the cross-tenant leak #199 closed.
+   */
+  @Query(
+      "select m.userId from GroupMembership m "
+          + "where m.group.id = :groupId and m.organizationId = :organizationId")
+  Set<UUID> findUserIdsByGroupIdAndOrganizationId(
+      @Param("groupId") UUID groupId, @Param("organizationId") UUID organizationId);
 }

--- a/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
@@ -2,6 +2,7 @@ package io.opaa.group;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.opaa.auth.UserRepository;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
@@ -30,10 +31,13 @@ import org.springframework.stereotype.Component;
 public class GroupMembershipResolver {
 
   private final GroupMembershipRepository membershipRepository;
+  private final UserRepository userRepository;
   private final Cache<UUID, Set<UUID>> groupIdsByUser;
 
-  public GroupMembershipResolver(GroupMembershipRepository membershipRepository) {
+  public GroupMembershipResolver(
+      GroupMembershipRepository membershipRepository, UserRepository userRepository) {
     this.membershipRepository = membershipRepository;
+    this.userRepository = userRepository;
     // A stale entry only ever grants access a moment too long between a completed transaction's
     // invalidation and its next read, never too little - invalidateUser/invalidateUsers below,
     // called post-commit, are the primary correctness mechanism. The time-based expiry is a
@@ -49,19 +53,36 @@ public class GroupMembershipResolver {
   }
 
   /**
-   * The set of user ids that a grant to {@code subject} would reach. For a {@code USER} subject
-   * this is just that user; for a {@code GROUP} subject it is the group's current membership,
-   * scoped to {@link PermissionSubject#organizationId()} so a subject naming a group from another
-   * organization resolves to nobody rather than leaking that group's members - membership is never
-   * inherited downward beyond what is recorded here (see #237, #208).
+   * The set of user ids that a grant to {@code subject} would reach, scoped to {@link
+   * PermissionSubject#organizationId()} in both branches: for a {@code GROUP} subject it is the
+   * group's current membership, filtered to that organization at the query in {@link
+   * GroupMembershipRepository#findUserIdsByGroupIdAndOrganizationId} - membership is never
+   * inherited downward beyond what is recorded there (see #237, #208). For a {@code USER} subject
+   * it is that one user, but only if the user actually belongs to the given organization; otherwise
+   * the empty set. This is the one place every future caller (#202) goes through, so it is
+   * deliberately not left to each caller to re-check the boundary for the {@code USER} case - the
+   * extra lookup costs one indexed hit on the hot path, which is cheaper than repeating the
+   * organization-boundary bug class that #199 had to fix in review.
    */
   public Set<UUID> resolveUserIds(PermissionSubject subject) {
     return switch (subject.type()) {
-      case USER -> Set.of(subject.id());
+      case USER -> resolveUserSubject(subject);
       case GROUP ->
           membershipRepository.findUserIdsByGroupIdAndOrganizationId(
               subject.id(), subject.organizationId());
     };
+  }
+
+  private Set<UUID> resolveUserSubject(PermissionSubject subject) {
+    // subject.id() rather than the loaded user's own getId(): a repository match by id already
+    // guarantees they are equal, and using subject.id() keeps this independent of whichever
+    // fields a test double happens to populate on the returned User.
+    boolean belongsToOrganization =
+        userRepository
+            .findById(subject.id())
+            .map(user -> user.getOrganizationId().equals(subject.organizationId()))
+            .orElse(false);
+    return belongsToOrganization ? Set.of(subject.id()) : Set.of();
   }
 
   public void invalidateUser(UUID userId) {

--- a/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
@@ -12,12 +12,19 @@ import org.springframework.stereotype.Component;
  * Resolves which groups a user belongs to, and which users a permission subject (see {@link
  * PermissionSubject}) reaches. This resolution sits on the hot path of every future permission
  * check (readable libraries, agent access - see #202), so it is cached; the cache is invalidated
- * immediately whenever a membership changes, which {@link GroupService} does on every add, remove
- * and group deletion.
+ * only after the enclosing transaction commits (or rolls back), which {@link GroupService} does on
+ * every add, remove and group deletion via its {@code invalidateAfterCommit} helper - not inline,
+ * because an inline invalidation can race a concurrent reader into repopulating the cache with the
+ * pre-commit state (see {@code GroupService#invalidateAfterCommit} for the sequence).
  *
  * <p>Follows the same direct-Caffeine-cache pattern as {@link io.opaa.api.RateLimitService} rather
  * than the Spring Cache abstraction, to avoid introducing a second caching mechanism into the
  * codebase for a single use case.
+ *
+ * <p>The cache is process-local. A single instance is all the MVP runs (see {@code
+ * docs/MVP-STATUS.md}); horizontal scaling is out of scope for now, but would require either a
+ * shared cache or a way to broadcast invalidations, since only the instance that wrote a membership
+ * change would otherwise evict it.
  */
 @Component
 public class GroupMembershipResolver {
@@ -27,10 +34,11 @@ public class GroupMembershipResolver {
 
   public GroupMembershipResolver(GroupMembershipRepository membershipRepository) {
     this.membershipRepository = membershipRepository;
-    // A stale entry only ever grants access a moment too long between an explicit invalidation
-    // and its next read, never too little - invalidateUser/invalidateUsers below are the primary
-    // correctness mechanism. The time-based expiry is a safety net for eviction paths this class
-    // does not yet know about (e.g. a future bulk directory sync, see #237).
+    // A stale entry only ever grants access a moment too long between a completed transaction's
+    // invalidation and its next read, never too little - invalidateUser/invalidateUsers below,
+    // called post-commit, are the primary correctness mechanism. The time-based expiry is a
+    // safety net for eviction paths this class does not yet know about (e.g. a future bulk
+    // directory sync, see #237).
     this.groupIdsByUser =
         Caffeine.newBuilder().maximumSize(50_000).expireAfterWrite(Duration.ofMinutes(10)).build();
   }
@@ -42,13 +50,17 @@ public class GroupMembershipResolver {
 
   /**
    * The set of user ids that a grant to {@code subject} would reach. For a {@code USER} subject
-   * this is just that user; for a {@code GROUP} subject it is the group's current membership -
-   * membership is never inherited downward beyond what is recorded here (see #237, #208).
+   * this is just that user; for a {@code GROUP} subject it is the group's current membership,
+   * scoped to {@link PermissionSubject#organizationId()} so a subject naming a group from another
+   * organization resolves to nobody rather than leaking that group's members - membership is never
+   * inherited downward beyond what is recorded here (see #237, #208).
    */
   public Set<UUID> resolveUserIds(PermissionSubject subject) {
     return switch (subject.type()) {
       case USER -> Set.of(subject.id());
-      case GROUP -> membershipRepository.findUserIdsByGroupId(subject.id());
+      case GROUP ->
+          membershipRepository.findUserIdsByGroupIdAndOrganizationId(
+              subject.id(), subject.organizationId());
     };
   }
 

--- a/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
+++ b/backend/src/main/java/io/opaa/group/GroupMembershipResolver.java
@@ -1,0 +1,62 @@
+package io.opaa.group;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves which groups a user belongs to, and which users a permission subject (see {@link
+ * PermissionSubject}) reaches. This resolution sits on the hot path of every future permission
+ * check (readable libraries, agent access - see #202), so it is cached; the cache is invalidated
+ * immediately whenever a membership changes, which {@link GroupService} does on every add, remove
+ * and group deletion.
+ *
+ * <p>Follows the same direct-Caffeine-cache pattern as {@link io.opaa.api.RateLimitService} rather
+ * than the Spring Cache abstraction, to avoid introducing a second caching mechanism into the
+ * codebase for a single use case.
+ */
+@Component
+public class GroupMembershipResolver {
+
+  private final GroupMembershipRepository membershipRepository;
+  private final Cache<UUID, Set<UUID>> groupIdsByUser;
+
+  public GroupMembershipResolver(GroupMembershipRepository membershipRepository) {
+    this.membershipRepository = membershipRepository;
+    // A stale entry only ever grants access a moment too long between an explicit invalidation
+    // and its next read, never too little - invalidateUser/invalidateUsers below are the primary
+    // correctness mechanism. The time-based expiry is a safety net for eviction paths this class
+    // does not yet know about (e.g. a future bulk directory sync, see #237).
+    this.groupIdsByUser =
+        Caffeine.newBuilder().maximumSize(50_000).expireAfterWrite(Duration.ofMinutes(10)).build();
+  }
+
+  /** The set of group ids the given user is a direct member of. Cached until invalidated. */
+  public Set<UUID> groupIdsForUser(UUID userId) {
+    return groupIdsByUser.get(userId, membershipRepository::findGroupIdsByUserId);
+  }
+
+  /**
+   * The set of user ids that a grant to {@code subject} would reach. For a {@code USER} subject
+   * this is just that user; for a {@code GROUP} subject it is the group's current membership -
+   * membership is never inherited downward beyond what is recorded here (see #237, #208).
+   */
+  public Set<UUID> resolveUserIds(PermissionSubject subject) {
+    return switch (subject.type()) {
+      case USER -> Set.of(subject.id());
+      case GROUP -> membershipRepository.findUserIdsByGroupId(subject.id());
+    };
+  }
+
+  public void invalidateUser(UUID userId) {
+    groupIdsByUser.invalidate(userId);
+  }
+
+  public void invalidateUsers(Collection<UUID> userIds) {
+    groupIdsByUser.invalidateAll(userIds);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/GroupRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupRepository.java
@@ -14,5 +14,10 @@ public interface GroupRepository extends JpaRepository<Group, UUID> {
   @Query("select distinct g from Group g left join fetch g.memberships where g.id = :groupId")
   Optional<Group> findByIdWithMemberships(@Param("groupId") UUID groupId);
 
+  /**
+   * Unused for now - a placeholder for #237's directory synchronisation, which matches ORG_UNIT
+   * groups by their stable {@code externalId} (not name) within an organization and needs exactly
+   * this check to decide "update" versus "create" for an incoming directory group.
+   */
   boolean existsByOrganizationIdAndExternalId(UUID organizationId, String externalId);
 }

--- a/backend/src/main/java/io/opaa/group/GroupRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupRepository.java
@@ -1,0 +1,18 @@
+package io.opaa.group;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GroupRepository extends JpaRepository<Group, UUID> {
+
+  List<Group> findByOrganizationId(UUID organizationId);
+
+  @Query("select distinct g from Group g left join fetch g.memberships where g.id = :groupId")
+  Optional<Group> findByIdWithMemberships(@Param("groupId") UUID groupId);
+
+  boolean existsByOrganizationIdAndExternalId(UUID organizationId, String externalId);
+}

--- a/backend/src/main/java/io/opaa/group/GroupService.java
+++ b/backend/src/main/java/io/opaa/group/GroupService.java
@@ -1,0 +1,288 @@
+package io.opaa.group;
+
+import io.opaa.api.dto.GroupListResponse;
+import io.opaa.api.dto.GroupMemberResponse;
+import io.opaa.api.dto.GroupRequest;
+import io.opaa.api.dto.GroupResponse;
+import io.opaa.api.dto.GroupUpdateRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Manages groups as permission subjects. All endpoints are system-admin only (enforced at the
+ * controller via {@code @PreAuthorize}); this service still resolves the caller's organization and
+ * enforces the organization boundary the same way {@code SpaceService} does, because a system admin
+ * exists per organization and must never see or touch another organization's groups.
+ *
+ * <p>Only {@link GroupKind#AD_HOC} groups can be created, renamed, deleted or have their membership
+ * managed here. {@link GroupKind#ORG_UNIT} groups are synchronised from the directory (#237) and
+ * are read-only through this service.
+ *
+ * <p>Deleting a group that owns an asset is meant to be blocked until ownership is transferred (see
+ * the feature spec's "Eigentuemerschaft und Verwaisung" and issue #200's acceptance criteria).
+ * There is no asset model yet ({@code io.opaa.indexing.Document} is the only content type, and it
+ * carries no owner) - #201/#202 introduce assets and asset ownership. Once they land, {@link
+ * #deleteGroup} must check for owned assets before deleting; there is nothing to check against yet,
+ * so no such check exists here.
+ */
+@Service
+@Transactional(readOnly = true)
+public class GroupService {
+
+  private static final int MAX_NAME_LENGTH = 255;
+  private static final int MAX_DESCRIPTION_LENGTH = 2000;
+
+  private final GroupRepository groupRepository;
+  private final UserRepository userRepository;
+  private final GroupMembershipResolver membershipResolver;
+
+  public GroupService(
+      GroupRepository groupRepository,
+      UserRepository userRepository,
+      GroupMembershipResolver membershipResolver) {
+    this.groupRepository = groupRepository;
+    this.userRepository = userRepository;
+    this.membershipResolver = membershipResolver;
+  }
+
+  @Transactional
+  public GroupResponse createGroup(GroupRequest request, UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    String normalizedName = validateName(request.getName());
+    validateDescription(request.getDescription());
+
+    Group group =
+        new Group(
+            currentUser.getOrganizationId(),
+            GroupKind.AD_HOC,
+            normalizedName,
+            request.getDescription(),
+            null,
+            null);
+    Group saved = groupRepository.save(group);
+    return toGroupResponse(saved);
+  }
+
+  public List<GroupListResponse> listGroups(UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    return groupRepository.findByOrganizationId(currentUser.getOrganizationId()).stream()
+        .map(this::toGroupListResponse)
+        .toList();
+  }
+
+  public GroupResponse getGroup(UUID groupId, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    return toGroupResponse(group);
+  }
+
+  @Transactional
+  public GroupResponse updateGroup(UUID groupId, GroupUpdateRequest request, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    rejectOrgUnit(group);
+
+    String normalizedName = validateName(request.getName());
+    validateDescription(request.getDescription());
+    group.updateDetails(normalizedName, request.getDescription());
+    Group updated = groupRepository.save(group);
+    return toGroupResponse(updated);
+  }
+
+  @Transactional
+  public void deleteGroup(UUID groupId, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    rejectOrgUnit(group);
+
+    List<UUID> affectedUserIds =
+        group.getMemberships().stream().map(GroupMembership::getUserId).toList();
+    groupRepository.delete(group);
+    membershipResolver.invalidateUsers(affectedUserIds);
+  }
+
+  public List<GroupMemberResponse> listMembers(UUID groupId, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    List<UUID> userIds = group.getMemberships().stream().map(GroupMembership::getUserId).toList();
+    Map<UUID, String> displayNames = resolveDisplayNames(userIds);
+
+    return group.getMemberships().stream()
+        .map(
+            m ->
+                new GroupMemberResponse(m.getUserId(), m.getCreatedAt())
+                    .displayName(displayNames.get(m.getUserId())))
+        .toList();
+  }
+
+  @Transactional
+  public GroupMemberResponse addMember(UUID groupId, UUID memberUserId, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    rejectOrgUnit(group);
+    // Resolving the target user first also turns a non-existent userId into a clean 404 instead
+    // of a raw foreign-key violation from the membership insert below.
+    requireUserInOrganization(memberUserId, group.getOrganizationId());
+
+    if (userMembership(group, memberUserId) != null) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT, "Der Benutzer ist bereits Mitglied dieser Gruppe");
+    }
+
+    GroupMembership membership = new GroupMembership(memberUserId, group.getOrganizationId());
+    group.addMembership(membership);
+    groupRepository.save(group);
+    membershipResolver.invalidateUser(memberUserId);
+
+    return new GroupMemberResponse(membership.getUserId(), membership.getCreatedAt())
+        .displayName(resolveDisplayName(membership.getUserId()));
+  }
+
+  @Transactional
+  public void removeMember(UUID groupId, UUID memberUserId, UUID currentUserId) {
+    Group group = loadGroup(groupId, currentUserId);
+    rejectOrgUnit(group);
+
+    GroupMembership target = userMembership(group, memberUserId);
+    if (target == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mitglied der Gruppe nicht gefunden");
+    }
+
+    group.removeMembership(target);
+    groupRepository.save(group);
+    membershipResolver.invalidateUser(memberUserId);
+  }
+
+  private String validateName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name ist erforderlich");
+    }
+    String trimmed = name.trim();
+    if (trimmed.length() > MAX_NAME_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "name darf hoechstens " + MAX_NAME_LENGTH + " Zeichen umfassen");
+    }
+    return trimmed;
+  }
+
+  private void validateDescription(String description) {
+    if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "description darf hoechstens " + MAX_DESCRIPTION_LENGTH + " Zeichen umfassen");
+    }
+  }
+
+  private void rejectOrgUnit(Group group) {
+    if (group.isOrgUnit()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Organisationseinheiten werden aus dem Verzeichnis synchronisiert und koennen hier"
+              + " nicht bearbeitet werden");
+    }
+  }
+
+  private User requireUser(UUID userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer nicht gefunden"));
+  }
+
+  /**
+   * Resolves a user and enforces the organization boundary for it - mirrors {@code
+   * SpaceService#requireUserInOrganization}. Returns 404 rather than 403 both when the user does
+   * not exist and when it belongs to a different organization, so a caller cannot distinguish "no
+   * such user" from "user in another organization".
+   */
+  private User requireUserInOrganization(UUID userId, UUID organizationId) {
+    User user = requireUser(userId);
+    if (!user.getOrganizationId().equals(organizationId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer nicht gefunden");
+    }
+    return user;
+  }
+
+  /**
+   * Loads a group and enforces the organization boundary, treating a group from another
+   * organization as not found - mirrors {@code SpaceService#loadSpace}. Applies to system admins as
+   * well; the boundary is not overstepped even to reveal existence.
+   */
+  private Group loadGroup(UUID groupId, UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    Group group =
+        groupRepository
+            .findByIdWithMemberships(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden"));
+
+    if (!group.getOrganizationId().equals(currentUser.getOrganizationId())) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden");
+    }
+    return group;
+  }
+
+  private GroupMembership userMembership(Group group, UUID userId) {
+    return group.getMemberships().stream()
+        .filter(membership -> membership.getUserId().equals(userId))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private String resolveDisplayName(UUID userId) {
+    return userRepository
+        .findById(userId)
+        .map(u -> u.getDisplayName() != null ? u.getDisplayName() : u.getEmail())
+        .orElse(null);
+  }
+
+  private Map<UUID, String> resolveDisplayNames(List<UUID> userIds) {
+    Map<UUID, String> result = new HashMap<>();
+    for (User user : userRepository.findAllById(userIds)) {
+      result.put(
+          user.getId(), user.getDisplayName() != null ? user.getDisplayName() : user.getEmail());
+    }
+    return result;
+  }
+
+  private GroupListResponse toGroupListResponse(Group group) {
+    return new GroupListResponse(
+            group.getId(),
+            group.getName(),
+            group.getKind(),
+            group.getMemberships().size(),
+            group.getCreatedAt(),
+            group.getUpdatedAt())
+        .description(group.getDescription())
+        .externalId(group.getExternalId())
+        .parentGroupId(group.getParentGroupId());
+  }
+
+  private GroupResponse toGroupResponse(Group group) {
+    List<UUID> memberIds = group.getMemberships().stream().map(GroupMembership::getUserId).toList();
+    Map<UUID, String> displayNames = resolveDisplayNames(memberIds);
+
+    List<GroupMemberResponse> members =
+        group.getMemberships().stream()
+            .map(
+                m ->
+                    new GroupMemberResponse(m.getUserId(), m.getCreatedAt())
+                        .displayName(displayNames.get(m.getUserId())))
+            .toList();
+
+    return new GroupResponse(
+            group.getId(),
+            group.getName(),
+            group.getKind(),
+            members.size(),
+            members,
+            group.getCreatedAt(),
+            group.getUpdatedAt())
+        .description(group.getDescription())
+        .externalId(group.getExternalId())
+        .parentGroupId(group.getParentGroupId());
+  }
+}

--- a/backend/src/main/java/io/opaa/group/GroupService.java
+++ b/backend/src/main/java/io/opaa/group/GroupService.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -29,9 +31,8 @@ import org.springframework.web.server.ResponseStatusException;
  * <p>Deleting a group that owns an asset is meant to be blocked until ownership is transferred (see
  * the feature spec's "Eigentuemerschaft und Verwaisung" and issue #200's acceptance criteria).
  * There is no asset model yet ({@code io.opaa.indexing.Document} is the only content type, and it
- * carries no owner) - #201/#202 introduce assets and asset ownership. Once they land, {@link
- * #deleteGroup} must check for owned assets before deleting; there is nothing to check against yet,
- * so no such check exists here.
+ * carries no owner) - #201/#202 introduce assets and asset ownership; see the {@code TODO} on
+ * {@link #deleteGroup}.
  */
 @Service
 @Transactional(readOnly = true)
@@ -97,13 +98,16 @@ public class GroupService {
 
   @Transactional
   public void deleteGroup(UUID groupId, UUID currentUserId) {
+    // TODO(#202): block deletion while the group still owns an asset, once asset ownership
+    // exists. There is nothing to check against yet - see the class javadoc for why no such
+    // check exists here.
     Group group = loadGroup(groupId, currentUserId);
     rejectOrgUnit(group);
 
     List<UUID> affectedUserIds =
         group.getMemberships().stream().map(GroupMembership::getUserId).toList();
     groupRepository.delete(group);
-    membershipResolver.invalidateUsers(affectedUserIds);
+    invalidateAfterCommit(() -> membershipResolver.invalidateUsers(affectedUserIds));
   }
 
   public List<GroupMemberResponse> listMembers(UUID groupId, UUID currentUserId) {
@@ -135,7 +139,7 @@ public class GroupService {
     GroupMembership membership = new GroupMembership(memberUserId, group.getOrganizationId());
     group.addMembership(membership);
     groupRepository.save(group);
-    membershipResolver.invalidateUser(memberUserId);
+    invalidateAfterCommit(() -> membershipResolver.invalidateUser(memberUserId));
 
     return new GroupMemberResponse(membership.getUserId(), membership.getCreatedAt())
         .displayName(resolveDisplayName(membership.getUserId()));
@@ -153,7 +157,7 @@ public class GroupService {
 
     group.removeMembership(target);
     groupRepository.save(group);
-    membershipResolver.invalidateUser(memberUserId);
+    invalidateAfterCommit(() -> membershipResolver.invalidateUser(memberUserId));
   }
 
   private String validateName(String name) {
@@ -174,6 +178,36 @@ public class GroupService {
           HttpStatus.BAD_REQUEST,
           "description darf hoechstens " + MAX_DESCRIPTION_LENGTH + " Zeichen umfassen");
     }
+  }
+
+  /**
+   * Defers a cache invalidation until the enclosing transaction has finished, instead of running it
+   * immediately at the point of the call. Every {@code @Transactional} method here commits through
+   * the Spring proxy only after it returns, so invalidating inline (as an earlier version of this
+   * class did) can race a concurrent reader: it can observe the pre-image under {@code READ
+   * COMMITTED}, repopulate the cache with it, and then have this transaction commit - leaving a
+   * revoked membership readable from the cache for up to the cache's expiry (see {@link
+   * GroupMembershipResolver}).
+   *
+   * <p>Registered as {@code afterCompletion} rather than {@code afterCommit} so a rollback also
+   * evicts the entry the transaction may have touched - a stale hit is the wrong failure mode
+   * either way, so there is no reason to skip cleanup on the rollback path.
+   *
+   * <p>Falls back to running immediately when no transaction is active (e.g. called directly in a
+   * test), so the invalidation is never silently dropped.
+   */
+  private void invalidateAfterCommit(Runnable invalidation) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      invalidation.run();
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            invalidation.run();
+          }
+        });
   }
 
   private void rejectOrgUnit(Group group) {

--- a/backend/src/main/java/io/opaa/group/PermissionSubject.java
+++ b/backend/src/main/java/io/opaa/group/PermissionSubject.java
@@ -1,0 +1,26 @@
+package io.opaa.group;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A permission entry references a user or a group, never both. This is the shared abstraction that
+ * a future grant (asset permissions, #202) will point at; this issue introduces the abstraction and
+ * its group-membership resolution ({@link GroupMembershipResolver}) ahead of the first grant,
+ * because retrofitting a subject type later would touch every grant, query and cache.
+ */
+public record PermissionSubject(PermissionSubjectType type, UUID id) {
+
+  public PermissionSubject {
+    Objects.requireNonNull(type, "type must not be null");
+    Objects.requireNonNull(id, "id must not be null");
+  }
+
+  public static PermissionSubject user(UUID userId) {
+    return new PermissionSubject(PermissionSubjectType.USER, userId);
+  }
+
+  public static PermissionSubject group(UUID groupId) {
+    return new PermissionSubject(PermissionSubjectType.GROUP, groupId);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/PermissionSubject.java
+++ b/backend/src/main/java/io/opaa/group/PermissionSubject.java
@@ -8,19 +8,25 @@ import java.util.UUID;
  * a future grant (asset permissions, #202) will point at; this issue introduces the abstraction and
  * its group-membership resolution ({@link GroupMembershipResolver}) ahead of the first grant,
  * because retrofitting a subject type later would touch every grant, query and cache.
+ *
+ * <p>Carries {@code organizationId} so that {@link GroupMembershipResolver#resolveUserIds} can
+ * enforce the organization boundary itself, at the one place every future caller goes through,
+ * instead of leaving each caller in #202 to rebuild that check independently - the same class of
+ * bug the boundary work in #199 exists to prevent.
  */
-public record PermissionSubject(PermissionSubjectType type, UUID id) {
+public record PermissionSubject(PermissionSubjectType type, UUID id, UUID organizationId) {
 
   public PermissionSubject {
     Objects.requireNonNull(type, "type must not be null");
     Objects.requireNonNull(id, "id must not be null");
+    Objects.requireNonNull(organizationId, "organizationId must not be null");
   }
 
-  public static PermissionSubject user(UUID userId) {
-    return new PermissionSubject(PermissionSubjectType.USER, userId);
+  public static PermissionSubject user(UUID userId, UUID organizationId) {
+    return new PermissionSubject(PermissionSubjectType.USER, userId, organizationId);
   }
 
-  public static PermissionSubject group(UUID groupId) {
-    return new PermissionSubject(PermissionSubjectType.GROUP, groupId);
+  public static PermissionSubject group(UUID groupId, UUID organizationId) {
+    return new PermissionSubject(PermissionSubjectType.GROUP, groupId, organizationId);
   }
 }

--- a/backend/src/main/java/io/opaa/group/PermissionSubjectType.java
+++ b/backend/src/main/java/io/opaa/group/PermissionSubjectType.java
@@ -1,0 +1,7 @@
+package io.opaa.group;
+
+/** Who a permission entry can refer to. See {@link PermissionSubject}. */
+public enum PermissionSubjectType {
+  USER,
+  GROUP
+}

--- a/backend/src/main/resources/db/changelog/changes/009-create-groups.yaml
+++ b/backend/src/main/resources/db/changelog/changes/009-create-groups.yaml
@@ -1,0 +1,178 @@
+databaseChangeLog:
+  # Rollback order (reverse of apply order):
+  # 009-create-group-memberships
+  # 009-create-groups
+  #
+  # Every changeSet below is a single Postgres transaction (Liquibase's default for DDL on
+  # Postgres). Introduces groups as permission subjects ahead of the first grant (#202) - see
+  # ADR-0008 and docs/features/spaces-and-assets.md#gruppen-als-rechtesubjekt.
+
+  - changeSet:
+      id: 009-create-groups
+      author: opaa
+      comment: "Create groups table - permission subject scoped to exactly one organization"
+      changes:
+        - createTable:
+            tableName: groups
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: kind
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: varchar(2000)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: external_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: parent_group_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: groups
+            baseColumnNames: organization_id
+            referencedTableName: organizations
+            referencedColumnNames: id
+            constraintName: fk_groups_organization
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            baseTableName: groups
+            baseColumnNames: parent_group_id
+            referencedTableName: groups
+            referencedColumnNames: id
+            constraintName: fk_groups_parent_group
+            onDelete: SET NULL
+        - sql:
+            comment: "Add check constraint for group kind values"
+            sql: >
+              ALTER TABLE groups
+              ADD CONSTRAINT chk_groups_kind
+              CHECK (kind IN ('ORG_UNIT', 'AD_HOC'));
+        - addUniqueConstraint:
+            tableName: groups
+            columnNames: id, organization_id
+            constraintName: uk_groups_id_organization
+        - addUniqueConstraint:
+            tableName: groups
+            columnNames: organization_id, external_id
+            constraintName: uk_groups_organization_external_id
+      rollback:
+        - dropUniqueConstraint:
+            tableName: groups
+            constraintName: uk_groups_organization_external_id
+        - dropUniqueConstraint:
+            tableName: groups
+            constraintName: uk_groups_id_organization
+        - sql:
+            sql: >
+              ALTER TABLE groups
+              DROP CONSTRAINT IF EXISTS chk_groups_kind;
+        - dropForeignKeyConstraint:
+            baseTableName: groups
+            constraintName: fk_groups_parent_group
+        - dropForeignKeyConstraint:
+            baseTableName: groups
+            constraintName: fk_groups_organization
+        - dropTable:
+            tableName: groups
+
+  - changeSet:
+      id: 009-create-group-memberships
+      author: opaa
+      comment: "Create group_memberships table for group membership"
+      changes:
+        - createTable:
+            tableName: group_memberships
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: group_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: group_memberships
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_group_memberships_user
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: group_memberships
+            baseColumnNames: group_id, organization_id
+            referencedTableName: groups
+            referencedColumnNames: id, organization_id
+            constraintName: fk_group_memberships_group_organization
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: group_memberships
+            columnNames: user_id, group_id
+            constraintName: uk_group_memberships_user_group
+      rollback:
+        - dropUniqueConstraint:
+            tableName: group_memberships
+            constraintName: uk_group_memberships_user_group
+        - dropForeignKeyConstraint:
+            baseTableName: group_memberships
+            constraintName: fk_group_memberships_group_organization
+        - dropForeignKeyConstraint:
+            baseTableName: group_memberships
+            constraintName: fk_group_memberships_user
+        - dropTable:
+            tableName: group_memberships

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,4 +16,6 @@ databaseChangeLog:
   - include:
       file: db/changelog/changes/008-rename-workspace-to-space.yaml
   - include:
+      file: db/changelog/changes/009-create-groups.yaml
+  - include:
       file: db/changelog/changes/010-space-uniqueness-and-membership-index.yaml

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -188,6 +188,193 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/admin/groups:
+    get:
+      operationId: listGroups
+      tags: [admin]
+      summary: List groups in the caller's organization (system admin only)
+      responses:
+        "200":
+          description: List of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GroupListResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+    post:
+      operationId: createGroup
+      tags: [admin]
+      summary: Create an ad-hoc group (system admin only)
+      description: >
+        Always creates a group of kind AD_HOC. Groups of kind ORG_UNIT are created only by
+        directory synchronisation (see #237) and cannot be created through this endpoint.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupRequest"
+      responses:
+        "201":
+          description: Group created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/admin/groups/{groupId}:
+    parameters:
+      - name: groupId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: getGroup
+      tags: [admin]
+      summary: Get group details (system admin only)
+      responses:
+        "200":
+          description: Group details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateGroup
+      tags: [admin]
+      summary: Rename an ad-hoc group or change its description (system admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupUpdateRequest"
+      responses:
+        "200":
+          description: Group updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteGroup
+      tags: [admin]
+      summary: Delete an ad-hoc group (system admin only)
+      responses:
+        "204":
+          description: Group deleted
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/admin/groups/{groupId}/members:
+    parameters:
+      - name: groupId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: listGroupMembers
+      tags: [admin]
+      summary: List group members (system admin only)
+      responses:
+        "200":
+          description: List of members
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GroupMemberResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    post:
+      operationId: addGroupMember
+      tags: [admin]
+      summary: Add a member to an ad-hoc group (system admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupAddMemberRequest"
+      responses:
+        "201":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupMemberResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /api/v1/admin/groups/{groupId}/members/{userId}:
+    parameters:
+      - name: groupId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    delete:
+      operationId: removeGroupMember
+      tags: [admin]
+      summary: Remove a member from an ad-hoc group (system admin only)
+      responses:
+        "204":
+          description: Member removed
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/v1/spaces:
     get:
       operationId: listSpaces
@@ -844,6 +1031,139 @@ components:
           $ref: "#/components/schemas/SpaceRole"
 
     SpaceTransferOwnershipRequest:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+
+    GroupKind:
+      type: string
+      description: >
+        ORG_UNIT groups are synchronised from the directory (see #237), carry a parent unit and
+        can have curators. AD_HOC groups are created in the system, have no curator and no
+        distribution level of their own.
+      enum: [ORG_UNIT, AD_HOC]
+      example: AD_HOC
+
+    GroupRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: Projektbeteiligte Phoenix
+        description:
+          type: string
+          maxLength: 2000
+          nullable: true
+          example: Ad-hoc-Gruppe fuer das Projekt Phoenix
+
+    GroupUpdateRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: Projektbeteiligte Phoenix
+        description:
+          type: string
+          maxLength: 2000
+          nullable: true
+          example: Ad-hoc-Gruppe fuer das Projekt Phoenix
+
+    GroupMemberResponse:
+      type: object
+      required: [userId, createdAt]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+
+    GroupListResponse:
+      type: object
+      required: [id, name, kind, memberCount, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Projektbeteiligte Phoenix
+        description:
+          type: string
+          nullable: true
+        kind:
+          $ref: "#/components/schemas/GroupKind"
+        externalId:
+          type: string
+          nullable: true
+          description: Stable directory identifier (objectGUID or SCIM externalId); null for AD_HOC groups
+        parentGroupId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Parent organizational unit; only set for ORG_UNIT groups
+        memberCount:
+          type: integer
+          example: 4
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    GroupResponse:
+      type: object
+      required: [id, name, kind, memberCount, members, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Projektbeteiligte Phoenix
+        description:
+          type: string
+          nullable: true
+        kind:
+          $ref: "#/components/schemas/GroupKind"
+        externalId:
+          type: string
+          nullable: true
+          description: Stable directory identifier (objectGUID or SCIM externalId); null for AD_HOC groups
+        parentGroupId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Parent organizational unit; only set for ORG_UNIT groups
+        memberCount:
+          type: integer
+          example: 4
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/GroupMemberResponse"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    GroupAddMemberRequest:
       type: object
       required: [userId]
       properties:

--- a/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
@@ -74,22 +74,40 @@ class GroupMembershipResolverTest {
   @Test
   void resolveUserIdsForAUserSubjectReturnsExactlyThatUserWithoutQueryingTheRepository() {
     UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
 
-    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.user(userId));
+    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.user(userId, organizationId));
 
     assertThat(resolved).containsExactly(userId);
   }
 
   @Test
-  void resolveUserIdsForAGroupSubjectReturnsItsMembers() {
+  void resolveUserIdsForAGroupSubjectReturnsItsMembersScopedToTheOrganization() {
     UUID groupId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
     UUID memberOne = UUID.randomUUID();
     UUID memberTwo = UUID.randomUUID();
-    when(membershipRepository.findUserIdsByGroupId(groupId))
+    when(membershipRepository.findUserIdsByGroupIdAndOrganizationId(groupId, organizationId))
         .thenReturn(Set.of(memberOne, memberTwo));
 
-    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.group(groupId));
+    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.group(groupId, organizationId));
 
     assertThat(resolved).containsExactlyInAnyOrder(memberOne, memberTwo);
+  }
+
+  @Test
+  void resolveUserIdsForAGroupSubjectFromAnotherOrganizationResolvesToNobody() {
+    UUID groupId = UUID.randomUUID();
+    UUID otherOrganizationId = UUID.randomUUID();
+    // The repository itself filters by organization; returning an empty set for the wrong
+    // organizationId here simulates that and shows resolveUserIds passes the subject's
+    // organizationId through rather than trusting the group id alone.
+    when(membershipRepository.findUserIdsByGroupIdAndOrganizationId(groupId, otherOrganizationId))
+        .thenReturn(Set.of());
+
+    Set<UUID> resolved =
+        resolver.resolveUserIds(PermissionSubject.group(groupId, otherOrganizationId));
+
+    assertThat(resolved).isEmpty();
   }
 }

--- a/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
@@ -1,0 +1,95 @@
+package io.opaa.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupMembershipResolverTest {
+
+  @Mock private GroupMembershipRepository membershipRepository;
+
+  private GroupMembershipResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new GroupMembershipResolver(membershipRepository);
+  }
+
+  @Test
+  void groupIdsForUserIsCachedAcrossRepeatedCalls() {
+    UUID user = UUID.randomUUID();
+    UUID group = UUID.randomUUID();
+    when(membershipRepository.findGroupIdsByUserId(user)).thenReturn(Set.of(group));
+
+    Set<UUID> first = resolver.groupIdsForUser(user);
+    Set<UUID> second = resolver.groupIdsForUser(user);
+
+    assertThat(first).containsExactly(group);
+    assertThat(second).containsExactly(group);
+    verify(membershipRepository, times(1)).findGroupIdsByUserId(user);
+  }
+
+  @Test
+  void invalidateUserForcesTheNextCallToHitTheRepositoryAgain() {
+    UUID user = UUID.randomUUID();
+    UUID group = UUID.randomUUID();
+    when(membershipRepository.findGroupIdsByUserId(user)).thenReturn(Set.of(group), Set.of());
+
+    Set<UUID> before = resolver.groupIdsForUser(user);
+    resolver.invalidateUser(user);
+    Set<UUID> after = resolver.groupIdsForUser(user);
+
+    assertThat(before).containsExactly(group);
+    assertThat(after).isEmpty();
+    verify(membershipRepository, times(2)).findGroupIdsByUserId(user);
+  }
+
+  @Test
+  void invalidateUsersEvictsMultipleUsersAtOnce() {
+    UUID userOne = UUID.randomUUID();
+    UUID userTwo = UUID.randomUUID();
+    when(membershipRepository.findGroupIdsByUserId(userOne)).thenReturn(Set.of());
+    when(membershipRepository.findGroupIdsByUserId(userTwo)).thenReturn(Set.of());
+    resolver.groupIdsForUser(userOne);
+    resolver.groupIdsForUser(userTwo);
+
+    resolver.invalidateUsers(Set.of(userOne, userTwo));
+    resolver.groupIdsForUser(userOne);
+    resolver.groupIdsForUser(userTwo);
+
+    verify(membershipRepository, times(2)).findGroupIdsByUserId(userOne);
+    verify(membershipRepository, times(2)).findGroupIdsByUserId(userTwo);
+  }
+
+  @Test
+  void resolveUserIdsForAUserSubjectReturnsExactlyThatUserWithoutQueryingTheRepository() {
+    UUID userId = UUID.randomUUID();
+
+    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.user(userId));
+
+    assertThat(resolved).containsExactly(userId);
+  }
+
+  @Test
+  void resolveUserIdsForAGroupSubjectReturnsItsMembers() {
+    UUID groupId = UUID.randomUUID();
+    UUID memberOne = UUID.randomUUID();
+    UUID memberTwo = UUID.randomUUID();
+    when(membershipRepository.findUserIdsByGroupId(groupId))
+        .thenReturn(Set.of(memberOne, memberTwo));
+
+    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.group(groupId));
+
+    assertThat(resolved).containsExactlyInAnyOrder(memberOne, memberTwo);
+  }
+}

--- a/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupMembershipResolverTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,12 +20,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class GroupMembershipResolverTest {
 
   @Mock private GroupMembershipRepository membershipRepository;
+  @Mock private UserRepository userRepository;
 
   private GroupMembershipResolver resolver;
 
   @BeforeEach
   void setUp() {
-    resolver = new GroupMembershipResolver(membershipRepository);
+    resolver = new GroupMembershipResolver(membershipRepository, userRepository);
   }
 
   @Test
@@ -72,13 +76,45 @@ class GroupMembershipResolverTest {
   }
 
   @Test
-  void resolveUserIdsForAUserSubjectReturnsExactlyThatUserWithoutQueryingTheRepository() {
+  void resolveUserIdsForAUserSubjectInTheSameOrganizationReturnsExactlyThatUser() {
     UUID userId = UUID.randomUUID();
     UUID organizationId = UUID.randomUUID();
+    User user = new User("sub", "issuer", "u@example.com", "User");
+    user.setOrganizationId(organizationId);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
     Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.user(userId, organizationId));
 
     assertThat(resolved).containsExactly(userId);
+  }
+
+  @Test
+  void resolveUserIdsForAUserSubjectFromAnotherOrganizationResolvesToNobody() {
+    UUID userId = UUID.randomUUID();
+    UUID actualOrganizationId = UUID.randomUUID();
+    UUID claimedOrganizationId = UUID.randomUUID();
+    User user = new User("sub", "issuer", "u@example.com", "User");
+    user.setOrganizationId(actualOrganizationId);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+    // A subject that names this user but the wrong organization must not resolve to them -
+    // otherwise the USER branch would be the unguarded exception to the boundary the GROUP
+    // branch enforces.
+    Set<UUID> resolved =
+        resolver.resolveUserIds(PermissionSubject.user(userId, claimedOrganizationId));
+
+    assertThat(resolved).isEmpty();
+  }
+
+  @Test
+  void resolveUserIdsForANonExistentUserSubjectResolvesToNobody() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+    Set<UUID> resolved = resolver.resolveUserIds(PermissionSubject.user(userId, organizationId));
+
+    assertThat(resolved).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
@@ -11,6 +11,8 @@ import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +22,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -62,6 +66,7 @@ class GroupServiceIntegrationTest {
   @Autowired private GroupMembershipRepository membershipRepository;
   @Autowired private GroupMembershipResolver membershipResolver;
   @Autowired private UserRepository userRepository;
+  @Autowired private PlatformTransactionManager transactionManager;
 
   private UUID organizationA;
   private UUID organizationB;
@@ -259,6 +264,63 @@ class GroupServiceIntegrationTest {
 
     groupService.deleteGroup(saved.getId(), admin);
 
+    assertThat(membershipResolver.groupIdsForUser(member)).isEmpty();
+  }
+
+  /**
+   * Reproduces the race the review of PR #283 raised: {@code removeMember} runs inside an open,
+   * not-yet-committed transaction; a concurrent reader on a separate connection reads the
+   * membership in that window. Under {@code READ COMMITTED}, that reader cannot see the deletion
+   * until the transaction commits, so it (correctly, given the timing) repopulates the cache with
+   * the still-current, soon-to-be-stale membership. What matters is what happens to that entry
+   * afterwards.
+   *
+   * <p>With invalidation deferred to {@code afterCompletion} (the fix), the entry the reader wrote
+   * is evicted right after the transaction commits, so the assertion below passes. With inline
+   * invalidation - called before the reader ever ran, so it has nothing left to evict - that stale
+   * entry survives with no further trigger to clear it, and the assertion fails. Confirmed manually
+   * by reverting {@code GroupService} to call {@code membershipResolver.invalidateUser} directly
+   * instead of through {@code invalidateAfterCommit}: this test fails against that version and
+   * passes against the current one.
+   */
+  @Test
+  void removingAMemberDoesNotLeaveAStaleCacheEntryFromAReaderDuringTheOpenTransaction()
+      throws InterruptedException {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    group.addMembership(new GroupMembership(member, organizationA));
+    Group saved = groupRepository.save(group);
+    // Start from a known, uncached state right before the race.
+    membershipResolver.invalidateUser(member);
+
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    CountDownLatch readerDone = new CountDownLatch(1);
+
+    transactionTemplate.execute(
+        status -> {
+          // removeMember's own @Transactional(REQUIRED) joins this already-open transaction
+          // rather than starting and committing a second one, so the deletion below is not yet
+          // committed when the reader thread runs.
+          groupService.removeMember(saved.getId(), member, admin);
+
+          Thread reader =
+              new Thread(
+                  () -> {
+                    membershipResolver.groupIdsForUser(member);
+                    readerDone.countDown();
+                  });
+          reader.start();
+          try {
+            assertThat(readerDone.await(5, TimeUnit.SECONDS)).isTrue();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+          }
+          return null;
+        });
+    // The transaction has now committed, and with it, invalidateAfterCommit's afterCompletion
+    // synchronization has run.
     assertThat(membershipResolver.groupIdsForUser(member)).isEmpty();
   }
 }

--- a/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
@@ -1,0 +1,251 @@
+package io.opaa.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opaa.api.dto.GroupListResponse;
+import io.opaa.api.dto.GroupRequest;
+import io.opaa.api.dto.GroupResponse;
+import io.opaa.api.dto.GroupUpdateRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.server.ResponseStatusException;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@DataJpaTest
+@Import({GroupService.class, GroupMembershipResolver.class})
+@Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(
+    properties = {"spring.liquibase.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+class GroupServiceIntegrationTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  @DynamicPropertySource
+  static void configureDataSource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+  }
+
+  @Autowired private GroupService groupService;
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private GroupMembershipRepository membershipRepository;
+  @Autowired private GroupMembershipResolver membershipResolver;
+  @Autowired private UserRepository userRepository;
+
+  private UUID organizationA;
+  private UUID organizationB;
+
+  @BeforeEach
+  void cleanUp() {
+    membershipRepository.deleteAll();
+    groupRepository.deleteAll();
+    userRepository.deleteAll();
+    organizationA = UUID.randomUUID();
+    organizationB = UUID.randomUUID();
+  }
+
+  private UUID createUser(UUID organizationId) {
+    User user =
+        new User(UUID.randomUUID().toString(), "test-issuer", "user@example.com", "Test User");
+    user.setOrganizationId(organizationId);
+    return userRepository.save(user).getId();
+  }
+
+  @Test
+  void createsAnAdHocGroup() {
+    UUID admin = createUser(organizationA);
+    GroupRequest request = new GroupRequest("Projektbeteiligte Phoenix").description("Ad hoc");
+
+    GroupResponse created = groupService.createGroup(request, admin);
+
+    assertThat(created.getKind()).isEqualTo(GroupKind.AD_HOC);
+    assertThat(created.getName()).isEqualTo("Projektbeteiligte Phoenix");
+    assertThat(created.getMemberCount()).isEqualTo(0);
+  }
+
+  @Test
+  void renamesAGroup() {
+    UUID admin = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Old name", null, null, null);
+    Group saved = groupRepository.save(group);
+
+    GroupUpdateRequest request = new GroupUpdateRequest("New name").description("Updated");
+    GroupResponse updated = groupService.updateGroup(saved.getId(), request, admin);
+
+    assertThat(updated.getName()).isEqualTo("New name");
+    assertThat(updated.getDescription()).isEqualTo("Updated");
+  }
+
+  @Test
+  void cannotRenameAnOrgUnitGroup() {
+    UUID admin = createUser(organizationA);
+    Group group =
+        new Group(organizationA, GroupKind.ORG_UNIT, "Referat 50", null, "directory-guid", null);
+    Group saved = groupRepository.save(group);
+
+    GroupUpdateRequest request = new GroupUpdateRequest("Renamed");
+    assertThatThrownBy(() -> groupService.updateGroup(saved.getId(), request, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void deletesAGroupAndRemovesMemberships() {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    group.addMembership(new GroupMembership(member, organizationA));
+    Group saved = groupRepository.save(group);
+
+    groupService.deleteGroup(saved.getId(), admin);
+
+    assertThat(groupRepository.findById(saved.getId())).isEmpty();
+    assertThat(membershipRepository.findByGroupId(saved.getId())).isEmpty();
+  }
+
+  @Test
+  void cannotDeleteAnOrgUnitGroup() {
+    UUID admin = createUser(organizationA);
+    Group group =
+        new Group(organizationA, GroupKind.ORG_UNIT, "Referat 50", null, "directory-guid", null);
+    Group saved = groupRepository.save(group);
+
+    assertThatThrownBy(() -> groupService.deleteGroup(saved.getId(), admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+    assertThat(groupRepository.findById(saved.getId())).isPresent();
+  }
+
+  @Test
+  void addsAndRemovesAMember() {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+
+    groupService.addMember(saved.getId(), member, admin);
+    Group afterAdd = groupRepository.findByIdWithMemberships(saved.getId()).orElseThrow();
+    assertThat(afterAdd.getMemberships()).hasSize(1);
+
+    groupService.removeMember(saved.getId(), member, admin);
+    Group afterRemove = groupRepository.findByIdWithMemberships(saved.getId()).orElseThrow();
+    assertThat(afterRemove.getMemberships()).isEmpty();
+  }
+
+  @Test
+  void addingTheSameMemberTwiceIsRejectedWithConflict() {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+    groupService.addMember(saved.getId(), member, admin);
+
+    assertThatThrownBy(() -> groupService.addMember(saved.getId(), member, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void addMemberRejectsAUserFromAnotherOrganization() {
+    UUID admin = createUser(organizationA);
+    UUID outsider = createUser(organizationB);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+
+    assertThatThrownBy(() -> groupService.addMember(saved.getId(), outsider, admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+    assertThat(membershipRepository.findByGroupId(saved.getId())).isEmpty();
+  }
+
+  @Test
+  void groupsNeverCrossAnOrganizationBoundaryEvenForTheAdminOfAnotherOrganization() {
+    UUID owner = createUser(organizationA);
+    UUID adminOfOtherOrganization = createUser(organizationB);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+
+    assertThatThrownBy(() -> groupService.getGroup(saved.getId(), adminOfOtherOrganization))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+
+    assertThat(owner).isNotNull();
+  }
+
+  @Test
+  void listGroupsReturnsOnlyGroupsOfTheCallersOrganization() {
+    UUID adminA = createUser(organizationA);
+    createUser(organizationB);
+    groupRepository.save(new Group(organizationA, GroupKind.AD_HOC, "Team A", null, null, null));
+    groupRepository.save(new Group(organizationB, GroupKind.AD_HOC, "Team B", null, null, null));
+
+    List<GroupListResponse> groups = groupService.listGroups(adminA);
+
+    assertThat(groups).extracting(GroupListResponse::getName).containsExactly("Team A");
+  }
+
+  @Test
+  void resolvingTheGroupsOfAUserIsCachedAndInvalidatedOnMembershipChange() {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+
+    assertThat(membershipResolver.groupIdsForUser(member)).isEmpty();
+
+    groupService.addMember(saved.getId(), member, admin);
+    // Without invalidation, this would still return the empty set cached above.
+    assertThat(membershipResolver.groupIdsForUser(member)).containsExactly(saved.getId());
+
+    groupService.removeMember(saved.getId(), member, admin);
+    // Without invalidation, this would still return the membership added above.
+    assertThat(membershipResolver.groupIdsForUser(member)).isEmpty();
+  }
+
+  @Test
+  void deletingAGroupInvalidatesTheCacheForItsFormerMembers() {
+    UUID admin = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    group.addMembership(new GroupMembership(member, organizationA));
+    Group saved = groupRepository.save(group);
+    assertThat(membershipResolver.groupIdsForUser(member)).containsExactly(saved.getId());
+
+    groupService.deleteGroup(saved.getId(), admin);
+
+    assertThat(membershipResolver.groupIdsForUser(member)).isEmpty();
+  }
+}

--- a/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
@@ -20,17 +20,30 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * {@code @Transactional(NOT_SUPPORTED)} disables the transaction Spring Test would otherwise wrap
+ * around each test method. Without it, every {@code GroupService} call below would join that single
+ * outer test transaction instead of committing on its own, and {@code
+ * GroupService#invalidateAfterCommit} would only fire once - when the outer transaction rolls back
+ * at the end of the test, not when each individual service call actually completes. That would
+ * silently defeat the very assertions this class makes about cache invalidation timing. Cleanup
+ * that a rolled-back transaction would otherwise have given us for free is done explicitly in
+ * {@link #cleanUp()} instead.
+ */
 @DataJpaTest
 @Import({GroupService.class, GroupMembershipResolver.class})
 @Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 class GroupServiceIntegrationTest {
 
   @Container

--- a/backend/src/test/java/io/opaa/migration/Migration009CreateGroupsTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration009CreateGroupsTest.java
@@ -1,0 +1,242 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 009 in isolation against a database built from the real, versioned
+ * changelog through changeSet 008 - the same pattern as {@link
+ * Migration008RenameWorkspaceToSpaceTest}, with a {@code test-master-through-008.yaml} fixture
+ * instead of 007.
+ *
+ * <p>Unlike 008, this changelog introduces new tables rather than migrating existing data, so there
+ * is nothing to seed beforehand. What still needs a real database is the composite foreign key
+ * {@code fk_group_memberships_group_organization}, which is the mechanism that keeps a group
+ * membership from ever crossing the organization boundary (see #200's acceptance criteria and
+ * {@code SpaceService#requireUserInOrganization} for the analogous application-level check on
+ * spaces). That constraint cannot be exercised by {@code GroupServiceIntegrationTest}, which runs
+ * with {@code spring.liquibase.enabled=false} and a Hibernate-generated schema that never executes
+ * this changeSet.
+ *
+ * <p>The container is shared across both test methods (declared {@code static}), so each test drops
+ * and recreates the {@code public} schema in {@link #tearDown()} - without that, the second test
+ * would run against a database that already has changelog 009 applied and Liquibase would skip it
+ * as already-run, silently passing even if the changeSet were broken.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration009CreateGroupsTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String ORGANIZATION_A = "00000000-0000-0000-0000-000000000001";
+  private static final String ORGANIZATION_B = "00000000-0000-0000-0000-000000000002";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    // Apply everything up to (and including) changeSet 008 - the schema exactly as it existed
+    // immediately before this migration - via the real, versioned changelog files.
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-008.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+
+    insertOrganization(ORGANIZATION_A);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    if (connection != null && !connection.isClosed()) {
+      // Reset for the next test method: this container is shared (static) across both tests in
+      // this class, and Liquibase would otherwise see changeSet 009 as already applied (recorded
+      // in DATABASECHANGELOG) and silently skip it on the second run.
+      // Liquibase's JdbcConnection disables autocommit, so a test that triggers a constraint
+      // violation (see rejectsAMembershipRowWhoseGroupBelongsToAnotherOrganization) leaves the
+      // connection's transaction aborted; rollback() is always safe to call, even with nothing
+      // pending, and clears that state before the DROP SCHEMA below.
+      connection.rollback();
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("DROP SCHEMA public CASCADE");
+        statement.execute("CREATE SCHEMA public");
+      }
+      connection.close();
+    }
+  }
+
+  @Test
+  void createsGroupsAndMembershipsScopedToOrganization() throws Exception {
+    applyChangelog009();
+
+    UUID userOne = UUID.randomUUID();
+    UUID userTwo = UUID.randomUUID();
+    insertUser(userOne, ORGANIZATION_A);
+    insertUser(userTwo, ORGANIZATION_A);
+
+    UUID adHocGroup = UUID.randomUUID();
+    insertGroup(adHocGroup, ORGANIZATION_A, "AD_HOC", "Projektbeteiligte Phoenix", null, null);
+    UUID orgUnitGroup = UUID.randomUUID();
+    insertGroup(orgUnitGroup, ORGANIZATION_A, "ORG_UNIT", "Referat 50", "directory-guid-1", null);
+
+    insertMembership(adHocGroup, userOne, ORGANIZATION_A);
+    insertMembership(adHocGroup, userTwo, ORGANIZATION_A);
+    insertMembership(orgUnitGroup, userOne, ORGANIZATION_A);
+
+    assertThat(countRows("groups")).isEqualTo(2);
+    assertThat(countRows("group_memberships")).isEqualTo(3);
+    assertThat(columnValue("groups", "kind", "id", adHocGroup)).isEqualTo("AD_HOC");
+    assertThat(columnValue("groups", "kind", "id", orgUnitGroup)).isEqualTo("ORG_UNIT");
+    assertThat(columnValue("groups", "external_id", "id", orgUnitGroup))
+        .isEqualTo("directory-guid-1");
+  }
+
+  @Test
+  void rejectsAMembershipRowWhoseGroupBelongsToAnotherOrganization() throws Exception {
+    applyChangelog009();
+    insertOrganization(ORGANIZATION_B);
+
+    UUID user = UUID.randomUUID();
+    insertUser(user, ORGANIZATION_A);
+    UUID groupInOrganizationA = UUID.randomUUID();
+    insertGroup(groupInOrganizationA, ORGANIZATION_A, "AD_HOC", "Team A", null, null);
+
+    // The composite foreign key fk_group_memberships_group_organization references
+    // groups(id, organization_id) - a membership row naming this group but organization B must
+    // violate it, because no such (id, organization_id) pair exists in groups.
+    assertThatThrownBy(() -> insertMembership(groupInOrganizationA, user, ORGANIZATION_B))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_group_memberships_group_organization");
+  }
+
+  private void applyChangelog009() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/009-create-groups.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+  }
+
+  private void insertOrganization(String id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO organizations (id, name, created_at) VALUES ('"
+              + id
+              + "', 'Org "
+              + id
+              + "', now()) ON CONFLICT (id) DO NOTHING");
+    }
+  }
+
+  private void insertUser(UUID id, String organizationId) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO users (id, subject, issuer, system_role, organization_id, created_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + id
+              + "', 'test-issuer', 'USER', '"
+              + organizationId
+              + "', now())");
+    }
+  }
+
+  private void insertGroup(
+      UUID id, String organizationId, String kind, String name, String externalId, UUID parentId)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO groups (id, organization_id, kind, name, external_id, parent_group_id,"
+              + " created_at, updated_at) VALUES ('"
+              + id
+              + "', '"
+              + organizationId
+              + "', '"
+              + kind
+              + "', '"
+              + name
+              + "', "
+              + (externalId == null ? "NULL" : "'" + externalId + "'")
+              + ", "
+              + (parentId == null ? "NULL" : "'" + parentId + "'")
+              + ", now(), now())");
+    }
+  }
+
+  private void insertMembership(UUID groupId, UUID userId, String organizationId)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO group_memberships (id, user_id, group_id, organization_id, created_at) "
+              + "VALUES ('"
+              + UUID.randomUUID()
+              + "', '"
+              + userId
+              + "', '"
+              + groupId
+              + "', '"
+              + organizationId
+              + "', now())");
+    }
+  }
+
+  private long countRows(String table) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT count(*) FROM " + table)) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private String columnValue(String table, String column, String whereColumn, UUID whereValue)
+      throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT "
+                    + column
+                    + " FROM "
+                    + table
+                    + " WHERE "
+                    + whereColumn
+                    + " = '"
+                    + whereValue
+                    + "'")) {
+      rs.next();
+      return rs.getString(1);
+    }
+  }
+}

--- a/backend/src/test/resources/db/changelog/test-master-through-008.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-008.yaml
@@ -1,10 +1,14 @@
 # Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
-# changeSet 008 - i.e. the schema exactly as it existed immediately before migration 010.
+# changeSet 008 - i.e. the schema exactly as it existed immediately before migrations 009 and 010,
+# both of which build on this same pre-migration state.
 #
-# Used by Migration010SpaceUniquenessTest to build a realistic pre-migration database (via the
-# real, versioned changelog files, not a hand-rolled schema) and then seed legacy data before
-# applying 010 in isolation. See test-master-through-007.yaml and
-# Migration008RenameWorkspaceToSpaceTest for the pattern this fixture follows.
+# Used by:
+# - Migration009CreateGroupsTest, to build a realistic pre-migration database (via the real,
+#   versioned changelog files, not a hand-rolled schema) and then apply 009 in isolation.
+# - Migration010SpaceUniquenessTest, to seed legacy data before applying 010 in isolation.
+#
+# See test-master-through-007.yaml and Migration008RenameWorkspaceToSpaceTest for the pattern
+# this fixture follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import LoginPage from './pages/LoginPage'
 import AuthCallbackPage from './pages/AuthCallbackPage'
 import SpacePage from './pages/SpacePage'
 import SpaceManagementPage from './pages/SpaceManagementPage'
+import GroupManagementPage from './pages/GroupManagementPage'
 import { useAuthStore } from './stores/authStore'
 import { useUiStore } from './stores/uiStore'
 
@@ -48,6 +49,7 @@ export default function App() {
               <Route path="spaces/:spaceId/manage" element={<SpaceManagementPage />} />
               <Route path="spaces" element={<SpacePage />} />
               <Route path="documents" element={<DocumentsPage />} />
+              <Route path="admin/groups" element={<GroupManagementPage />} />
               <Route path="settings" element={<SettingsPage />} />
               <Route path="*" element={<Navigate to="/chat" replace />} />
             </Route>

--- a/frontend/src/components/CreateGroupDialog.tsx
+++ b/frontend/src/components/CreateGroupDialog.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import Alert from '@mui/material/Alert'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import TextField from '@mui/material/TextField'
+import { useGroupStore } from '../stores/groupStore'
+
+interface CreateGroupDialogProps {
+  open: boolean
+  onClose: () => void
+  onCreated: () => void
+}
+
+export default function CreateGroupDialog({ open, onClose, onCreated }: CreateGroupDialogProps) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const createNewGroup = useGroupStore((s) => s.createNewGroup)
+
+  function handleClose() {
+    if (submitting) return
+    setName('')
+    setDescription('')
+    setError(null)
+    onClose()
+  }
+
+  async function handleCreate() {
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError('Name ist erforderlich')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      await createNewGroup(trimmedName, description.trim())
+      setName('')
+      setDescription('')
+      onCreated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Gruppe konnte nicht erstellt werden')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Gruppe erstellen</DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <TextField
+          autoFocus
+          label="Name"
+          fullWidth
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          slotProps={{ htmlInput: { maxLength: 255 } }}
+          sx={{ mt: 1 }}
+        />
+        <TextField
+          label="Beschreibung"
+          fullWidth
+          multiline
+          minRows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          slotProps={{ htmlInput: { maxLength: 2000 } }}
+          sx={{ mt: 2 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting}>
+          Abbrechen
+        </Button>
+        <Button onClick={handleCreate} variant="contained" disabled={submitting || !name.trim()}>
+          {submitting ? 'Wird erstellt …' : 'Erstellen'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -16,6 +16,7 @@ import ChatIcon from '@mui/icons-material/Chat'
 import DescriptionIcon from '@mui/icons-material/Description'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import GroupsIcon from '@mui/icons-material/Groups'
 import LogoutIcon from '@mui/icons-material/Logout'
 import PersonIcon from '@mui/icons-material/Person'
 import SettingsIcon from '@mui/icons-material/Settings'
@@ -208,6 +209,19 @@ export default function Sidebar() {
           </ListItemIcon>
           <ListItemText primary="Dokumente" />
         </ListItemButton>
+        {user?.systemRole === 'SYSTEM_ADMIN' && (
+          <ListItemButton
+            component={NavLink}
+            to="/admin/groups"
+            selected={location.pathname === '/admin/groups'}
+            sx={{ borderRadius: 2 }}
+          >
+            <ListItemIcon sx={{ minWidth: 36 }}>
+              <GroupsIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Gruppen" />
+          </ListItemButton>
+        )}
       </List>
 
       <Box sx={{ flexGrow: 1 }} />

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -5,6 +5,8 @@ import type {
   UserInfo,
   SpaceListResponse,
   SpaceResponse,
+  GroupListResponse,
+  GroupResponse,
 } from '../types/api'
 import type { AuthConfig, AuthUser, LoginResponse } from '../types/auth'
 
@@ -329,6 +331,75 @@ export const mockSpaceDetails: Record<string, SpaceResponse> = {
         userId: 'mock-user-id',
         displayName: 'Admin',
         role: 'CURATOR',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ],
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  },
+}
+
+export const mockGroups: GroupListResponse[] = [
+  {
+    id: 'group-phoenix',
+    name: 'Projektbeteiligte Phoenix',
+    description: 'Ad-hoc-Gruppe fuer das Projekt Phoenix',
+    kind: 'AD_HOC',
+    externalId: null,
+    parentGroupId: null,
+    memberCount: 2,
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  },
+  {
+    id: 'group-referat-50',
+    name: 'Referat 50',
+    description: 'Aus dem Verzeichnis synchronisiert',
+    kind: 'ORG_UNIT',
+    externalId: 'directory-guid-referat-50',
+    parentGroupId: null,
+    memberCount: 1,
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  },
+]
+
+export const mockGroupDetails: Record<string, GroupResponse> = {
+  'group-phoenix': {
+    id: 'group-phoenix',
+    name: 'Projektbeteiligte Phoenix',
+    description: 'Ad-hoc-Gruppe fuer das Projekt Phoenix',
+    kind: 'AD_HOC',
+    externalId: null,
+    parentGroupId: null,
+    memberCount: 2,
+    members: [
+      {
+        userId: 'mock-user-id',
+        displayName: 'Admin',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+      {
+        userId: 'owner-1',
+        displayName: 'Alice',
+        createdAt: '2026-03-01T10:00:00Z',
+      },
+    ],
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  },
+  'group-referat-50': {
+    id: 'group-referat-50',
+    name: 'Referat 50',
+    description: 'Aus dem Verzeichnis synchronisiert',
+    kind: 'ORG_UNIT',
+    externalId: 'directory-guid-referat-50',
+    parentGroupId: null,
+    memberCount: 1,
+    members: [
+      {
+        userId: 'curator-1',
+        displayName: 'Bob',
         createdAt: '2026-03-01T10:00:00Z',
       },
     ],

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -11,6 +11,8 @@ import {
   mockUsers,
   mockSpaces,
   mockSpaceDetails,
+  mockGroups,
+  mockGroupDetails,
 } from './fixtures'
 import type { IndexingStatusResponse, QueryRequest } from '../types/api'
 import type { LoginRequest } from '../types/auth'
@@ -259,6 +261,105 @@ export const handlers = [
 
   http.get('/api/v1/admin/users', () => {
     return HttpResponse.json(mockUsers)
+  }),
+
+  http.get('/api/v1/admin/groups', () => {
+    return HttpResponse.json(mockGroups)
+  }),
+
+  http.post('/api/v1/admin/groups', async ({ request }) => {
+    const body = (await request.json()) as { name: string; description?: string }
+    if (!body.name || body.name.trim() === '') {
+      return HttpResponse.json({ error: 'Der Name der Gruppe ist erforderlich' }, { status: 400 })
+    }
+    const id = `group-${crypto.randomUUID().slice(0, 8)}`
+    const now = new Date().toISOString()
+    const listEntry: (typeof mockGroups)[number] = {
+      id,
+      name: body.name.trim(),
+      description: body.description?.trim() ?? null,
+      kind: 'AD_HOC',
+      externalId: null,
+      parentGroupId: null,
+      memberCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    }
+    mockGroups.push(listEntry)
+    mockGroupDetails[id] = { ...listEntry, members: [] }
+    return HttpResponse.json(mockGroupDetails[id], { status: 201 })
+  }),
+
+  http.get('/api/v1/admin/groups/:groupId', ({ params }) => {
+    const groupId = String(params.groupId)
+    const group = mockGroupDetails[groupId]
+    if (!group) {
+      return HttpResponse.json({ error: 'Gruppe nicht gefunden' }, { status: 404 })
+    }
+    return HttpResponse.json(group)
+  }),
+
+  http.put('/api/v1/admin/groups/:groupId', async ({ params, request }) => {
+    const groupId = String(params.groupId)
+    const group = mockGroupDetails[groupId]
+    const listEntry = mockGroups.find((item) => item.id === groupId)
+    if (!group || !listEntry) {
+      return HttpResponse.json({ error: 'Gruppe nicht gefunden' }, { status: 404 })
+    }
+    const body = (await request.json()) as { name: string; description?: string }
+    group.name = body.name
+    group.description = body.description ?? null
+    listEntry.name = body.name
+    listEntry.description = body.description ?? null
+    return HttpResponse.json(group)
+  }),
+
+  http.delete('/api/v1/admin/groups/:groupId', ({ params }) => {
+    const groupId = String(params.groupId)
+    delete mockGroupDetails[groupId]
+    const idx = mockGroups.findIndex((item) => item.id === groupId)
+    if (idx >= 0) {
+      mockGroups.splice(idx, 1)
+    }
+    return new HttpResponse(null, { status: 204 })
+  }),
+
+  http.post('/api/v1/admin/groups/:groupId/members', async ({ params, request }) => {
+    const groupId = String(params.groupId)
+    const group = mockGroupDetails[groupId]
+    const listEntry = mockGroups.find((item) => item.id === groupId)
+    if (!group || !listEntry) {
+      return HttpResponse.json({ error: 'Gruppe nicht gefunden' }, { status: 404 })
+    }
+    const body = (await request.json()) as { userId: string }
+    if (!body.userId) {
+      return HttpResponse.json({ error: 'userId is required' }, { status: 400 })
+    }
+    if (group.members.some((member) => member.userId === body.userId)) {
+      return HttpResponse.json(
+        { error: 'Der Benutzer ist bereits Mitglied dieser Gruppe' },
+        { status: 409 },
+      )
+    }
+    const member = { userId: body.userId, createdAt: new Date().toISOString() }
+    group.members.push(member)
+    group.memberCount = group.members.length
+    listEntry.memberCount = group.members.length
+    return HttpResponse.json(member, { status: 201 })
+  }),
+
+  http.delete('/api/v1/admin/groups/:groupId/members/:userId', ({ params }) => {
+    const groupId = String(params.groupId)
+    const userId = String(params.userId)
+    const group = mockGroupDetails[groupId]
+    const listEntry = mockGroups.find((item) => item.id === groupId)
+    if (!group || !listEntry) {
+      return HttpResponse.json({ error: 'Gruppe nicht gefunden' }, { status: 404 })
+    }
+    group.members = group.members.filter((member) => member.userId !== userId)
+    group.memberCount = group.members.length
+    listEntry.memberCount = group.members.length
+    return new HttpResponse(null, { status: 204 })
   }),
 
   http.get('/api/v1/auth/config', () => {

--- a/frontend/src/pages/GroupManagementPage.test.tsx
+++ b/frontend/src/pages/GroupManagementPage.test.tsx
@@ -1,0 +1,151 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '../test/test-utils'
+import GroupManagementPage from './GroupManagementPage'
+import { useGroupStore } from '../stores/groupStore'
+import type { GroupListResponse, GroupResponse } from '../types/api'
+
+const {
+  mockCreateGroup,
+  mockUpdateGroup,
+  mockDeleteGroup,
+  mockAddGroupMember,
+  mockRemoveGroupMember,
+} = vi.hoisted(() => ({
+  mockCreateGroup: vi.fn(async () => ({}) as GroupResponse),
+  mockUpdateGroup: vi.fn(async () => ({}) as GroupResponse),
+  mockDeleteGroup: vi.fn(async () => undefined),
+  mockAddGroupMember: vi.fn(async () => ({})),
+  mockRemoveGroupMember: vi.fn(async () => undefined),
+}))
+
+vi.mock('../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../services/api')>('../services/api')
+  return {
+    ...actual,
+    getUsers: vi.fn(async () => []),
+    getGroups: vi.fn(async () => useGroupStore.getState().groups),
+    getGroup: vi.fn(async (groupId: string) => useGroupStore.getState().groupDetails[groupId]),
+    createGroup: mockCreateGroup,
+    updateGroup: mockUpdateGroup,
+    deleteGroup: mockDeleteGroup,
+    addGroupMember: mockAddGroupMember,
+    removeGroupMember: mockRemoveGroupMember,
+  }
+})
+
+const adHocGroup: GroupListResponse = {
+  id: 'group-phoenix',
+  name: 'Projektbeteiligte Phoenix',
+  description: 'Ad hoc',
+  kind: 'AD_HOC',
+  externalId: null,
+  parentGroupId: null,
+  memberCount: 1,
+  createdAt: '2026-03-01T10:00:00Z',
+  updatedAt: '2026-03-01T10:00:00Z',
+}
+
+const orgUnitGroup: GroupListResponse = {
+  id: 'group-referat-50',
+  name: 'Referat 50',
+  description: 'Directory-synced',
+  kind: 'ORG_UNIT',
+  externalId: 'directory-guid',
+  parentGroupId: null,
+  memberCount: 1,
+  createdAt: '2026-03-01T10:00:00Z',
+  updatedAt: '2026-03-01T10:00:00Z',
+}
+
+const adHocDetails: GroupResponse = {
+  ...adHocGroup,
+  members: [{ userId: 'u1', displayName: 'Alice', createdAt: '2026-03-01T10:00:00Z' }],
+}
+
+const orgUnitDetails: GroupResponse = {
+  ...orgUnitGroup,
+  members: [{ userId: 'u2', displayName: 'Bob', createdAt: '2026-03-01T10:00:00Z' }],
+}
+
+function setGroupState(groups: GroupListResponse[], details: Record<string, GroupResponse>) {
+  useGroupStore.setState({
+    groups,
+    groupDetails: details,
+    isLoading: false,
+    error: null,
+  })
+}
+
+describe('GroupManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists groups with their kind', async () => {
+    setGroupState([adHocGroup, orgUnitGroup], {})
+    renderWithProviders(<GroupManagementPage />)
+
+    expect(await screen.findByText('Projektbeteiligte Phoenix')).toBeInTheDocument()
+    expect(screen.getByText('Referat 50')).toBeInTheDocument()
+    expect(screen.getByText('Ad-hoc-Gruppe')).toBeInTheDocument()
+    expect(screen.getByText('Organisationseinheit')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no groups', async () => {
+    setGroupState([], {})
+    renderWithProviders(<GroupManagementPage />)
+
+    expect(await screen.findByText(/noch keine gruppen/i)).toBeInTheDocument()
+  })
+
+  it('expands an ad-hoc group and allows renaming and deleting', async () => {
+    setGroupState([adHocGroup], { 'group-phoenix': adHocDetails })
+    renderWithProviders(<GroupManagementPage />)
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('Projektbeteiligte Phoenix'))
+
+    expect(await screen.findByText('Alice')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /speichern/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /gruppe löschen/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /speichern/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateGroup).toHaveBeenCalledWith(
+        'group-phoenix',
+        'Projektbeteiligte Phoenix',
+        'Ad hoc',
+      )
+    })
+  })
+
+  it('disables editing and member management for an org-unit group', async () => {
+    setGroupState([orgUnitGroup], { 'group-referat-50': orgUnitDetails })
+    renderWithProviders(<GroupManagementPage />)
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('Referat 50'))
+
+    expect(await screen.findByText('Bob')).toBeInTheDocument()
+    expect(screen.getByText(/aus dem verzeichnis synchronisiert/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /gruppe löschen/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^entfernen$/i })).not.toBeInTheDocument()
+  })
+
+  it('creates a new group through the dialog', async () => {
+    setGroupState([], {})
+    renderWithProviders(<GroupManagementPage />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: /neue gruppe/i }))
+    await user.type(screen.getByLabelText(/^name/i), 'Neue Gruppe')
+    await user.click(screen.getByRole('button', { name: /^erstellen$/i }))
+
+    await waitFor(() => {
+      expect(mockCreateGroup).toHaveBeenCalledWith('Neue Gruppe', '')
+    })
+  })
+})

--- a/frontend/src/pages/GroupManagementPage.tsx
+++ b/frontend/src/pages/GroupManagementPage.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Alert from '@mui/material/Alert'
+import Autocomplete from '@mui/material/Autocomplete'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import type { GroupListResponse, UserInfo } from '../types/api'
+import { getUsers } from '../services/api'
+import { useGroupStore } from '../stores/groupStore'
+import { groupKindLabel } from '../utils/labels'
+import CreateGroupDialog from '../components/CreateGroupDialog'
+
+function GroupCard({ group }: { group: GroupListResponse }) {
+  const details = useGroupStore((s) => s.groupDetails[group.id])
+  const loadGroupDetails = useGroupStore((s) => s.loadGroupDetails)
+  const renameGroup = useGroupStore((s) => s.renameGroup)
+  const deleteExistingGroup = useGroupStore((s) => s.deleteExistingGroup)
+  const addMember = useGroupStore((s) => s.addMember)
+  const removeMember = useGroupStore((s) => s.removeMember)
+
+  const [expanded, setExpanded] = useState(false)
+  const [draft, setDraft] = useState<{ groupId: string | null; name: string; description: string }>(
+    { groupId: null, name: '', description: '' },
+  )
+  const [selectedUser, setSelectedUser] = useState<UserInfo | null>(null)
+  const [allUsers, setAllUsers] = useState<UserInfo[]>([])
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  const isAdHoc = group.kind === 'AD_HOC'
+  const name = draft.groupId === group.id ? draft.name : group.name
+  const description = draft.groupId === group.id ? draft.description : (group.description ?? '')
+
+  useEffect(() => {
+    if (expanded && !details) {
+      void loadGroupDetails(group.id)
+    }
+  }, [expanded, details, group.id, loadGroupDetails])
+
+  useEffect(() => {
+    if (expanded) {
+      void getUsers()
+        .then(setAllUsers)
+        .catch(() => setAllUsers([]))
+    }
+  }, [expanded])
+
+  const availableUsers = useMemo(() => {
+    const memberIds = new Set(details?.members.map((m) => m.userId) ?? [])
+    return allUsers.filter((u) => !memberIds.has(u.id))
+  }, [allUsers, details?.members])
+
+  return (
+    <Accordion
+      expanded={expanded}
+      onChange={(_event, isExpanded) => setExpanded(isExpanded)}
+      variant="outlined"
+      disableGutters
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexGrow: 1 }}>
+          <Typography sx={{ fontWeight: 600 }}>{group.name}</Typography>
+          <Chip label={groupKindLabel(group.kind)} size="small" variant="outlined" />
+          <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto', mr: 1 }}>
+            {group.memberCount} {group.memberCount === 1 ? 'Mitglied' : 'Mitglieder'}
+          </Typography>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        {localError && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setLocalError(null)}>
+            {localError}
+          </Alert>
+        )}
+        {!isAdHoc && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Organisationseinheiten werden aus dem Verzeichnis synchronisiert und können hier nicht
+            bearbeitet werden.
+          </Alert>
+        )}
+
+        <Stack spacing={1.5} sx={{ mb: 2 }}>
+          <TextField
+            label="Name der Gruppe"
+            value={name}
+            onChange={(e) => setDraft({ groupId: group.id, name: e.target.value, description })}
+            disabled={!isAdHoc}
+            size="small"
+          />
+          <TextField
+            label="Beschreibung"
+            value={description}
+            onChange={(e) => setDraft({ groupId: group.id, name, description: e.target.value })}
+            multiline
+            minRows={2}
+            disabled={!isAdHoc}
+            size="small"
+          />
+          {isAdHoc && (
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                size="small"
+                onClick={async () => {
+                  setLocalError(null)
+                  try {
+                    await renameGroup(group.id, name.trim(), description.trim())
+                  } catch (err) {
+                    setLocalError(
+                      err instanceof Error ? err.message : 'Aktualisierung fehlgeschlagen',
+                    )
+                  }
+                }}
+              >
+                Speichern
+              </Button>
+              <Button
+                color="error"
+                variant="outlined"
+                size="small"
+                onClick={async () => {
+                  if (
+                    !window.confirm(
+                      `Gruppe "${group.name}" löschen? Diese Aktion kann nicht rückgängig gemacht werden.`,
+                    )
+                  ) {
+                    return
+                  }
+                  setLocalError(null)
+                  try {
+                    await deleteExistingGroup(group.id)
+                  } catch (err) {
+                    setLocalError(err instanceof Error ? err.message : 'Löschen fehlgeschlagen')
+                  }
+                }}
+              >
+                Gruppe löschen
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+
+        <Divider sx={{ mb: 2 }} />
+
+        <Typography variant="subtitle2" gutterBottom>
+          Mitglieder
+        </Typography>
+        <Stack spacing={1}>
+          {(details?.members ?? []).map((member) => (
+            <Box
+              key={member.userId}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 1,
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={member.displayName ? undefined : { fontFamily: 'monospace' }}
+              >
+                {member.displayName ?? member.userId}
+              </Typography>
+              {isAdHoc && (
+                <Button
+                  color="error"
+                  size="small"
+                  onClick={async () => {
+                    setLocalError(null)
+                    try {
+                      await removeMember(group.id, member.userId)
+                    } catch (err) {
+                      setLocalError(
+                        err instanceof Error
+                          ? err.message
+                          : 'Entfernen des Mitglieds fehlgeschlagen',
+                      )
+                    }
+                  }}
+                >
+                  Entfernen
+                </Button>
+              )}
+            </Box>
+          ))}
+
+          {isAdHoc && (
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} sx={{ pt: 1 }}>
+              <Autocomplete
+                options={availableUsers}
+                getOptionLabel={(option) =>
+                  option.displayName
+                    ? `${option.displayName} (${option.email ?? option.id})`
+                    : (option.email ?? option.id)
+                }
+                value={selectedUser}
+                onChange={(_event, value) => setSelectedUser(value)}
+                renderInput={(params) => (
+                  <TextField {...params} label="Benutzer" placeholder="Benutzer suchen …" />
+                )}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                size="small"
+                sx={{ minWidth: 280 }}
+              />
+              <Button
+                variant="contained"
+                size="small"
+                disabled={!selectedUser}
+                onClick={async () => {
+                  if (!selectedUser) return
+                  setLocalError(null)
+                  try {
+                    await addMember(group.id, selectedUser.id)
+                    setSelectedUser(null)
+                  } catch (err) {
+                    setLocalError(
+                      err instanceof Error
+                        ? err.message
+                        : 'Mitglied konnte nicht hinzugefügt werden',
+                    )
+                  }
+                }}
+              >
+                Mitglied hinzufügen
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  )
+}
+
+export default function GroupManagementPage() {
+  const groups = useGroupStore((s) => s.groups)
+  const isLoading = useGroupStore((s) => s.isLoading)
+  const error = useGroupStore((s) => s.error)
+  const loadGroups = useGroupStore((s) => s.loadGroups)
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+
+  useEffect(() => {
+    void loadGroups()
+  }, [loadGroups])
+
+  return (
+    <Box sx={{ flexGrow: 1, p: { xs: 2, md: 3 }, overflowY: 'auto' }}>
+      <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h6">Gruppen</Typography>
+        <Button variant="contained" onClick={() => setCreateDialogOpen(true)}>
+          Neue Gruppe
+        </Button>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <Typography color="text.secondary">Gruppen werden geladen …</Typography>
+      ) : groups.length === 0 ? (
+        <Typography color="text.secondary">Es sind noch keine Gruppen vorhanden.</Typography>
+      ) : (
+        <Stack spacing={1}>
+          {groups.map((group) => (
+            <GroupCard key={group.id} group={group} />
+          ))}
+        </Stack>
+      )}
+
+      <CreateGroupDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onCreated={() => setCreateDialogOpen(false)}
+      />
+    </Box>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,8 @@
 import axios, { AxiosError } from 'axios'
 import type {
+  GroupListResponse,
+  GroupMemberResponse,
+  GroupResponse,
   HealthResponse,
   IndexingStatusResponse,
   IndexingTriggerRequest,
@@ -201,6 +204,79 @@ export async function getUsers(): Promise<UserInfo[]> {
   try {
     const { data } = await client.get<UserInfo[]>('/v1/admin/users')
     return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function getGroups(): Promise<GroupListResponse[]> {
+  try {
+    const { data } = await client.get<GroupListResponse[]>('/v1/admin/groups')
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function getGroup(groupId: string): Promise<GroupResponse> {
+  try {
+    const { data } = await client.get<GroupResponse>(`/v1/admin/groups/${groupId}`)
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function createGroup(name: string, description: string): Promise<GroupResponse> {
+  try {
+    const { data } = await client.post<GroupResponse>('/v1/admin/groups', { name, description })
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function updateGroup(
+  groupId: string,
+  name: string,
+  description: string,
+): Promise<GroupResponse> {
+  try {
+    const { data } = await client.put<GroupResponse>(`/v1/admin/groups/${groupId}`, {
+      name,
+      description,
+    })
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function deleteGroup(groupId: string): Promise<void> {
+  try {
+    await client.delete(`/v1/admin/groups/${groupId}`)
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function addGroupMember(
+  groupId: string,
+  userId: string,
+): Promise<GroupMemberResponse> {
+  try {
+    const { data } = await client.post<GroupMemberResponse>(`/v1/admin/groups/${groupId}/members`, {
+      userId,
+    })
+    return data
+  } catch (err) {
+    normalizeError(err)
+  }
+}
+
+export async function removeGroupMember(groupId: string, userId: string): Promise<void> {
+  try {
+    await client.delete(`/v1/admin/groups/${groupId}/members/${userId}`)
   } catch (err) {
     normalizeError(err)
   }

--- a/frontend/src/stores/groupStore.test.ts
+++ b/frontend/src/stores/groupStore.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { useGroupStore } from './groupStore'
+
+const mockCreateGroup = vi.fn()
+const mockAddGroupMember = vi.fn()
+const mockRemoveGroupMember = vi.fn()
+const mockDeleteGroup = vi.fn()
+const mockUpdateGroup = vi.fn()
+
+vi.mock('../services/api', () => ({
+  getGroups: vi.fn(async () => [
+    {
+      id: 'group-b',
+      name: 'Team B',
+      description: null,
+      kind: 'AD_HOC',
+      externalId: null,
+      parentGroupId: null,
+      memberCount: 1,
+      createdAt: '2026-03-01T10:00:00Z',
+      updatedAt: '2026-03-01T10:00:00Z',
+    },
+    {
+      id: 'group-a',
+      name: 'Team A',
+      description: null,
+      kind: 'AD_HOC',
+      externalId: null,
+      parentGroupId: null,
+      memberCount: 2,
+      createdAt: '2026-03-01T10:00:00Z',
+      updatedAt: '2026-03-01T10:00:00Z',
+    },
+  ]),
+  getGroup: vi.fn(async (groupId: string) => ({
+    id: groupId,
+    name: 'Team A',
+    description: null,
+    kind: 'AD_HOC',
+    externalId: null,
+    parentGroupId: null,
+    memberCount: 1,
+    members: [{ userId: 'u1', displayName: 'User 1', createdAt: '2026-03-01T10:00:00Z' }],
+    createdAt: '2026-03-01T10:00:00Z',
+    updatedAt: '2026-03-01T10:00:00Z',
+  })),
+  createGroup: (...args: unknown[]) => mockCreateGroup(...args),
+  updateGroup: (...args: unknown[]) => mockUpdateGroup(...args),
+  deleteGroup: (...args: unknown[]) => mockDeleteGroup(...args),
+  addGroupMember: (...args: unknown[]) => mockAddGroupMember(...args),
+  removeGroupMember: (...args: unknown[]) => mockRemoveGroupMember(...args),
+}))
+
+describe('groupStore', () => {
+  beforeEach(() => {
+    useGroupStore.setState({ groups: [], groupDetails: {}, isLoading: false, error: null })
+    mockCreateGroup.mockReset()
+    mockAddGroupMember.mockReset()
+    mockRemoveGroupMember.mockReset()
+    mockDeleteGroup.mockReset()
+    mockUpdateGroup.mockReset()
+  })
+
+  it('sorts groups alphabetically', async () => {
+    await useGroupStore.getState().loadGroups()
+    const names = useGroupStore.getState().groups.map((g) => g.name)
+    expect(names).toEqual(['Team A', 'Team B'])
+  })
+
+  it('creates a new group and reloads the list', async () => {
+    mockCreateGroup.mockResolvedValueOnce({})
+    await useGroupStore.getState().createNewGroup('Team C', 'desc')
+    expect(mockCreateGroup).toHaveBeenCalledWith('Team C', 'desc')
+    expect(useGroupStore.getState().groups.length).toBeGreaterThan(0)
+  })
+
+  it('loads group details on demand', async () => {
+    await useGroupStore.getState().loadGroupDetails('group-a')
+    expect(useGroupStore.getState().groupDetails['group-a'].members).toHaveLength(1)
+  })
+
+  it('adds a member and refreshes list and details', async () => {
+    mockAddGroupMember.mockResolvedValueOnce({})
+    await useGroupStore.getState().addMember('group-a', 'u2')
+    expect(mockAddGroupMember).toHaveBeenCalledWith('group-a', 'u2')
+    expect(useGroupStore.getState().groupDetails['group-a']).toBeDefined()
+  })
+
+  it('removes a member and refreshes list and details', async () => {
+    mockRemoveGroupMember.mockResolvedValueOnce(undefined)
+    await useGroupStore.getState().removeMember('group-a', 'u1')
+    expect(mockRemoveGroupMember).toHaveBeenCalledWith('group-a', 'u1')
+  })
+
+  it('deletes a group and clears its cached details', async () => {
+    useGroupStore.setState({
+      groupDetails: {
+        'group-a': {
+          id: 'group-a',
+          name: 'Team A',
+          kind: 'AD_HOC',
+          memberCount: 0,
+          members: [],
+          createdAt: '2026-03-01T10:00:00Z',
+          updatedAt: '2026-03-01T10:00:00Z',
+        },
+      },
+    })
+    mockDeleteGroup.mockResolvedValueOnce(undefined)
+
+    await useGroupStore.getState().deleteExistingGroup('group-a')
+
+    expect(mockDeleteGroup).toHaveBeenCalledWith('group-a')
+    expect(useGroupStore.getState().groupDetails['group-a']).toBeUndefined()
+  })
+
+  it('renames a group and refreshes list and details', async () => {
+    mockUpdateGroup.mockResolvedValueOnce({})
+    await useGroupStore.getState().renameGroup('group-a', 'Renamed', 'desc')
+    expect(mockUpdateGroup).toHaveBeenCalledWith('group-a', 'Renamed', 'desc')
+  })
+})

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand'
+import type { GroupListResponse, GroupResponse } from '../types/api'
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  getGroup,
+  getGroups,
+  removeGroupMember,
+  updateGroup,
+} from '../services/api'
+
+interface GroupState {
+  groups: GroupListResponse[]
+  groupDetails: Record<string, GroupResponse>
+  isLoading: boolean
+  error: string | null
+  reset: () => void
+  loadGroups: () => Promise<void>
+  loadGroupDetails: (groupId: string) => Promise<void>
+  createNewGroup: (name: string, description: string) => Promise<void>
+  renameGroup: (groupId: string, name: string, description: string) => Promise<void>
+  deleteExistingGroup: (groupId: string) => Promise<void>
+  addMember: (groupId: string, userId: string) => Promise<void>
+  removeMember: (groupId: string, userId: string) => Promise<void>
+}
+
+function sortGroups(list: GroupListResponse[]): GroupListResponse[] {
+  return [...list].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export const useGroupStore = create<GroupState>((set, get) => ({
+  groups: [],
+  groupDetails: {},
+  isLoading: false,
+  error: null,
+
+  reset: () => set({ groups: [], groupDetails: {}, isLoading: false, error: null }),
+
+  loadGroups: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const groups = sortGroups(await getGroups())
+      set({ groups, isLoading: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gruppen konnten nicht geladen werden'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  loadGroupDetails: async (groupId: string) => {
+    try {
+      const group = await getGroup(groupId)
+      set({ groupDetails: { ...get().groupDetails, [groupId]: group } })
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Gruppendetails konnten nicht geladen werden'
+      set({ error: message })
+    }
+  },
+
+  createNewGroup: async (name, description) => {
+    await createGroup(name, description)
+    await get().loadGroups()
+  },
+
+  renameGroup: async (groupId, name, description) => {
+    await updateGroup(groupId, name, description)
+    await Promise.all([get().loadGroups(), get().loadGroupDetails(groupId)])
+  },
+
+  deleteExistingGroup: async (groupId) => {
+    await deleteGroup(groupId)
+    const rest = { ...get().groupDetails }
+    delete rest[groupId]
+    set({ groupDetails: rest })
+    await get().loadGroups()
+  },
+
+  addMember: async (groupId, userId) => {
+    await addGroupMember(groupId, userId)
+    await Promise.all([get().loadGroups(), get().loadGroupDetails(groupId)])
+  },
+
+  removeMember: async (groupId, userId) => {
+    await removeGroupMember(groupId, userId)
+    await Promise.all([get().loadGroups(), get().loadGroupDetails(groupId)])
+  },
+}))

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -39,6 +39,14 @@ export type UserInfo = UserInfoResponse
 export type RoleChangeRequest = components['schemas']['RoleChangeRequest']
 export type SystemRole = components['schemas']['SystemRole']
 
+export type GroupKind = components['schemas']['GroupKind']
+export type GroupRequest = components['schemas']['GroupRequest']
+export type GroupUpdateRequest = components['schemas']['GroupUpdateRequest']
+export type GroupMemberResponse = components['schemas']['GroupMemberResponse']
+export type GroupListResponse = components['schemas']['GroupListResponse']
+export type GroupResponse = components['schemas']['GroupResponse']
+export type GroupAddMemberRequest = components['schemas']['GroupAddMemberRequest']
+
 export function isErrorResponse(data: unknown): data is ErrorResponse {
   return (
     typeof data === 'object' &&

--- a/frontend/src/utils/labels.ts
+++ b/frontend/src/utils/labels.ts
@@ -1,4 +1,4 @@
-import type { SpaceKind, SpaceRole } from '../types/api'
+import type { GroupKind, SpaceKind, SpaceRole } from '../types/api'
 import type { AccessLevel } from '../types/chat'
 
 const spaceRoleLabels: Record<SpaceRole, string> = {
@@ -21,6 +21,16 @@ export function spaceRoleLabel(role: SpaceRole | string | undefined): string {
 export function spaceKindLabel(kind: SpaceKind | string | undefined): string {
   if (!kind) return ''
   return spaceKindLabels[kind as SpaceKind] ?? kind
+}
+
+const groupKindLabels: Record<GroupKind, string> = {
+  ORG_UNIT: 'Organisationseinheit',
+  AD_HOC: 'Ad-hoc-Gruppe',
+}
+
+export function groupKindLabel(kind: GroupKind | string | undefined): string {
+  if (!kind) return ''
+  return groupKindLabels[kind as GroupKind] ?? kind
 }
 
 const accessLevelLabels: Record<AccessLevel, string> = {


### PR DESCRIPTION
## Zusammenfassung

Fuehrt Gruppen als zweiten Rechtesubjekt-Typ neben Nutzern ein, bevor der erste Grant existiert (#202) - ein nachtraeglich eingefuehrter Subjekttyp wuerde sonst jede Rechteabfrage, jeden Grant und jeden Cache beruehren.

- `io.opaa.group` mit `Group`/`GroupMembership`: `Group.kind` unterscheidet `ORG_UNIT` (aus dem Verzeichnis, stabile `externalId` = objectGUID/SCIM-externalId statt Name, Elterneinheit) von `AD_HOC` (im System angelegt, ohne Kurator/Verteilungsstufe). Gruppen sind per zusammengesetztem Fremdschluessel strikt an eine Organisation gebunden (analog `space_memberships`).
- `PermissionSubject` (User oder Group, mit `organizationId`) als gemeinsame Abstraktion fuer kuenftige Grants; `GroupMembershipResolver` loest die Gruppen eines Nutzers sowie die Nutzer eines Subjekts auf und cacht das Ergebnis (Caffeine, wie `RateLimitService`), mit Invalidierung nach Transaktions-Commit bei jeder Mitgliedschaftsaenderung. Beide Zweige von `resolveUserIds` (USER und GROUP) sind organisationsscharf.
- `GroupService`/`GroupController` unter `/api/v1/admin/groups` (nur Systemadministratoren): Gruppen anlegen, umbenennen, loeschen, Mitglieder hinzufuegen/entfernen - beschraenkt auf `AD_HOC`-Gruppen; `ORG_UNIT`-Gruppen bleiben schreibgeschuetzt, bis die Verzeichnissynchronisation sie befuellt (#237).
- Liquibase-Changelog `009` legt `groups` und `group_memberships` an; `Migration009CreateGroupsTest` belegt am realen Schema (nicht am Hibernate-generierten Test-Schema), dass die Organisationsgrenze durch die zusammengesetzte Fremdschluesselbeziehung tatsaechlich durchgesetzt wird.
- Frontend: neue Seite „Gruppen" unter `/admin/groups`, nur fuer Systemadministratoren im Menue sichtbar - Gruppen anlegen/umbenennen/loeschen, Mitglieder pflegen; `ORG_UNIT`-Gruppen werden als schreibgeschuetzt dargestellt.

## Review-Runden

**Runde 1** (Merge-Konflikt mit #280, Cache-Invalidierung vor statt nach Commit, `PermissionSubject` ohne Organisationsgrenze, diverse Nits) - behoben, siehe Kommentare unten.

**Runde 2** (Nachpruefung) - zwei verbleibende Punkte behoben:
- Der Integrationstest fuer die Cache-Invalidierung pruefte bislang nur „irgendwann vor der Assertion", nicht „nach dem Commit". Neuer Test `removingAMemberDoesNotLeaveAStaleCacheEntryFromAReaderDuringTheOpenTransaction` in `GroupServiceIntegrationTest` stellt die Race explizit nach: offene Transaktion via `PlatformTransactionManager`/`TransactionTemplate`, ein Leser-Thread liest waehrend die Transaktion offen ist, Assertion erst nach dem Commit.
  **Reproduktionsnachweis** (gefordert seit der zwischenzeitlich gemergten AGENTS.md-Ergaenzung, siehe #295): Fix in `GroupService#removeMember` vorruebergehend auf die urspruengliche Inline-Invalidierung zurueckgesetzt (`membershipResolver.invalidateUser(memberUserId)` statt `invalidateAfterCommit(...)`), Test lief:
  ```
  GroupServiceIntegrationTest > removingAMemberDoesNotLeaveAStaleCacheEntryFromAReaderDuringTheOpenTransaction() FAILED
  java.lang.AssertionError:
  Expecting empty but was: [2ec42d3e-5d9c-444d-9fc8-3fdc887779c7]
  ```
  Fix wiederhergestellt, Test lief wieder gruen (siehe Pre-Push-Belege unten).
- `GroupMembershipResolver#resolveUserIds` pruefte im `USER`-Zweig die Organisationsgrenze nicht, obwohl der Javadoc genau das versprach. Behoben: `USER`-Subjekte werden jetzt gegen `UserRepository` auf Zugehoerigkeit zur genannten Organisation geprueft (ein zusaetzlicher indizierter Zugriff auf dem heissen Pfad, bewusst in Kauf genommen, damit die Klasse ihr eigenes Versprechen haelt statt es an kuenftige Aufrufer in #202 zu delegieren).
- Nit: `GroupMembershipRepository#findByUserIdAndGroupId` entfernt (unbenutzt).
- Nit (asymmetrische DB-Grenze `users(id, organization_id)`): bewusst nicht in diesem PR behoben, siehe #289.

## Zugehörige Issues

Closes #200
Teil von #198 (Stage A)
Folge-Issue fuer eine DB-seitige Haertung, die dieser PR bewusst nicht mitnimmt: #289

## Art der Änderung

- [x] Neues Feature
- [ ] Bugfix
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Annahmen

- **Gruppenerstellung ist auf `AD_HOC` beschraenkt.** `ORG_UNIT`-Gruppen entstehen laut Spezifikation ausschliesslich durch die Verzeichnissynchronisation (#237); die Admin-API/-UI dieses PRs erstellt daher nur `AD_HOC`-Gruppen. `ORG_UNIT` ist im Datenmodell bereits vollstaendig angelegt (Kind, `externalId`, `parentGroupId`).
- **„Loeschen einer Gruppe mit Asset-Eigentum wird blockiert" ist noch nicht implementierbar.** Es gibt noch kein Asset-Modell (`io.opaa.indexing.Document` kennt keinen Eigentuemer) - #201/#202 fuehren Assets und Asset-Eigentuemerschaft erst ein. `GroupService#deleteGroup` traegt dafuer ein `TODO(#202)`.
- **Gruppenmanagement ist system-adminweit, nicht curator-basiert.** Kuratoren an Organisationseinheiten sind #208; dieses PR haelt lediglich `parentGroupId` fuer die spaetere Eskalation vor.

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend) - die Spezifikation (`docs/features/spaces-and-assets.md`, ADR-0008) beschreibt das Modell bereits vollstaendig; keine weiteren Aenderungen noetig
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Sonnet 5, Developer-Agent)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
