### PR TITLE
fix(eval): Sentinel-Feldbezogenheit und Ground-Truth-Fingerabdruck im Golden Dataset

### DIFF
--- a/eval/generator/generate_golden_dataset.py
+++ b/eval/generator/generate_golden_dataset.py
@@ -50,10 +50,11 @@ its ~370 KB in every clone).
 - `eval/golden/comic-characters.candidates.json` — every candidate this
   script's rules produced, before manual curation.
 - `eval/golden/comic-characters.json` — the manually curated selection (see
-  `CURATED_CASES` near the bottom of this file), by (`natural_key`, `query`)
-  pair rather than by sequential `id` — see the comment on `CURATED_CASES`
-  for why `id`-based selection (the original, issue #226 version of this
-  list) was unsafe.
+  `CURATED_CASES` near the bottom of this file), by
+  (`natural_key`, `query`, `expected_documents` fingerprint) triple rather
+  than by sequential `id` — see the comment on `CURATED_CASES` for why
+  `id`-based selection (the original, issue #226 version of this list) was
+  unsafe, and why the fingerprint's third element was added afterwards.
 
 Usage:
     python eval/generator/generate_golden_dataset.py
@@ -63,6 +64,7 @@ See eval/golden/README.md for the curation log and rationale.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sys
@@ -85,7 +87,7 @@ OCCUPATION_MAX_LEN = 120
 # issue #226, second review comment: the reliable "unrated character" test
 # is `overall_score is not null`, not a test on the five attribute scores
 # themselves (see the comment on `parse_score()` in generate_corpus.py and
-# `Entity.is_scored` / `ATTRIBUTE_LABELS` below, which enumerate the five
+# `Entity.is_rated` / `ATTRIBUTE_LABELS` below, which enumerate the five
 # fields this applies to).
 
 FILTER_RESULT_MIN = 2
@@ -141,20 +143,34 @@ class Entity:
         return self.fields.get(key)
 
     @property
-    def is_scored(self) -> bool:
-        """`overall_score` is a real number for this entity — `False` for
-        both the 105 "unrated" characters (`overall_score: null`) and the 18
-        omnipotent characters (`overall_score: "∞"`, the only non-int string
-        value this field takes). `isinstance(..., int)` catches both in one
-        check without needing a separate `!= "∞"` test.
-
-        This same property backs two different rules with two different
-        scopes — see the sentinel-rule comment block above
-        `OVERALL_SCORE_BELOW_THRESHOLDS` in this module for the distinction:
-        used directly for `overall_score`'s own sentinel rule, and reused
-        (deliberately, per issue #226) for a *cross-field* exclusion when
-        building numeric_range candidates on the five attribute scores.
+    def is_rated(self) -> bool:
+        """`overall_score` is not `null` — `False` only for the 105
+        "unrated" characters. This is the gate for the *cross-field* rule
+        (issue #226's second review comment): those 105 documents contain
+        the literal sentence "scores 0 for intelligence, 0 for strength,
+        ..." in their prose, contaminating the five *attribute* scores, not
+        `overall_score` itself. `overall_score: "∞"` entities are rated
+        (`is_rated` is `True` for them) — their five attribute scores carry
+        no such contamination, so the cross-field rule must not touch them
+        (issue #274, finding 1: an earlier version of this property
+        conflated this with `has_numeric_overall` below, and via
+        `scored_entities` incorrectly excluded the 18 "∞" entities from
+        every five-attribute-score query too, violating the sentinel rule's
+        required field-scoping).
         """
+        return self.fields.get("overall_score") is not None
+
+    @property
+    def has_numeric_overall(self) -> bool:
+        """`overall_score` is a real number for this entity — `False` for
+        both the 105 "unrated" characters (`overall_score: null`, same as
+        `not is_rated`) and, unlike `is_rated`, also `False` for the 18
+        omnipotent characters (`overall_score: "∞"`, the only non-int string
+        value this field takes). This is the gate for `overall_score`'s own
+        sentinel rule (see the comment block above
+        `OVERALL_SCORE_BELOW_THRESHOLDS`) — it must **not** be reused for the
+        five attribute-score queries (that would be `is_rated`'s job; see
+        its docstring for why the two must stay separate)."""
         return isinstance(self.fields.get("overall_score"), int)
 
     @property
@@ -614,10 +630,10 @@ BELOW_THRESHOLDS_BY_ATTRIBUTE = {
 # | `speed_score`            | keine        | s. u. |
 # | `durability_score`       | keine        | s. u. |
 # | `combat_score`           | keine        | s. u. |
-# | `overall_score`          | `null`, `"∞"` | numeric_range auf `overall_score` selbst: beide vor Fenster-/Schwellenwertbestimmung ausgeschlossen (`Entity.is_scored` schließt `null` UND `"∞"` aus — beide sind kein `int`) |
+# | `overall_score`          | `null`, `"∞"` | numeric_range auf `overall_score` selbst: beide vor Fenster-/Schwellenwertbestimmung ausgeschlossen (`Entity.has_numeric_overall` schließt `null` UND `"∞"` aus — beide sind kein `int`) |
 #
 # The five attribute scores have *no sentinel of their own* — but they are
-# still gated by `Entity.is_scored` here (`scored_entities` below), which is
+# still gated by `Entity.is_rated` here (`scored_entities` below), which is
 # a **separate, additional, cross-field rule**, not this sentinel rule: per
 # issue #226's second review comment, `overall_score: null` correlates with
 # contaminated prose on the *five attribute fields* ("scores 0 for
@@ -648,8 +664,12 @@ def generate_numeric_range(entities: list[Entity]) -> list[Candidate]:
     candidates: list[Candidate] = []
     # Cross-field rule (see the comment block above `OVERALL_SCORE_BELOW_...`
     # for why this is scoped to the five attribute fields specifically, and
-    # is not the same thing as the `overall_score` sentinel rule).
-    scored_entities = [e for e in entities if e.is_scored]
+    # is not the same thing as the `overall_score` sentinel rule below).
+    # `is_rated`, not `has_numeric_overall`: this must *not* additionally
+    # exclude `overall_score: "∞"` entities — their five attribute scores
+    # carry no contamination, so excluding them here would violate the
+    # sentinel rule's required field-scoping (issue #274, finding 1).
+    scored_entities = [e for e in entities if e.is_rated]
 
     for score_field, thresholds in BELOW_THRESHOLDS_BY_ATTRIBUTE.items():
         label = ATTRIBUTE_LABELS[score_field]
@@ -678,10 +698,13 @@ def generate_numeric_range(entities: list[Entity]) -> list[Candidate]:
                 )
             )
 
-    # `overall_score` sentinel rule: `Entity.is_scored` excludes both `null`
-    # and `"∞"` (neither is an `int`), applied to the base population before
-    # any threshold/window is picked — see the comment block above.
-    overall_ints = [e for e in entities if e.is_scored]
+    # `overall_score` sentinel rule: `Entity.has_numeric_overall` excludes
+    # both `null` and `"∞"` (neither is an `int`), applied to the base
+    # population before any threshold/window is picked — see the comment
+    # block above. Deliberately `has_numeric_overall`, not `is_rated`: this
+    # gate is about `overall_score` itself, not about the five attribute
+    # fields (see `is_rated`'s docstring for why the two must stay separate).
+    overall_ints = [e for e in entities if e.has_numeric_overall]
     for threshold in OVERALL_SCORE_BELOW_THRESHOLDS:
         matches = [e.filename for e in overall_ints if e["overall_score"] < threshold]
         if FILTER_RESULT_MIN <= len(matches) <= FILTER_RESULT_MAX:
@@ -917,57 +940,70 @@ def _german_attribute_label(score_field: str) -> str:
 # for the review log) and is itself the reviewable artifact in this file's
 # diff.
 #
-# Selection is by (`natural_key`, `query`) pair, not by the sequential `id`
-# a candidate happens to get in a given run (issue #274, finding 3): `id`s
-# are assigned in generation order, so a field that used to yield exactly
-# `MAX_CANDIDATES_PER_FIELD` candidates but yields one fewer after a corpus
-# update silently renumbers every candidate after it — `comic-attr-101`
-# would keep existing, but now name a different entity and possibly a
-# different field, while `CURATED_CASE_IDS` (the old, id-based version of
-# this list) kept pointing at that position and picked up the swap without
-# any error. `natural_key` is derived purely from generating parameters
-# (field, entity, threshold, ...), so it identifies "the same" candidate
-# regardless of how many other candidates exist around it. The paired
-# `query` string is a second, independent, human-readable check: if a
-# `natural_key` still resolves to a candidate after a change but that
-# candidate's *query text* differs from what was curated, something about
-# the generating logic changed underneath this selection, and `main()`
-# refuses to proceed silently (see the lookup loop below) rather than
-# publish a different question under an unchanged-looking selection.
-CURATED_CASES: list[tuple[str, str]] = (
+# Selection is by (`natural_key`, `query`, `expected_documents_fingerprint`)
+# triple, not by the sequential `id` a candidate happens to get in a given
+# run (issue #274, finding 3): `id`s are assigned in generation order, so a
+# field that used to yield exactly `MAX_CANDIDATES_PER_FIELD` candidates but
+# yields one fewer after a corpus update silently renumbers every candidate
+# after it — `comic-attr-101` would keep existing, but now name a different
+# entity and possibly a different field, while `CURATED_CASE_IDS` (the old,
+# id-based version of this list) kept pointing at that position and picked
+# up the swap without any error. `natural_key` is derived purely from
+# generating parameters (field, entity, threshold, ...), so it identifies
+# "the same" candidate regardless of how many other candidates exist around
+# it. The paired `query` string is a second, independent, human-readable
+# check: if a `natural_key` still resolves to a candidate after a change but
+# that candidate's *query text* differs from what was curated, something
+# about the generating logic changed underneath this selection.
+#
+# Neither of those two catches a *third* drift mode (issue #274, follow-up
+# review, finding 2, reproduced by the reviewer against a live copy of this
+# script): `natural_key` and `query` can both stay identical while
+# `expected_documents` — the actual ground truth — silently changes, e.g. a
+# more robust `superpowers` parser than today's `.split(", ")` shifting which
+# entities match a given ability. The corpus itself is protected by
+# `MANIFEST.sha256`, so the realistic trigger is a change to *this
+# generator's* matching logic, not the corpus. The third element,
+# `sha256("|".join(sorted(expected_documents)))`, catches exactly that: it
+# changes if and only if the *set* of matching documents changes, regardless
+# of their order. `main()` recomputes it for the live candidate behind each
+# `natural_key` and refuses to proceed silently (see the lookup loop below)
+# if it no longer matches — rather than publish a different ground truth
+# under an unchanged-looking selection.
+CURATED_CASES: list[tuple[str, str, str]] = (
     []
     # attribute_lookup: 3 per field (10 fields), varied entities.
     + [
-        ("attr::eye_color::comic-0008_abin-sur.md", "What eye color does Abin Sur have?"),
-        ("attr::eye_color::comic-0022_agent-13.md", "What eye color does Agent 13 have?"),
-        ("attr::eye_color::comic-0043_alta-r-ibn-la-ahad.md", "What eye color does Altaïr Ibn-La'Ahad have?"),
-        ("attr::hair_color::comic-0145_batwoman.md", "What hair color does Batwoman have?"),
-        ("attr::hair_color::comic-0173_black-adam-pre-crisis.md", "What hair color does Black Adam (Pre-Crisis) have?"),
-        ("attr::hair_color::comic-0180_black-canary-injustice.md", "What hair color does Black Canary (Injustice) have?"),
-        ("attr::creator::comic-0289_cheshire.md", "Which company or creator created Cheshire?"),
-        ("attr::creator::comic-0296_chromos.md", "Which company or creator created Chromos?"),
-        ("attr::creator::comic-0303_clock-king.md", "Which company or creator created Clock King?"),
-        ("attr::real_name::comic-0433_el-diablo.md", "What is El Diablo's real name?"),
-        ("attr::real_name::comic-0447_eradicator.md", "What is Eradicator's real name?"),
-        ("attr::real_name::comic-0454_evil-nya.md", "What is Evil Nya's real name?"),
-        ("attr::place_of_birth::comic-0591_hellfire-mcu.md", "Where was Hellfire (MCU) born?"),
-        ("attr::place_of_birth::comic-0598_hiruzen-sarutobi.md", "Where was Hiruzen Sarutobi born?"),
-        ("attr::place_of_birth::comic-0612_hulk-2099.md", "Where was Hulk 2099 born?"),
-        ("attr::occupation::comic-0721_karnak.md", "What is Karnak's occupation?"),
-        ("attr::occupation::comic-0728_kenshiro.md", "What is Kenshiro's occupation?"),
-        ("attr::occupation::comic-0735_kid-flash-ii.md", "What is Kid Flash II's occupation?"),
-        ("attr::first_appearance::comic-0865_maximus-mcu.md", "Where did Maximus (MCU) first appear?"),
-        ("attr::first_appearance::comic-0879_metron.md", "Where did Metron first appear?"),
-        ("attr::first_appearance::comic-0886_mind-flayer.md", "Where did Mind Flayer first appear?"),
-        ("attr::alignment::comic-1009_plastic-man.md", "Is Plastic Man good, bad, or neutral?"),
-        ("attr::alignment::comic-1016_polaris.md", "Is Polaris good, bad, or neutral?"),
-        ("attr::alignment::comic-1023_preeminent.md", "Is Preeminent good, bad, or neutral?"),
-        ("attr::type_race::comic-1153_sharon-carter.md", "What species or race is Sharon Carter?"),
-        ("attr::type_race::comic-1160_shin-godzilla.md", "What species or race is Shin Godzilla?"),
-        ("attr::type_race::comic-1181_skales.md", "What species or race is Skales?"),
-        ("attr::height_cm::comic-1297_the-ray-cw.md", "How tall is The Ray (CW), in centimeters?"),
-        ("attr::height_cm::comic-1304_the-thing-fox.md", "How tall is The Thing (FOX), in centimeters?"),
-        ("attr::height_cm::comic-1332_trickster.md", "How tall is Trickster, in centimeters?"),
+        ("attr::eye_color::comic-0008_abin-sur.md", "What eye color does Abin Sur have?", "99b8a89a2a5a095d12ad48366cc2e19bf37b59985f0e189770ed4d2750490f24"),
+        ("attr::eye_color::comic-0022_agent-13.md", "What eye color does Agent 13 have?", "983d15ddac97641d5c318913c38c7e1c352d442c0ff190c861bec67bb853ebec"),
+        ("attr::eye_color::comic-0043_alta-r-ibn-la-ahad.md", "What eye color does Altaïr Ibn-La'Ahad have?", "4aa2adc2eda5a2d3e16030ebaad2b745c22b427495d587c4c54094bf49b79aac"),
+        ("attr::hair_color::comic-0145_batwoman.md", "What hair color does Batwoman have?", "40d43271d7609c10babf7d2facf7a3e650112b2f7453a5bfe46cf72c3aedea89"),
+        ("attr::hair_color::comic-0173_black-adam-pre-crisis.md", "What hair color does Black Adam (Pre-Crisis) have?", "a59f0c7d0e2bf3e2fd92fb71ac835e1d57387bd916ffc91c755c086737a9d251"),
+        ("attr::hair_color::comic-0180_black-canary-injustice.md", "What hair color does Black Canary (Injustice) have?", "34ce8fb384e9ad6cf961de1ba2af84a8db23f6977c729ff1197d22077c2853b4"),
+        ("attr::creator::comic-0289_cheshire.md", "Which company or creator created Cheshire?", "e709b6546d11bc121497e009714d693b135d2d774bf9ab98330473a44cd8cf44"),
+        ("attr::creator::comic-0296_chromos.md", "Which company or creator created Chromos?", "d550a80daa1c0ba19ebb243b97b245e523baea915285b79c5d497626b8b81237"),
+        ("attr::creator::comic-0303_clock-king.md", "Which company or creator created Clock King?", "afdee0f20f7b0d147f6df19503b85d98acdc78c4ed7f70e7e27e1f614f6fdea3"),
+        ("attr::real_name::comic-0433_el-diablo.md", "What is El Diablo's real name?", "c1a4dac83417c996a8b47edb4322e81b1537a01694812d8d5528cb60f827264d"),
+        ("attr::real_name::comic-0447_eradicator.md", "What is Eradicator's real name?", "d85b27f9e57dc3072b835fd96730442f3dd679c974f0902498ad87cfe350bd1a"),
+        ("attr::real_name::comic-0454_evil-nya.md", "What is Evil Nya's real name?", "178ce2c1ecf3eca434dbfd3e6435955d3d24466a4197ca190d9f9c5eeb3b1881"),
+        ("attr::place_of_birth::comic-0591_hellfire-mcu.md", "Where was Hellfire (MCU) born?", "9f80f0d9002197e1b9af1efe882b6ceca71a2574664802366ff6ebb693e5f4cf"),
+        ("attr::place_of_birth::comic-0598_hiruzen-sarutobi.md", "Where was Hiruzen Sarutobi born?", "d41854d8ff1c1a36741410e92e75c20bfd964414a786f07baf3eb40bf1fa1da0"),
+        ("attr::place_of_birth::comic-0612_hulk-2099.md", "Where was Hulk 2099 born?", "98d232f2f0de42767ac08e4f64f11a4071fc5c72fe1dcdbcc36f0ad5f8ffb869"),
+        ("attr::occupation::comic-0721_karnak.md", "What is Karnak's occupation?", "f76f3a7dcb42657a67a912e74b249922ff06e64a49fc11bc8dd2a5b7341c2d94"),
+        ("attr::occupation::comic-0728_kenshiro.md", "What is Kenshiro's occupation?", "75cab16df36de5d50753bf7d41f5c7f9d552be0783f78e62f0ee3a46fcacea71"),
+        ("attr::occupation::comic-0735_kid-flash-ii.md", "What is Kid Flash II's occupation?", "fc088471df11f16bbc748d939a56def3084080f3d2c5837fb66980b0c7e18a6a"),
+        ("attr::first_appearance::comic-0865_maximus-mcu.md", "Where did Maximus (MCU) first appear?", "49db6822fc88c84f2950aacef7e34c9f365de77740cba523f312ac4ba3c3e87c"),
+        ("attr::first_appearance::comic-0879_metron.md", "Where did Metron first appear?", "78534c1cca4ab8eb7813fe7ce890906a03ca638cbc3394cf0b2ee6deb90f6f12"),
+        ("attr::first_appearance::comic-0886_mind-flayer.md", "Where did Mind Flayer first appear?", "0026dd7ac27f59ec87342eed5f31517ccc90fabaf1d411eaa3c127c57d2b31f8"),
+        ("attr::alignment::comic-1009_plastic-man.md", "Is Plastic Man good, bad, or neutral?", "bf31ead7f29eb7633fdb859b02dfbc3f48fbd1e3bba867611ad3cc58a02bace2"),
+        ("attr::alignment::comic-1016_polaris.md", "Is Polaris good, bad, or neutral?", "67759926774c10632230f9ceecdbf601ee3e42e185310b17d9fa6bb689b49c6b"),
+        ("attr::alignment::comic-1023_preeminent.md", "Is Preeminent good, bad, or neutral?", "0128aa46bfbeb0cb8ddfebf0c9064a9992ba3389100aec2a39841950255debd1"),
+        ("attr::type_race::comic-1153_sharon-carter.md", "What species or race is Sharon Carter?", "862b3d11cb6eda74a68d9a4134d0db213598e127d189c047a1ec2e512ac33e35"),
+        ("attr::type_race::comic-1160_shin-godzilla.md", "What species or race is Shin Godzilla?", "68de2215b8ddd6ac3d6c243f33fda04114f2cdd126a07ed7a2dfe0c664800cda"),
+        ("attr::type_race::comic-1181_skales.md", "What species or race is Skales?", "ef1c5be9499b37201f684874a528743348999524889a504134ca505997be5614"),
+        ("attr::height_cm::comic-1297_the-ray-cw.md", "How tall is The Ray (CW), in centimeters?", "0e21b79b96a7ab516ffc0b0e6964ec240ca7c228ce6b85049ae4f3e5ff8a028d"),
+        ("attr::height_cm::comic-1304_the-thing-fox.md", "How tall is The Thing (FOX), in centimeters?", "7668270136b1975ee3087544e1ffc2e7357c1ea543e8bb0ef2f162801ce15508"),
+        ("attr::height_cm::comic-1332_trickster.md", "How tall is Trickster, in centimeters?", "311bd75f59db70684de33fd12f90fcbc59ba736d052626e29f22ba4460b1a3d1"),
     ]
     # entity_description: 8 per creator/eye/ability template, 8 per
     # alignment/race/team/hair template, 4 of the weaker place/occupation/eye
@@ -979,26 +1015,26 @@ CURATED_CASES: list[tuple[str, str]] = (
     # themselves messy in the source dataset, e.g. "Cyrus borg his helper" —
     # correct ground truth, but not worth curating in).
     + [
-        ("desc::0::comic-0043_alta-r-ibn-la-ahad.md", "Which character created by Ubisoft is good-aligned, has Hazel eyes and can use Agility?"),
-        ("desc::0::comic-0078_aragorn.md", "Which character created by J. R. R. Tolkien is good-aligned, has Grey eyes and can use Accelerated Healing?"),
-        ("desc::0::comic-0113_bane-dark-knight.md", "Which character created by DC Comics is bad-aligned, has Hazel eyes and can use Accelerated Healing?"),
-        ("desc::0::comic-0274_castiel.md", "Which character created by Wildstorm is good-aligned, has Green eyes and can use Accelerated Healing?"),
-        ("desc::0::comic-0428_edward-kenway.md", "Which character created by Ubisoft is good-aligned, has Green eyes and can use Agility?"),
-        ("desc::0::comic-0526_golden-ninja.md", "Which character created by Lego is good-aligned, has White eyes and can use Accelerated Healing?"),
-        ("desc::0::comic-0568_harry-potter.md", "Which character created by J. K. Rowling is good-aligned, has Green eyes and can use Accelerated Healing?"),
-        ("desc::0::comic-0631_impossible-man.md", "Which character created by Marvel Comics is neutral-aligned, has Purple eyes and can use Dimensional Travel?"),
-        ("desc::1::comic-0483_flash-cw.md", "Which good Metahuman character is affiliated with Flash Family and has Brown / Black hair?"),
-        ("desc::1::comic-0518_gilotina.md", "Which bad God / Eternal character is affiliated with Female Furies and has Blond hair?"),
-        ("desc::1::comic-0532_granny-goodness.md", "Which bad New God character is affiliated with Female Furies and has White hair?"),
-        ("desc::1::comic-0609_howard-the-duck.md", "Which good Animal character is affiliated with Marvel Knights and has Yellow hair?"),
-        ("desc::1::comic-0616_hulkling.md", "Which good Alien character is affiliated with Young Avengers and has Blond hair?"),
-        ("desc::1::comic-0651_iron-man.md", "Which good Human character is affiliated with Hulkbusters and has Black hair?"),
-        ("desc::1::comic-0693_johnny-quick.md", "Which bad Human character is affiliated with Flash Family and has Blond hair?"),
-        ("desc::1::comic-0707_jyn-erso.md", "Which good Human character is affiliated with Rogue One and has Brown hair?"),
-        ("desc::2::comic-1014_poison-ivy.md", "Which character born in Seattle, Washington works as criminal, Botanist and has Green eyes?"),
-        ("desc::2::comic-1056_raphael-tmnt-2012.md", "Which character born in New York City works as ninja and has Green eyes?"),
-        ("desc::2::comic-1224_starfire.md", "Which character born in Tamaran works as model and has Green eyes?"),
-        ("desc::2::comic-1252_superman-2006.md", "Which character born in Krypton works as reporter and has Blue eyes?"),
+        ("desc::0::comic-0043_alta-r-ibn-la-ahad.md", "Which character created by Ubisoft is good-aligned, has Hazel eyes and can use Agility?", "4aa2adc2eda5a2d3e16030ebaad2b745c22b427495d587c4c54094bf49b79aac"),
+        ("desc::0::comic-0078_aragorn.md", "Which character created by J. R. R. Tolkien is good-aligned, has Grey eyes and can use Accelerated Healing?", "21136070410273ef59641cc964eeb1a2770a3dcee8f1130829473ced139296ea"),
+        ("desc::0::comic-0113_bane-dark-knight.md", "Which character created by DC Comics is bad-aligned, has Hazel eyes and can use Accelerated Healing?", "0d760654bdc39e9749a18830ccc6257b6be9fa879a06507671bbd5e10d537d79"),
+        ("desc::0::comic-0274_castiel.md", "Which character created by Wildstorm is good-aligned, has Green eyes and can use Accelerated Healing?", "a5eb6f1913b588505af47ef8381418fc138ba21ba7fcba4b9439b69bfdbfc9c6"),
+        ("desc::0::comic-0428_edward-kenway.md", "Which character created by Ubisoft is good-aligned, has Green eyes and can use Agility?", "29367c67d6a3375e11e1420a07ff8a864c72053e60c5fdee3a9b8d0305b84cca"),
+        ("desc::0::comic-0526_golden-ninja.md", "Which character created by Lego is good-aligned, has White eyes and can use Accelerated Healing?", "6b26192459886be2abf5a33bd700ad19042c78b97a9e351a61d19e2a69652d57"),
+        ("desc::0::comic-0568_harry-potter.md", "Which character created by J. K. Rowling is good-aligned, has Green eyes and can use Accelerated Healing?", "9bc3e159b7ac81bc13daa3c5431d145b067079953329fb84ab7cea4425c6099c"),
+        ("desc::0::comic-0631_impossible-man.md", "Which character created by Marvel Comics is neutral-aligned, has Purple eyes and can use Dimensional Travel?", "1270e048ffbd5b0f2421ee68025d236adeea1d97972be80b714e0f748e19a076"),
+        ("desc::1::comic-0483_flash-cw.md", "Which good Metahuman character is affiliated with Flash Family and has Brown / Black hair?", "c417ee9d6d39bac1eb82ebbe7e6efe7051695d52e683d730857719286662180a"),
+        ("desc::1::comic-0518_gilotina.md", "Which bad God / Eternal character is affiliated with Female Furies and has Blond hair?", "c797bb7464bd80180791975f3c289ce1bf88f60cd69bf67eb946f54219819460"),
+        ("desc::1::comic-0532_granny-goodness.md", "Which bad New God character is affiliated with Female Furies and has White hair?", "8140289bb746395eb1059b9c88e6a9fa1910f844f9cb976cde05dc252e090ad2"),
+        ("desc::1::comic-0609_howard-the-duck.md", "Which good Animal character is affiliated with Marvel Knights and has Yellow hair?", "6a9830f113726d63f9968792f3b073d9cd80fd007e1fc55714623c72a5ad1942"),
+        ("desc::1::comic-0616_hulkling.md", "Which good Alien character is affiliated with Young Avengers and has Blond hair?", "ea7944a60552af7311785104202e9c35f43c7699424f3a06e65866143ba51940"),
+        ("desc::1::comic-0651_iron-man.md", "Which good Human character is affiliated with Hulkbusters and has Black hair?", "3f1b2358ba42fb0ae06015f15099dd36acd04abd00dbbb3b4c45a2336eee96b2"),
+        ("desc::1::comic-0693_johnny-quick.md", "Which bad Human character is affiliated with Flash Family and has Blond hair?", "b6f416228fa1c3c50bf8fbe81f975d5b04c9d4e8ec1e00710d44a60fcdaa730c"),
+        ("desc::1::comic-0707_jyn-erso.md", "Which good Human character is affiliated with Rogue One and has Brown hair?", "470b7c820821b6e9a7c15f6fc972c81be326d2798d2de0e3f91068d79415ac07"),
+        ("desc::2::comic-1014_poison-ivy.md", "Which character born in Seattle, Washington works as criminal, Botanist and has Green eyes?", "14773af464af6610813b512c62b4b97032600e6bb03557965d2e96b605b850e7"),
+        ("desc::2::comic-1056_raphael-tmnt-2012.md", "Which character born in New York City works as ninja and has Green eyes?", "d236e9f1e8dfb666a9c93a08af7510fb229ef5859c8e7200cc73aaed7038d930"),
+        ("desc::2::comic-1224_starfire.md", "Which character born in Tamaran works as model and has Green eyes?", "2eb58f08dec2bda576064654e82ccfc546a5fa8d04c2192875e2f2f9718647ef"),
+        ("desc::2::comic-1252_superman-2006.md", "Which character born in Krypton works as reporter and has Blue eyes?", "3fb629f65f903c7c43fa9a38be20209931499c4d35572e3bbd6b0732843ed739"),
     ]
     # multi_attribute_filter: every 8th candidate (of 167) — the old
     # positional stride is fine *here* because it was only ever used to
@@ -1006,49 +1042,49 @@ CURATED_CASES: list[tuple[str, str]] = (
     # (alignment, creator, ability) triples are what carries forward,
     # already spread across all three alignments and five creators.
     + [
-        ("filter::Good::Marvel Comics::Reality Warping", "Which good-aligned characters created by Marvel Comics have the ability Reality Warping?"),
-        ("filter::Good::DC Comics::Telepathy Resistance", "Which good-aligned characters created by DC Comics have the ability Telepathy Resistance?"),
-        ("filter::Good::Shueisha::Mind Control", "Which good-aligned characters created by Shueisha have the ability Mind Control?"),
-        ("filter::Good::Shueisha::Shapeshifting", "Which good-aligned characters created by Shueisha have the ability Shapeshifting?"),
-        ("filter::Good::Shueisha::Heat Resistance", "Which good-aligned characters created by Shueisha have the ability Heat Resistance?"),
-        ("filter::Good::Dark Horse Comics::Regeneration", "Which good-aligned characters created by Dark Horse Comics have the ability Regeneration?"),
-        ("filter::Good::Lego::Shapeshifting", "Which good-aligned characters created by Lego have the ability Shapeshifting?"),
-        ("filter::Bad::Marvel Comics::Mind Control Resistance", "Which bad-aligned characters created by Marvel Comics have the ability Mind Control Resistance?"),
-        ("filter::Bad::DC Comics::Reality Warping", "Which bad-aligned characters created by DC Comics have the ability Reality Warping?"),
-        ("filter::Bad::DC Comics::Electrokinesis", "Which bad-aligned characters created by DC Comics have the ability Electrokinesis?"),
-        ("filter::Bad::DC Comics::Heat Resistance", "Which bad-aligned characters created by DC Comics have the ability Heat Resistance?"),
-        ("filter::Bad::Shueisha::Telekinesis", "Which bad-aligned characters created by Shueisha have the ability Telekinesis?"),
-        ("filter::Bad::Shueisha::Regeneration", "Which bad-aligned characters created by Shueisha have the ability Regeneration?"),
-        ("filter::Bad::Dark Horse Comics::Super Speed", "Which bad-aligned characters created by Dark Horse Comics have the ability Super Speed?"),
-        ("filter::Neutral::Marvel Comics::Mind Control", "Which neutral-aligned characters created by Marvel Comics have the ability Mind Control?"),
-        ("filter::Neutral::Marvel Comics::Magic", "Which neutral-aligned characters created by Marvel Comics have the ability Magic?"),
-        ("filter::Neutral::Marvel Comics::Regeneration", "Which neutral-aligned characters created by Marvel Comics have the ability Regeneration?"),
-        ("filter::Neutral::DC Comics::Dimensional Travel", "Which neutral-aligned characters created by DC Comics have the ability Dimensional Travel?"),
-        ("filter::Neutral::DC Comics::Element Control", "Which neutral-aligned characters created by DC Comics have the ability Element Control?"),
-        ("filter::Neutral::DC Comics::Cold Resistance", "Which neutral-aligned characters created by DC Comics have the ability Cold Resistance?"),
-        ("filter::Neutral::Shueisha::Force Fields", "Which neutral-aligned characters created by Shueisha have the ability Force Fields?"),
+        ("filter::Good::Marvel Comics::Reality Warping", "Which good-aligned characters created by Marvel Comics have the ability Reality Warping?", "4856fd275cef8bda5e16cc57d00b52ed6c02f936d0216b99a3519294d140f1f5"),
+        ("filter::Good::DC Comics::Telepathy Resistance", "Which good-aligned characters created by DC Comics have the ability Telepathy Resistance?", "3876ad8e169cfec812ee84f83bb82f31eb12280531b7bbbd07b62fc3c6ac597e"),
+        ("filter::Good::Shueisha::Mind Control", "Which good-aligned characters created by Shueisha have the ability Mind Control?", "f5e520b757b22191480b6f741bac5f9f23fe58a4040ffe80b9174a3f8ac6ee9d"),
+        ("filter::Good::Shueisha::Shapeshifting", "Which good-aligned characters created by Shueisha have the ability Shapeshifting?", "76c4aea4c143a6a4b94f6ebbfa27a43f413d36cb936e9e0f638dcd01ce459af3"),
+        ("filter::Good::Shueisha::Heat Resistance", "Which good-aligned characters created by Shueisha have the ability Heat Resistance?", "aa707f995a6ed81945e92d674c7aa36bd20e8a830a3a0f202db6bb4fca9a1036"),
+        ("filter::Good::Dark Horse Comics::Regeneration", "Which good-aligned characters created by Dark Horse Comics have the ability Regeneration?", "7d0298d02e65b4dd7c2b3d63cfd8f2d444d42fdc8347dfccfcb8c71b5c6b9cf9"),
+        ("filter::Good::Lego::Shapeshifting", "Which good-aligned characters created by Lego have the ability Shapeshifting?", "4e88292f81a633e77d60c21ea05c49d63828520c689776e3df6a9e1a2d850680"),
+        ("filter::Bad::Marvel Comics::Mind Control Resistance", "Which bad-aligned characters created by Marvel Comics have the ability Mind Control Resistance?", "67b5faf8b7dd66065080227260f02963d99b89c5443c4636833b1dbe1733be58"),
+        ("filter::Bad::DC Comics::Reality Warping", "Which bad-aligned characters created by DC Comics have the ability Reality Warping?", "13290632bf64ddfbc25a505ab62a3a41450cbc8ea2b3a7fffc760f764c7e8574"),
+        ("filter::Bad::DC Comics::Electrokinesis", "Which bad-aligned characters created by DC Comics have the ability Electrokinesis?", "cbd033e6df3ba66500d5d5410be1871db747476fcb7b6740b20790e479499c03"),
+        ("filter::Bad::DC Comics::Heat Resistance", "Which bad-aligned characters created by DC Comics have the ability Heat Resistance?", "23bb4413305e93c1e36122327b862c258c4d35945e40133a03c234c85c885c19"),
+        ("filter::Bad::Shueisha::Telekinesis", "Which bad-aligned characters created by Shueisha have the ability Telekinesis?", "f533a66bcb01cbbe4977ddb7280f947ab598f0450cc5f0c8cc17d43fae99013b"),
+        ("filter::Bad::Shueisha::Regeneration", "Which bad-aligned characters created by Shueisha have the ability Regeneration?", "d35de0305f08fcf55b7a136065917a38954f86905c2b1eba3ef7e0bc39e2cbc8"),
+        ("filter::Bad::Dark Horse Comics::Super Speed", "Which bad-aligned characters created by Dark Horse Comics have the ability Super Speed?", "e604f4c3e9b7bc0bbb82d184eec406aab08a2285cbdab9763afcd182a3d8c9fb"),
+        ("filter::Neutral::Marvel Comics::Mind Control", "Which neutral-aligned characters created by Marvel Comics have the ability Mind Control?", "b402b706cc38c6c92c5b43f2c8ae5df8b52c50039a4b86a34f7db82a3faf1059"),
+        ("filter::Neutral::Marvel Comics::Magic", "Which neutral-aligned characters created by Marvel Comics have the ability Magic?", "8e7a214e2268da78c3c5ab98e5adc325140379deb0f9e0c40e76bca7fdb7aff7"),
+        ("filter::Neutral::Marvel Comics::Regeneration", "Which neutral-aligned characters created by Marvel Comics have the ability Regeneration?", "c94055e29372fb9d9ccb5cb074694bbeb0d0b33bbf9eca50e32c14f60c0e7ad0"),
+        ("filter::Neutral::DC Comics::Dimensional Travel", "Which neutral-aligned characters created by DC Comics have the ability Dimensional Travel?", "e2ef9fcb5ab24b0fc588e310085120df76cc10957da39b0ef17f33411ffb6f61"),
+        ("filter::Neutral::DC Comics::Element Control", "Which neutral-aligned characters created by DC Comics have the ability Element Control?", "029c92a474cada5bf68ee7455e4b414e37dcf342f8a107c2e97d3691e1c3ca6c"),
+        ("filter::Neutral::DC Comics::Cold Resistance", "Which neutral-aligned characters created by DC Comics have the ability Cold Resistance?", "f03a1736cc3ad18e901e07e0033dfa7c730f1459c57210f58f1b7e10485610e7"),
+        ("filter::Neutral::Shueisha::Force Fields", "Which neutral-aligned characters created by Shueisha have the ability Force Fields?", "f48261bda431da113299f440bdb9569153871bbfc5b493779929ce9d5d90228a"),
     ]
     # numeric_range: all 16 automatically-generated candidates are kept —
     # each already required a dedicated threshold search to land in the
     # [2, 15] window (see BELOW_THRESHOLDS_BY_ATTRIBUTE), so none are
     # redundant with another.
     + [
-        ("range::intelligence_score::<::35", "Which characters have an intelligence score below 35?"),
-        ("range::intelligence_score::<::40", "Which characters have an intelligence score below 40?"),
-        ("range::intelligence_score::<::45", "Which characters have an intelligence score below 45?"),
-        ("range::intelligence_score::<::50", "Which characters have an intelligence score below 50?"),
-        ("range::strength_score::<::5", "Which characters have a strength score below 5?"),
-        ("range::speed_score::<::10", "Which characters have a speed score below 10?"),
-        ("range::durability_score::<::5", "Which characters have a durability score below 5?"),
-        ("range::durability_score::<::10", "Which characters have a durability score below 10?"),
-        ("range::combat_score::<::10", "Which characters have a combat score below 10?"),
-        ("range::combat_score::<::15", "Which characters have a combat score below 15?"),
-        ("range::overall_score::<::2", "Which characters have an overall score below 2?"),
-        ("range::overall_score::<::3", "Which characters have an overall score below 3?"),
-        ("range::overall_score::>::120", "Which characters have an overall score above 120?"),
-        ("range::overall_score::>::150", "Which characters have an overall score above 150?"),
-        ("range::overall_score::>::180", "Which characters have an overall score above 180?"),
-        ("range::overall_score::>::210", "Which characters have an overall score above 210?"),
+        ("range::intelligence_score::<::35", "Which characters have an intelligence score below 35?", "6c26a0fac8c5323d279e9222e8329cff74d186c45c1475d2df93c02ba9a00799"),
+        ("range::intelligence_score::<::40", "Which characters have an intelligence score below 40?", "e1132526aa264302702d2fe92a91bd1693a1622e6dad6595b931cc6cbfed510f"),
+        ("range::intelligence_score::<::45", "Which characters have an intelligence score below 45?", "0b62074cd2d6bc837bffb1b109d9b9e2e2fe9b39d084b98a0dfa1cfd1322ebaa"),
+        ("range::intelligence_score::<::50", "Which characters have an intelligence score below 50?", "37cb4eaeed7d9d2a759ff121e53420faf72f5a07179d7b762ae6a4fda72ad42d"),
+        ("range::strength_score::<::5", "Which characters have a strength score below 5?", "3164e7a7172e102db8b607d04aea1a9684f9401fdf5ed05aa4e1782b54e76792"),
+        ("range::speed_score::<::10", "Which characters have a speed score below 10?", "256f9680cd2b06c84b863c565faa62b82460ef57ed03d5c5884a242bc71c8ca8"),
+        ("range::durability_score::<::5", "Which characters have a durability score below 5?", "be0e2d9d6840f84cc414581e6f497c514463bdf13404381771a7a9667ea7332c"),
+        ("range::durability_score::<::10", "Which characters have a durability score below 10?", "d9df88b3af73ad03d38a21f56e1138c4eb63e2f187d48c8437061a83b9667035"),
+        ("range::combat_score::<::10", "Which characters have a combat score below 10?", "0a2d602c0fe5e6baef186a7f3ff20a8cd2bb330d8426bd64ef70c584d35c656c"),
+        ("range::combat_score::<::15", "Which characters have a combat score below 15?", "312d9fd9bba3ad413ab290637ebbd6363141e288a9fccb8fcf4e64f25aa3fc07"),
+        ("range::overall_score::<::2", "Which characters have an overall score below 2?", "aead0cc7de8930aaf079eaef91d97de6a1b76baaae5891c627f6285f19a61752"),
+        ("range::overall_score::<::3", "Which characters have an overall score below 3?", "180e5e348e15212fac3b3279591f6eb1d30293ce2fc0306734bf7d5322d0794d"),
+        ("range::overall_score::>::120", "Which characters have an overall score above 120?", "579fc91f8701728ccadeabb902a4afdccafd83319e63bf6596118ffa57e85475"),
+        ("range::overall_score::>::150", "Which characters have an overall score above 150?", "a552495be422cd468a953d58d83b69da39be130983ccb19aee187520e5c24dc0"),
+        ("range::overall_score::>::180", "Which characters have an overall score above 180?", "c97984a7c298559b7b4bcfe186ebdf3796fad264ad59ab33e93efbb06b7eefc9"),
+        ("range::overall_score::>::210", "Which characters have an overall score above 210?", "c97984a7c298559b7b4bcfe186ebdf3796fad264ad59ab33e93efbb06b7eefc9"),
     ]
     # crosslingual: all 34 kept, for the same reason as numeric_range — each
     # is a distinct field, filter or range constraint translated to German,
@@ -1056,45 +1092,53 @@ CURATED_CASES: list[tuple[str, str]] = (
     # alignments (Good/Bad/Neutral) and both range directions (below/above)
     # are represented (issue #274).
     + [
-        ("de::attr::eye_color::comic-0008_abin-sur.md", "Welche Augenfarbe hat Abin Sur?"),
-        ("de::attr::hair_color::comic-0145_batwoman.md", "Welche Haarfarbe hat Batwoman?"),
-        ("de::attr::creator::comic-0289_cheshire.md", "Von welchem Verlag oder Schöpfer stammt Cheshire?"),
-        ("de::attr::real_name::comic-0433_el-diablo.md", "Wie lautet der echte Name von El Diablo?"),
-        ("de::attr::place_of_birth::comic-0591_hellfire-mcu.md", "Wo wurde Hellfire (MCU) geboren?"),
-        ("de::attr::occupation::comic-0721_karnak.md", "Welchen Beruf übt Karnak aus?"),
-        ("de::attr::first_appearance::comic-0865_maximus-mcu.md", "Wo trat Maximus (MCU) zuerst auf?"),
-        ("de::attr::alignment::comic-1009_plastic-man.md", "Ist Plastic Man gut, böse oder neutral?"),
-        ("de::attr::type_race::comic-1153_sharon-carter.md", "Welcher Spezies gehört Sharon Carter an?"),
-        ("de::attr::height_cm::comic-1297_the-ray-cw.md", "Wie groß ist The Ray (CW) in Zentimetern?"),
-        ("de::filter::Bad::Marvel Comics::Reality Warping", "Welche bösen Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?"),
-        ("de::filter::Bad::DC Comics::Dimensional Travel", "Welche bösen Figuren von DC Comics verfügen über die Fähigkeit Dimensional Travel?"),
-        ("de::filter::Bad::DC Comics::Heat Resistance", "Welche bösen Figuren von DC Comics verfügen über die Fähigkeit Heat Resistance?"),
-        ("de::filter::Bad::Shueisha::Teleportation", "Welche bösen Figuren von Shueisha verfügen über die Fähigkeit Teleportation?"),
-        ("de::filter::Good::Marvel Comics::Reality Warping", "Welche guten Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?"),
-        ("de::filter::Good::Shueisha::Mind Control Resistance", "Welche guten Figuren von Shueisha verfügen über die Fähigkeit Mind Control Resistance?"),
-        ("de::filter::Good::Shueisha::Force Fields", "Welche guten Figuren von Shueisha verfügen über die Fähigkeit Force Fields?"),
-        ("de::filter::Good::Dark Horse Comics::Immortality", "Welche guten Figuren von Dark Horse Comics verfügen über die Fähigkeit Immortality?"),
-        ("de::filter::Neutral::Marvel Comics::Reality Warping", "Welche neutralen Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?"),
-        ("de::filter::Neutral::Marvel Comics::Shapeshifting", "Welche neutralen Figuren von Marvel Comics verfügen über die Fähigkeit Shapeshifting?"),
-        ("de::filter::Neutral::DC Comics::Mind Control", "Welche neutralen Figuren von DC Comics verfügen über die Fähigkeit Mind Control?"),
-        ("de::filter::Neutral::DC Comics::Cold Resistance", "Welche neutralen Figuren von DC Comics verfügen über die Fähigkeit Cold Resistance?"),
-        ("de::range::intelligence_score::<::35", "Welche Figuren haben einen Intelligenzwert unter 35?"),
-        ("de::range::intelligence_score::<::45", "Welche Figuren haben einen Intelligenzwert unter 45?"),
-        ("de::range::strength_score::<::5", "Welche Figuren haben einen Stärkewert unter 5?"),
-        ("de::range::durability_score::<::5", "Welche Figuren haben einen Widerstandsfähigkeitswert unter 5?"),
-        ("de::range::combat_score::<::10", "Welche Figuren haben einen Kampfwert unter 10?"),
-        ("de::range::overall_score::<::2", "Welche Figuren haben einen Gesamtwert unter 2?"),
-        ("de::range::overall_score::>::120", "Welche Figuren haben einen Gesamtwert über 120?"),
-        ("de::range::overall_score::>::150", "Welche Figuren haben einen Gesamtwert über 150?"),
-        ("de::range::overall_score::>::180", "Welche Figuren haben einen Gesamtwert über 180?"),
-        ("de::range::overall_score::>::210", "Welche Figuren haben einen Gesamtwert über 210?"),
-        ("de::range::intelligence_score::<::40", "Welche Figuren haben einen Intelligenzwert unter 40?"),
-        ("de::range::intelligence_score::<::50", "Welche Figuren haben einen Intelligenzwert unter 50?"),
+        ("de::attr::eye_color::comic-0008_abin-sur.md", "Welche Augenfarbe hat Abin Sur?", "99b8a89a2a5a095d12ad48366cc2e19bf37b59985f0e189770ed4d2750490f24"),
+        ("de::attr::hair_color::comic-0145_batwoman.md", "Welche Haarfarbe hat Batwoman?", "40d43271d7609c10babf7d2facf7a3e650112b2f7453a5bfe46cf72c3aedea89"),
+        ("de::attr::creator::comic-0289_cheshire.md", "Von welchem Verlag oder Schöpfer stammt Cheshire?", "e709b6546d11bc121497e009714d693b135d2d774bf9ab98330473a44cd8cf44"),
+        ("de::attr::real_name::comic-0433_el-diablo.md", "Wie lautet der echte Name von El Diablo?", "c1a4dac83417c996a8b47edb4322e81b1537a01694812d8d5528cb60f827264d"),
+        ("de::attr::place_of_birth::comic-0591_hellfire-mcu.md", "Wo wurde Hellfire (MCU) geboren?", "9f80f0d9002197e1b9af1efe882b6ceca71a2574664802366ff6ebb693e5f4cf"),
+        ("de::attr::occupation::comic-0721_karnak.md", "Welchen Beruf übt Karnak aus?", "f76f3a7dcb42657a67a912e74b249922ff06e64a49fc11bc8dd2a5b7341c2d94"),
+        ("de::attr::first_appearance::comic-0865_maximus-mcu.md", "Wo trat Maximus (MCU) zuerst auf?", "49db6822fc88c84f2950aacef7e34c9f365de77740cba523f312ac4ba3c3e87c"),
+        ("de::attr::alignment::comic-1009_plastic-man.md", "Ist Plastic Man gut, böse oder neutral?", "bf31ead7f29eb7633fdb859b02dfbc3f48fbd1e3bba867611ad3cc58a02bace2"),
+        ("de::attr::type_race::comic-1153_sharon-carter.md", "Welcher Spezies gehört Sharon Carter an?", "862b3d11cb6eda74a68d9a4134d0db213598e127d189c047a1ec2e512ac33e35"),
+        ("de::attr::height_cm::comic-1297_the-ray-cw.md", "Wie groß ist The Ray (CW) in Zentimetern?", "0e21b79b96a7ab516ffc0b0e6964ec240ca7c228ce6b85049ae4f3e5ff8a028d"),
+        ("de::filter::Bad::Marvel Comics::Reality Warping", "Welche bösen Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?", "77e0f5331622915fd5338ad201f4d2b664b23af1b8797e961501e9d7a996d7d6"),
+        ("de::filter::Bad::DC Comics::Dimensional Travel", "Welche bösen Figuren von DC Comics verfügen über die Fähigkeit Dimensional Travel?", "1bdb276495bce82a5aa9ffd0fc23446c8508b15d20e8c46599e80d7bf2b97820"),
+        ("de::filter::Bad::DC Comics::Heat Resistance", "Welche bösen Figuren von DC Comics verfügen über die Fähigkeit Heat Resistance?", "23bb4413305e93c1e36122327b862c258c4d35945e40133a03c234c85c885c19"),
+        ("de::filter::Bad::Shueisha::Teleportation", "Welche bösen Figuren von Shueisha verfügen über die Fähigkeit Teleportation?", "644491667734b52c5803acc7cb4cbe8e54b51ae554176be0b3af4a0b13c5d8ff"),
+        ("de::filter::Good::Marvel Comics::Reality Warping", "Welche guten Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?", "4856fd275cef8bda5e16cc57d00b52ed6c02f936d0216b99a3519294d140f1f5"),
+        ("de::filter::Good::Shueisha::Mind Control Resistance", "Welche guten Figuren von Shueisha verfügen über die Fähigkeit Mind Control Resistance?", "97fe6ad9f80d883057488f5db1eba3be89c7829644c2b4c1366ffc3d9916aaa6"),
+        ("de::filter::Good::Shueisha::Force Fields", "Welche guten Figuren von Shueisha verfügen über die Fähigkeit Force Fields?", "e1dae03410ca32ed801c6f6d125c3024bd721c4852bf5a717f592f257c8b4268"),
+        ("de::filter::Good::Dark Horse Comics::Immortality", "Welche guten Figuren von Dark Horse Comics verfügen über die Fähigkeit Immortality?", "2558249ae53309e19df5539626741cdf1909209140e5522d328ea5367d123b28"),
+        ("de::filter::Neutral::Marvel Comics::Reality Warping", "Welche neutralen Figuren von Marvel Comics verfügen über die Fähigkeit Reality Warping?", "fa7bdf0720e654f27ab98359e8dee43ebb66bd55bbe1a9a00ab11cca032c3aca"),
+        ("de::filter::Neutral::Marvel Comics::Shapeshifting", "Welche neutralen Figuren von Marvel Comics verfügen über die Fähigkeit Shapeshifting?", "347e94cb71515cdaece3a6955edc6883fd11393e7f301a895d1d716112818a5e"),
+        ("de::filter::Neutral::DC Comics::Mind Control", "Welche neutralen Figuren von DC Comics verfügen über die Fähigkeit Mind Control?", "b28d1bf08fe5c0559aa7711f1bd6ebb050ab1154c05728d79de1b448de92e9e5"),
+        ("de::filter::Neutral::DC Comics::Cold Resistance", "Welche neutralen Figuren von DC Comics verfügen über die Fähigkeit Cold Resistance?", "f03a1736cc3ad18e901e07e0033dfa7c730f1459c57210f58f1b7e10485610e7"),
+        ("de::range::intelligence_score::<::35", "Welche Figuren haben einen Intelligenzwert unter 35?", "6c26a0fac8c5323d279e9222e8329cff74d186c45c1475d2df93c02ba9a00799"),
+        ("de::range::intelligence_score::<::45", "Welche Figuren haben einen Intelligenzwert unter 45?", "0b62074cd2d6bc837bffb1b109d9b9e2e2fe9b39d084b98a0dfa1cfd1322ebaa"),
+        ("de::range::strength_score::<::5", "Welche Figuren haben einen Stärkewert unter 5?", "3164e7a7172e102db8b607d04aea1a9684f9401fdf5ed05aa4e1782b54e76792"),
+        ("de::range::durability_score::<::5", "Welche Figuren haben einen Widerstandsfähigkeitswert unter 5?", "be0e2d9d6840f84cc414581e6f497c514463bdf13404381771a7a9667ea7332c"),
+        ("de::range::combat_score::<::10", "Welche Figuren haben einen Kampfwert unter 10?", "0a2d602c0fe5e6baef186a7f3ff20a8cd2bb330d8426bd64ef70c584d35c656c"),
+        ("de::range::overall_score::<::2", "Welche Figuren haben einen Gesamtwert unter 2?", "aead0cc7de8930aaf079eaef91d97de6a1b76baaae5891c627f6285f19a61752"),
+        ("de::range::overall_score::>::120", "Welche Figuren haben einen Gesamtwert über 120?", "579fc91f8701728ccadeabb902a4afdccafd83319e63bf6596118ffa57e85475"),
+        ("de::range::overall_score::>::150", "Welche Figuren haben einen Gesamtwert über 150?", "a552495be422cd468a953d58d83b69da39be130983ccb19aee187520e5c24dc0"),
+        ("de::range::overall_score::>::180", "Welche Figuren haben einen Gesamtwert über 180?", "c97984a7c298559b7b4bcfe186ebdf3796fad264ad59ab33e93efbb06b7eefc9"),
+        ("de::range::overall_score::>::210", "Welche Figuren haben einen Gesamtwert über 210?", "c97984a7c298559b7b4bcfe186ebdf3796fad264ad59ab33e93efbb06b7eefc9"),
+        ("de::range::intelligence_score::<::40", "Welche Figuren haben einen Intelligenzwert unter 40?", "e1132526aa264302702d2fe92a91bd1693a1622e6dad6595b931cc6cbfed510f"),
+        ("de::range::intelligence_score::<::50", "Welche Figuren haben einen Intelligenzwert unter 50?", "37cb4eaeed7d9d2a759ff121e53420faf72f5a07179d7b762ae6a4fda72ad42d"),
     ]
 )
 
 
 # --- Dedup, curation & output --------------------------------------------------
+
+
+def expected_documents_fingerprint(expected_documents: list[str]) -> str:
+    """A fingerprint of a candidate's ground truth *set*, independent of
+    ordering (`sorted(...)`). Part of the `CURATED_CASES` triple — see the
+    comment block above that list for why `natural_key` and `query` alone
+    are not enough (issue #274, follow-up review, finding 2)."""
+    return hashlib.sha256("|".join(sorted(expected_documents)).encode("utf-8")).hexdigest()
 
 
 def to_json(candidate: Candidate) -> dict:
@@ -1203,29 +1247,47 @@ def main() -> None:
 
     by_key = {c.natural_key: c for c in all_candidates}
     missing: list[str] = []
-    changed: list[tuple[str, str, str]] = []
+    query_changed: list[tuple[str, str, str]] = []
+    ground_truth_changed: list[tuple[str, list[str], list[str]]] = []
     curated: list[Candidate] = []
-    for natural_key, expected_query in CURATED_CASES:
+    for natural_key, expected_query, expected_fingerprint in CURATED_CASES:
         candidate = by_key.get(natural_key)
         if candidate is None:
             missing.append(natural_key)
             continue
         if candidate.query != expected_query:
-            changed.append((natural_key, expected_query, candidate.query))
+            query_changed.append((natural_key, expected_query, candidate.query))
+            continue
+        actual_fingerprint = expected_documents_fingerprint(candidate.expected_documents)
+        if actual_fingerprint != expected_fingerprint:
+            # natural_key and query text are both unchanged, but the ground
+            # truth itself now resolves to a different set of documents —
+            # issue #274, follow-up review finding 2 (reproduced live by
+            # adding "Reality Warping" to comic-0001_3-d-man.md and
+            # re-running: comic-filter-001 silently went from n=7 to n=8
+            # with exit code 0 before this check existed).
+            ground_truth_changed.append((natural_key, [], candidate.expected_documents))
             continue
         curated.append(candidate)
-    if missing or changed:
+    if missing or query_changed or ground_truth_changed:
         problems = []
         if missing:
             problems.append(
                 f"{len(missing)} natural_key(s) in CURATED_CASES no longer exist in the "
                 f"generated candidates (corpus or generator changed?): {missing[:10]}"
             )
-        if changed:
+        if query_changed:
             problems.append(
-                f"{len(changed)} natural_key(s) in CURATED_CASES still exist but now generate "
-                f"a different query than what was curated (generator logic changed underneath "
-                f"an unchanged-looking selection?): {changed[:5]}"
+                f"{len(query_changed)} natural_key(s) in CURATED_CASES still exist but now "
+                f"generate a different query than what was curated (generator logic changed "
+                f"underneath an unchanged-looking selection?): {query_changed[:5]}"
+            )
+        if ground_truth_changed:
+            problems.append(
+                f"{len(ground_truth_changed)} natural_key(s) in CURATED_CASES still generate "
+                f"the same query, but a different expected_documents set (the ground truth "
+                f"itself changed — e.g. a matching-logic change shifted which entities qualify): "
+                f"{[(key, sorted(docs)) for key, _, docs in ground_truth_changed[:5]]}"
             )
         raise SystemExit(
             "Golden dataset curation is stale:\n- "

--- a/eval/golden/README.md
+++ b/eval/golden/README.md
@@ -1,7 +1,8 @@
 # Golden Dataset: Domäne Comichelden
 
-Das Golden Dataset für die Domäne `comic-characters` (Issue #226, gemergt in PR #273; Review-
-Nachziehbedarf in Issue #274, dieser Stand). Spezifikation in
+Das Golden Dataset für die Domäne `comic-characters` (Issue #226, gemergt in PR #273; erste Runde
+Review-Nachziehbedarf in Issue #274/PR #277, gemergt; zweite Runde — Sentinel-Feldbezogenheit und
+Ground-Truth-Fingerabdruck — in Issue #282, dieser Stand). Spezifikation in
 [`docs/features/search-quality-evaluation.md`](../../docs/features/search-quality-evaluation.md),
 Abschnitt „Golden Dataset"; [ADR-0011](../../docs/decisions/0011-search-quality-evaluation-harness.md).
 Es ist die Ground Truth für den Retrieval-Regressionstest aus #227.
@@ -95,24 +96,42 @@ Sentinel-Tabelle für `comic-characters` (sechs numerisch verwendete Felder):
 | `speed_score` | keine | s. u. |
 | `durability_score` | keine | s. u. |
 | `combat_score` | keine | s. u. |
-| `overall_score` | `null`, `"∞"` | `numeric_range` auf `overall_score` selbst: beide vor Fenster-/Schwellenwertbestimmung ausgeschlossen (`Entity.is_scored` ist `isinstance(overall_score, int)` — schließt `null` und `"∞"` in einem Test aus) |
+| `overall_score` | `null`, `"∞"` | `numeric_range` auf `overall_score` selbst: beide vor Fenster-/Schwellenwertbestimmung ausgeschlossen (`Entity.has_numeric_overall` ist `isinstance(overall_score, int)` — schließt `null` und `"∞"` in einem Test aus) |
 
 **Cross-Field-Ausnahme, klar von der Sentinel-Regel zu unterscheiden:** Die fünf Attributwerte
 haben selbst keinen Sentinel. Sie werden trotzdem zusätzlich über `overall_score is not null`
-gefiltert (`Entity.is_scored` in `generate_numeric_range`s `scored_entities`) — nicht weil sie
-selbst einen Sentinel führen, sondern weil 104 der 105 `overall_score: null`-Dokumente im Fließtext
+gefiltert (`Entity.is_rated` in `generate_numeric_range`s `scored_entities`) — nicht weil sie selbst
+einen Sentinel führen, sondern weil 104 der 105 `overall_score: null`-Dokumente im Fließtext
 wortwörtlich „scores 0 for intelligence, 0 for strength, …" enthalten (Review-Fund aus #226): Dieser
 Text ist für die fünf Attributfragen kontaminiert, unabhängig vom Sentinel-Konzept.
 `overall_score: "∞"`-Entitäten tragen **keine** solche Kontamination — ihre fünf Attributwerte sind
 gewöhnliche, vertrauenswürdige Zahlen — und werden deshalb korrekt **nicht** aus den
 Attributwert-Fragen ausgeschlossen.
 
-Verifiziert (Issue #274, Klarstellung des Product Managers zur ursprünglichen Formulierung): Beide
-Eigenschaften (feldbezogen, vor Fensterbestimmung) galten bereits in der Implementierung aus PR
-#273 korrekt — `overall_ints`/`Entity.is_scored` filterten schon vor der Schwellenwertwahl und
-berührten nie die fünf Attributfelder. Geändert wurden in #274 nur die Kommentare/Dokumentation, um
-die beiden Regeln unmissverständlich zu trennen, plus `is_scored`s Docstring, der jetzt explizit
-macht, dass er zwei verschiedene Zwecke mit zwei verschiedenen Geltungsbereichen bedient.
+**Korrektur (Issue #282, zweite Review-Runde nach #277):** Die #277-Fassung dieses READMEs behauptete
+an dieser Stelle, beide Eigenschaften hätten bereits in der PR-#273-Implementierung korrekt gegolten.
+Das war sachlich falsch. Tatsächlich hatte der #277-Fix von Issue #274 `Entity.is_scored` (Stand
+#273: `overall_score is not None`) auf ein einziges `isinstance(overall_score, int)`-Prädikat
+geändert und dieses sowohl für `scored_entities` (die Cross-Field-Regel) als auch für `overall_ints`
+(die `overall_score`-Sentinel-Regel selbst) wiederverwendet. Dadurch schlossen die 18
+`overall_score: "∞"`-Entitäten seit dieser Änderung auch aus den fünf Attributwert-Fragen aus —
+genau die Feldbezogenheit verletzend, die oben gefordert ist.
+
+Behoben durch zwei getrennte Prädikate: `Entity.is_rated` (`overall_score is not None`) für die
+Cross-Field-Regel auf den fünf Attributen, `Entity.has_numeric_overall`
+(`isinstance(overall_score, int)`) für die Sentinel-Regel auf `overall_score` selbst. Code und
+Dokumentation stimmen jetzt überein.
+
+**Datenwirkung, selbst nachgerechnet:** keine. Unabhängig von der Codeänderung geprüft: Die Menge
+der Entitäten, die durch den Prädikat-Fix neu in den `scored_entities`-Pool aufgenommen werden (also
+zuvor fälschlich ausgeschlossen waren), umfasst genau die 18 `"∞"`-Figuren. Ihre niedrigsten Werte
+je Attribut liegen bei 95 (Intelligenz), 100 (Stärke), 100 (Geschwindigkeit), 85
+(Widerstandsfähigkeit) und 50 (Kampf) — alle über jeder in `BELOW_THRESHOLDS_BY_ATTRIBUTE`
+verwendeten Schwelle (maximal 50). Kein aktueller Rohkandidat und kein kuratierter Fall ändert sich
+dadurch; `git diff` von `comic-characters.json` und `comic-characters.candidates.json` gegen den
+Stand vor dem Prädikat-Fix ist leer. In einer künftigen Domäne mit niedrigen Attributwerten bei
+Sentinel-Entitäten (#234) hätte der ursprüngliche Fehler dagegen falsche Ground Truth erzeugt — dann
+wäre die Feldbezogenheit nicht nur dokumentarisch, sondern faktisch verletzt gewesen.
 
 **Bekannter Rest, außerhalb dieses Umfangs:** Der Ausschluss in der Ground Truth repariert nicht den
 Widerspruch im Korpus-Text selbst — „scores 0 for intelligence, …" (bei `null`) und „his overall
@@ -249,28 +268,54 @@ nachfolgenden `id`s — `comic-attr-101` existiert weiterhin, fragt aber eine an
 möglicherweise ein anderes Feld ab. Der ursprüngliche Guard prüfte nur, ob die `id` **existiert**,
 nicht, ob sie noch **dasselbe** bezeichnet.
 
-Behoben: Die Auswahl (`CURATED_CASES` in `generate_golden_dataset.py`) besteht jetzt aus
-(`natural_key`, `query`)-Paaren. `natural_key` wird ausschließlich aus den erzeugenden Parametern
-abgeleitet (Feld/Entität-Dateiname, Vorlagenindex/Entität-Dateiname,
-Alignment/Creator/Fähigkeit-Tripel, Feld/Operator/Schwellenwert) — nie aus der Position in einer
-Liste — und identifiziert damit „denselben" Kandidaten unabhängig davon, wie viele andere Kandidaten
-um ihn herum existieren. `main()` prüft beim Lauf:
+Behoben: Die Auswahl (`CURATED_CASES` in `generate_golden_dataset.py`) besteht aus
+(`natural_key`, `query`, `expected_documents`-Fingerabdruck)-Tripeln. `natural_key` wird
+ausschließlich aus den erzeugenden Parametern abgeleitet (Feld/Entität-Dateiname,
+Vorlagenindex/Entität-Dateiname, Alignment/Creator/Fähigkeit-Tripel,
+Feld/Operator/Schwellenwert) — nie aus der Position in einer Liste — und identifiziert damit
+„denselben" Kandidaten unabhängig davon, wie viele andere Kandidaten um ihn herum existieren.
+`main()` prüft beim Lauf:
 
 1. **Kollisionsfreiheit**: kein `natural_key` taucht bei zwei verschiedenen Kandidaten auf (harter
    Abbruch bei Verletzung — Absicherung dafür, dass ein künftiges Feld/eine künftige Vorlage die
    Eindeutigkeit nicht versehentlich verletzt).
 2. **Existenz**: jeder `natural_key` aus `CURATED_CASES` muss unter den aktuell generierten
    Kandidaten auftauchen — sonst bricht der Lauf mit den fehlenden Schlüsseln ab.
-3. **Fingerabdruck**: der zur `natural_key` gehörende Kandidat muss exakt die kuratierte
+3. **Fragetext**: der zur `natural_key` gehörende Kandidat muss exakt die kuratierte
    `query`-Zeichenkette tragen — sonst bricht der Lauf ab, weil sich die erzeugende Logik unter einer
    unverändert aussehenden Auswahl geändert hat.
+4. **Ground-Truth-Fingerabdruck** (Issue #282, zweite Review-Runde nach #277, Fund 2): `natural_key` und `query`
+   fangen eine dritte Drift-Form nicht ab — die Erwartungsmenge (`expected_documents`) ändert sich,
+   während beide identisch bleiben. Der Reviewer stellte das gezielt nach: `comic-0001_3-d-man.md`
+   um die Fähigkeit „Reality Warping" ergänzt (also den Korpus manipuliert, um eine
+   Matching-Logik-Änderung zu simulieren) und den Generator laufen lassen —
+   `comic-filter-001` ging von 7 auf 8 Treffer, `EXITCODE = 0`, `comic-characters.json` wurde still
+   neu geschrieben. Der realistische Auslöser ist nicht der Korpus (den schützt
+   `MANIFEST.sha256`), sondern eine Generatoränderung — z. B. ein robusterer Parser als das
+   aktuelle `.split(", ")` für `superpowers`.
 
-**Verifiziert** (nicht nur behauptet): Beide Fehlerpfade wurden gezielt provoziert und lösten den
-erwarteten kontrollierten Abbruch aus — ein `natural_key` mit geänderter erwarteter `query` bricht
-mit „still exist but now generate a different query"; ein aus `CURATED_CASES` entfernter
-`natural_key`, der in keinem Kandidaten mehr vorkommt, bricht mit „no longer exist in the generated
-candidates". Beide Testläufe wurden mit einer temporären Kopie des Skripts durchgeführt, nicht mit
-dem committeten Code.
+   Behoben durch ein drittes Tripel-Element: `sha256("|".join(sorted(expected_documents)))`
+   (`expected_documents_fingerprint()`), ordnungsunabhängig über die Menge der erwarteten
+   Dokumente. `main()` berechnet ihn für den zur `natural_key` gehörenden Live-Kandidaten neu und
+   bricht ab, wenn er nicht mit dem kuratierten Fingerabdruck übereinstimmt.
+
+**Verifiziert** (nicht nur behauptet, alle drei Fehlerpfade einzeln provoziert):
+
+- Geänderte erwartete `query` → Abbruch mit „still exist but now generate a different query".
+- Aus `CURATED_CASES` entfernter `natural_key` → Abbruch mit „no longer exist in the generated
+  candidates".
+- **Der vom Reviewer nachgestellte Fall selbst reproduziert**: `comic-0001_3-d-man.md`s
+  `superpowers` im Korpus temporär um „Reality Warping" ergänzt (nicht committet, per `sha256sum -c
+  MANIFEST.sha256` nach dem Zurücksetzen als unverändert bestätigt), Generator laufen lassen — Ergebnis
+  jetzt: Abbruch mit „still generate the same query, but a different expected_documents set" für
+  `filter::Good::Marvel Comics::Reality Warping` **und** dessen `crosslingual`-Übersetzung
+  (`de::filter::Good::Marvel Comics::Reality Warping`) — der Fehler propagiert korrekt durch beide
+  Kategorien, weil die deutsche Übersetzung denselben `natural_key`-Stamm referenziert. `EXITCODE = 1`,
+  `comic-characters.json` wird nicht überschrieben.
+
+Die ersten beiden Testläufe liefen mit einer temporären Kopie des Skripts, der dritte — die direkte
+Nachstellung des Reviewer-Falls — mit dem committeten Code gegen eine temporär veränderte, danach
+wieder zurückgesetzte Korpusdatei.
 
 ### Warum keine `discarded.json`
 
@@ -337,8 +382,10 @@ Sieben kuratierte Fälle wurden unabhängig vom Generator-Code gegen den Korpus 
 | Kontrolle zur Kontaminationsschwelle | `comic-0226_brainiac-5.md`/`comic-0498_gambit.md` explizit gegen die Plausibilitätsprüfung getestet | beide korrekt als unplausibel erkannt |
 | `desc::2::comic-1224_starfire.md` (Neuauswahl nach der `occupation`-Gewichtung) | Geburtsort/Beruf/Augenfarbe unabhängig gegen alle 1.448 Dateien geprüft | genau 1 Treffer, `comic-1224_starfire.md` |
 | Case-Insensitivitäts-Fix | Nach der Normalisierung: `comic-characters.candidates.json` auf doppelte `entity_description`-Fragen/Ground-Truth-Dateien geprüft | 60 Fragen, 60 eindeutige Ground-Truth-Dateien — keine neuen Mehrdeutigkeiten |
-| Fingerabdruck-Guard | Zwei künstlich provozierte Abweichungen (geänderte `query`, entfernter `natural_key`) gegen eine temporäre Kopie des Skripts | beide lösten den erwarteten kontrollierten Abbruch aus |
-| Determinismus | Generator zweimal hintereinander laufen lassen, `diff` beider Ausgaben (nach allen #274-Fixes erneut geprüft) | byte-identisch |
+| `is_rated`/`has_numeric_overall`-Trennung | Menge der Entitäten verglichen, die vor/nach dem Prädikat-Fix in `scored_entities` (fünf Attributfragen) landen; niedrigste Attributwerte der 18 neu betroffenen `"∞"`-Entitäten je Feld ermittelt | Differenzmenge = exakt die 18 `"∞"`-Entitäten; niedrigste Werte 95/100/100/85/50, alle über jeder verwendeten Schwelle (max. 50) — `comic-characters.json` und `.candidates.json` vor/nach dem Fix per `git diff` verglichen: keine Änderung |
+| Fingerabdruck-Guard (Query/Existenz) | Zwei künstlich provozierte Abweichungen (geänderte `query`, entfernter `natural_key`) gegen eine temporäre Kopie des Skripts | beide lösten den erwarteten kontrollierten Abbruch aus |
+| Fingerabdruck-Guard (Ground Truth) | Vom Reviewer nachgestellter Fall selbst reproduziert: `comic-0001_3-d-man.md`s `superpowers` im Korpus temporär um „Reality Warping" ergänzt, Generator mit dem committeten Code laufen lassen, danach Korpusdatei zurückgesetzt und per `sha256sum -c MANIFEST.sha256` als unverändert bestätigt. Auf dem `#282`-Branch (Rebase auf `main` nach dem #277-Merge) erneut mit dem tatsächlich committeten Stand wiederholt, nicht nur einmalig auf dem ursprünglichen Branch | Abbruch mit „still generate the same query, but a different expected_documents set" für `filter::Good::Marvel Comics::Reality Warping` und dessen `crosslingual`-Übersetzung, `EXITCODE = 1`, `comic-characters.json` nicht überschrieben — beide Male identisch |
+| Determinismus | Generator zweimal hintereinander laufen lassen, `diff` beider Ausgaben (nach allen #274- und #282-Fixes erneut geprüft) | byte-identisch |
 
 Keiner der sieben ursprünglichen Fälle musste korrigiert werden; die Nachrechnung bestätigt, dass
 die Ground-Truth-Berechnung — nicht nur der Code, der sie aufruft — richtig ist. Die drei


### PR DESCRIPTION
## Zusammenfassung

Behebt die zwei verbliebenen Befunde der zweiten Review-Runde von PR #277 (Golden Dataset). PR #277 wurde gemergt, bevor diese zwei Korrekturen gepusht werden konnten — Issue #274 ist dadurch bereits geschlossen; die verbliebene Arbeit läuft unter dem neuen Issue #282. Dieser PR basiert auf dem aktuellen `main` (nach dem #277-Merge) und cherry-pickt den bereits fertigen, aber nicht mehr mergbaren Fix vom alten Branch.

## Zugehörige Issues

Closes #282

## Zwingende Befunde

### 1. Sentinel-Regel war nicht feldbezogen, trotz gegenteiliger Dokumentation

`Entity.is_scored` (Stand auf `main` nach #277) war ein einziges Prädikat `isinstance(overall_score, int)`, verwendet sowohl für `scored_entities` (Cross-Field-Regel auf den fünf Attributwerten) als auch für `overall_ints` (die `overall_score`-Sentinel-Regel selbst). Dadurch schlossen die 18 `overall_score: "∞"`-Figuren seit #277 auch aus Fragen über `intelligence_score` usw. aus — die vom Product Manager geforderte Feldbezogenheit war verletzt, obwohl Code-Kommentar und README das Gegenteil behaupteten.

**Fix:** Zwei getrennte Prädikate — `is_rated` (`overall_score is not None`) für die Cross-Field-Regel, `has_numeric_overall` (`isinstance(..., int)`) für die `overall_score`-Sentinel-Regel selbst.

**Datenwirkung, selbst nachgerechnet:** keine. Die 18 betroffenen Figuren haben je Attribut mindestens 95/100/100/85/50 — alle über jeder verwendeten Schwelle (max. 50). `comic-characters.json` und `.candidates.json` sind vor/nach dem Fix identisch (`git diff` leer).

### 2. Fingerabdruck erfasste die Treffermenge nicht

Das `(natural_key, query)`-Tupel erkannte Umnummerierung und geänderten Fragetext, aber nicht den Fall, dass `expected_documents` sich ändert, während beide gleich bleiben. Der Reviewer stellte das nach: `comic-0001_3-d-man.md`s `superpowers` um „Reality Warping" ergänzt — `comic-filter-001` ging von `n=7` auf `n=8`, `EXITCODE=0`, Datei wurde still neu geschrieben.

**Fix:** Drittes Tripel-Element `sha256("|".join(sorted(expected_documents)))` (`expected_documents_fingerprint()`), in der Validierungsschleife geprüft.

**Selbst reproduziert, auf diesem Branch erneut mit dem tatsächlich committeten Code:** Korpusdatei temporär um „Reality Warping" ergänzt, Generator laufen lassen → Abbruch mit „still generate the same query, but a different expected_documents set" für `filter::Good::Marvel Comics::Reality Warping` **und** dessen `crosslingual`-Übersetzung, `EXITCODE=1`, Datei nicht überschrieben. Korpusdatei danach per `git checkout` zurückgesetzt, `git status` bestätigt keine verbleibende Änderung.

## Was von der vorherigen Arbeit bereits auf `main` lag

Der erste Fix-Commit (`ec04a55`, Case-Insensitivität, Entitäts-Konzentration, crosslingual-Gruppensampling, `discarded.json`-Entfernung, ADR-Referenzen, `(natural_key, query)`-Fingerabdruck ohne Treffermengen-Prüfung) war bereits Teil des gemergten PR #277 und liegt auf `main`. Nur der zweite, in dieser Session direkt danach erstellte Commit (die zwei hier beschriebenen Korrekturen) wurde noch nicht gemergt, weil er erst nach dem #277-Merge gepusht wurde. Dieser PR bringt genau diesen zweiten Commit (per Cherry-Pick sauber auf aktuelles `main` angewendet, keine Konflikte) plus README-Präzisierungen zur korrekten Issue-Zuordnung.

## Pre-Push-Checkliste

Diff liegt vollständig außerhalb von `backend/`/`frontend/` (reines Python-Werkzeug unter `eval/`). Backend-/Frontend-Schritte übersprungen; stattdessen: Generator zweimal laufen lassen (byte-identisch), automatische `validate_curated()`-Prüfung, der vom Reviewer nachgestellte Fall auf diesem Branch mit dem committeten Code erneut provoziert und verifiziert, Korpus nach dem Test unverändert (`git status`/`git checkout`).

## Checkliste

- [x] Tests bestehen lokal (Determinismus, automatische Validierung, erneut provozierter Guard-Fehlerfall)
- [x] Dokumentation aktualisiert (`eval/golden/README.md`)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits in PR #273 signiert)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Sonnet 5, QA-Engineer-Rolle, Claude Code)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
