### PR TITLE
fix(auth): Erstanmeldung nach #280 wieder funktionsfähig machen

### DIFF
--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -10,6 +10,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @Profile({"oidc", "basic"})
@@ -53,8 +55,39 @@ public class UserService {
                   return userRepository.save(newUser);
                 });
 
-    spaceService.ensurePersonalSpace(user.getId(), user.getOrganizationId());
+    ensurePersonalSpaceAfterCommit(user.getId(), user.getOrganizationId());
     return user;
+  }
+
+  /**
+   * Runs {@link SpaceService#ensurePersonalSpace} only after this method's own transaction has
+   * committed the {@code users} row.
+   *
+   * <p>{@code findOrCreateUser} is {@code @Transactional} and inserts the new user in a still-open
+   * transaction. {@code ensurePersonalSpace} inserts the personal space in its own {@code
+   * REQUIRES_NEW} transaction (see its Javadoc), which runs on a separate connection with its own
+   * snapshot - a call from inside the still-open outer transaction cannot see the uncommitted
+   * {@code users} row there, so the insert violated {@code fk_spaces_owner} and the whole login
+   * failed (regression from #265, fixed in #280 follow-up). Deferring the call to {@link
+   * TransactionSynchronization#afterCommit()} guarantees the user row is already committed and
+   * visible on any connection by the time the personal space is created.
+   *
+   * <p>Falls back to an immediate, synchronous call when no transaction synchronization is active -
+   * this keeps {@code UserServiceTest} working without a real Spring-managed transaction, and would
+   * also apply if this method were ever called outside of a transactional context.
+   */
+  private void ensurePersonalSpaceAfterCommit(UUID userId, UUID organizationId) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              spaceService.ensurePersonalSpace(userId, organizationId);
+            }
+          });
+    } else {
+      spaceService.ensurePersonalSpace(userId, organizationId);
+    }
   }
 
   public Optional<User> findBySubjectAndIssuer(String subject, String issuer) {

--- a/backend/src/main/java/io/opaa/space/SpaceService.java
+++ b/backend/src/main/java/io/opaa/space/SpaceService.java
@@ -270,6 +270,14 @@ public class SpaceService {
    * transaction that performed the insert would leave every subsequent statement in that
    * transaction failing too. The loser then simply reads the space the winner created instead of
    * surfacing a 500.
+   *
+   * <p><b>Caller requirement:</b> because the insert runs on its own connection, {@code userId}
+   * must already be committed and visible to other connections when this method is called - not
+   * merely persisted in a still-open transaction. Calling this from inside the same transaction
+   * that first creates the user row will fail with a {@code fk_spaces_owner} violation, because the
+   * {@code REQUIRES_NEW} connection cannot see the uncommitted row (regression fixed as a follow-up
+   * to #265/#280; see {@code UserService#ensurePersonalSpaceAfterCommit}, which defers this call to
+   * a post-commit hook for exactly this reason).
    */
   public void ensurePersonalSpace(UUID userId, UUID organizationId) {
     if (spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)) {

--- a/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
@@ -1,0 +1,171 @@
+package io.opaa.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.opaa.space.Space;
+import io.opaa.space.SpaceKind;
+import io.opaa.space.SpaceRepository;
+import io.opaa.space.SpaceService;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Exercises {@link UserService#findOrCreateUser} against a real Postgres database with the real,
+ * versioned Liquibase schema applied ({@code spring.liquibase.enabled=true}, {@code ddl-auto=none})
+ * - not against Hibernate-generated DDL, and not with a mocked transaction manager. This is
+ * deliberate: the regression this test guards against (follow-up to #265/#280) only manifests with
+ * real foreign-key constraints and real, separately committed transactions. Neither {@code
+ * SpaceServiceIntegrationTest} (Hibernate {@code ddl-auto=create-drop}; plain UUID columns like
+ * {@code Space.ownerId} get no foreign key at all under that regime) nor {@code SpaceServiceTest}
+ * (mocked {@link org.springframework.transaction.PlatformTransactionManager} - no real connection,
+ * no real propagation, no real visibility semantics) can exercise it.
+ *
+ * <p><b>The regression:</b> {@code SpaceService.ensurePersonalSpace} (#265) runs its insert in its
+ * own {@code REQUIRES_NEW} transaction, on its own connection with its own snapshot, so that a
+ * constraint violation there does not poison the caller's transaction. {@code
+ * UserService.findOrCreateUser} is itself {@code @Transactional} and - before this fix - called
+ * {@code ensurePersonalSpace} from inside that still-open transaction. The {@code users} row it had
+ * just inserted was not committed yet, so it was invisible on the {@code REQUIRES_NEW} connection,
+ * and the personal-space insert failed on {@code fk_spaces_owner} for every single first login (not
+ * just concurrent ones) - the whole outer transaction then rolled back, so not even the user was
+ * created. {@link #firstLoginCreatesUserAndPersonalSpaceWithoutError()} reproduces this with a
+ * single call and no concurrency at all. {@code UserService} now defers the {@code
+ * ensurePersonalSpace} call to a {@code TransactionSynchronization#afterCommit} callback,
+ * guaranteeing the user row is committed and visible by the time the personal space is created.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(UserServicePersonalSpaceIntegrationTest.PostgresTestConfiguration.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class UserServicePersonalSpaceIntegrationTest {
+
+  @TestConfiguration(proxyBeanMethods = false)
+  static class PostgresTestConfiguration {
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer postgresContainer() {
+      return new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+    }
+  }
+
+  @Autowired private UserService userService;
+  @Autowired private SpaceService spaceService;
+  @Autowired private SpaceRepository spaceRepository;
+  @Autowired private UserRepository userRepository;
+
+  @BeforeEach
+  void cleanUp() {
+    spaceRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  @Test
+  void firstLoginCreatesUserAndPersonalSpaceWithoutError() {
+    String subject = UUID.randomUUID().toString();
+
+    // A single, non-concurrent call is enough to reproduce the regression - see the class
+    // Javadoc. Before the fix, this threw a fk_spaces_owner DataIntegrityViolationException and no
+    // user was created at all.
+    assertThatCode(
+            () -> userService.findOrCreateUser(subject, "test-issuer", "user@example.com", "Test"))
+        .doesNotThrowAnyException();
+
+    User user = userRepository.findBySubjectAndIssuer(subject, "test-issuer").orElseThrow();
+    List<Space> spaces = spaceRepository.findDistinctByMembershipsUserId(user.getId());
+    assertThat(spaces).hasSize(1);
+    assertThat(spaces.getFirst().getKind()).isEqualTo(SpaceKind.PERSONAL);
+  }
+
+  @Test
+  void concurrentFirstLoginsOfDifferentUsersEachGetExactlyOnePersonalSpace() throws Exception {
+    // Two real, independent first logins racing end-to-end through UserService, with real
+    // connections and real commits - not SpaceService in isolation.
+    String subjectA = UUID.randomUUID().toString();
+    String subjectB = UUID.randomUUID().toString();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<User> loginA =
+          executor.submit(
+              () -> userService.findOrCreateUser(subjectA, "test-issuer", "a@example.com", "A"));
+      Future<User> loginB =
+          executor.submit(
+              () -> userService.findOrCreateUser(subjectB, "test-issuer", "b@example.com", "B"));
+
+      User userA = loginA.get(30, TimeUnit.SECONDS);
+      User userB = loginB.get(30, TimeUnit.SECONDS);
+
+      assertThat(spaceRepository.findDistinctByMembershipsUserId(userA.getId())).hasSize(1);
+      assertThat(spaceRepository.findDistinctByMembershipsUserId(userB.getId())).hasSize(1);
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  @Test
+  void concurrentEnsurePersonalSpaceCallsForTheSameAlreadyCommittedUserCreateExactlyOneSpace()
+      throws Exception {
+    // The race #265 actually targets: two concurrent calls for the SAME user, both starting after
+    // the user row is already committed - exactly what UserService's afterCommit hook now
+    // guarantees. Calling SpaceService directly (bypassing UserService) isolates the
+    // partial-unique-index race from the user-creation race exercised above.
+    User user =
+        userService.findOrCreateUser(
+            UUID.randomUUID().toString(), "test-issuer", "race@example.com", "Race");
+    spaceRepository.deleteAll();
+    assertThat(spaceRepository.findDistinctByMembershipsUserId(user.getId())).isEmpty();
+
+    int threadCount = 2;
+    CountDownLatch ready = new CountDownLatch(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      List<Future<?>> futures =
+          List.of(
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    spaceService.ensurePersonalSpace(user.getId(), user.getOrganizationId());
+                    return null;
+                  }),
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    spaceService.ensurePersonalSpace(user.getId(), user.getOrganizationId());
+                    return null;
+                  }));
+      ready.await();
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    assertThat(spaceRepository.findDistinctByMembershipsUserId(user.getId())).hasSize(1);
+  }
+}

--- a/docs/migrations/010-space-uniqueness-and-membership-index.md
+++ b/docs/migrations/010-space-uniqueness-and-membership-index.md
@@ -53,6 +53,19 @@ Transaktion, die den Insert ausgeführt hat, jede nachfolgende Anweisung in dies
 ebenfalls scheitern ließe. Details siehe Klassenkommentar auf
 `SpaceService.ensurePersonalSpace`.
 
+**Regression nach dem Merge (Fix-PR, Referenz statt eigener Nummer hier — siehe Git-Historie):**
+Die `REQUIRES_NEW`-Transaktion oben löst die Race zwischen zwei `ensurePersonalSpace`-Aufrufen,
+setzt aber voraus, dass die referenzierte `users`-Zeile zum Zeitpunkt des Inserts bereits committet
+ist — der Insert läuft auf einer eigenen Connection mit eigenem Snapshot. `UserService.findOrCreateUser`
+ist selbst `@Transactional` und legte die `users`-Zeile ursprünglich in derselben, noch offenen
+Transaktion an, bevor `ensurePersonalSpace` gerufen wurde. Die `REQUIRES_NEW`-Connection konnte die
+noch nicht committete Zeile nicht sehen, der Insert verletzte `fk_spaces_owner`, und da der Space
+tatsächlich nicht existierte, griff auch die Race-Behandlung nicht — jede Erstanmeldung scheiterte.
+Behoben, indem `UserService` den Aufruf von `ensurePersonalSpace` über
+`TransactionSynchronization#afterCommit` erst nach dem Commit der eigenen Transaktion ausführt.
+Siehe Klassenkommentar auf `UserService#ensurePersonalSpaceAfterCommit` und den Regressionstest
+`UserServicePersonalSpaceIntegrationTest` (echtes Postgres-Schema über Liquibase, `ddl-auto=none`).
+
 ### Fehlender Index auf `space_memberships.space_id` (#266)
 
 Der vorhandene Unique-Index `uk_space_memberships_user_space` führt mit `(user_id, space_id)` und


### PR DESCRIPTION
## Zusammenfassung

**Regression:** Nach dem Merge von #280 scheiterte jede Erstanmeldung. `UserService.findOrCreateUser` ist `@Transactional` und legte die `users`-Zeile in einer noch offenen Transaktion an, bevor `SpaceService.ensurePersonalSpace` gerufen wurde. `ensurePersonalSpace` führt seinen Insert seit #265/#280 in einer eigenen `REQUIRES_NEW`-Transaktion aus — auf einer eigenen Connection mit eigenem Snapshot, auf der die noch nicht committete `users`-Zeile unsichtbar war. Der Insert verletzte `fk_spaces_owner`, und da der Space tatsächlich nicht existierte, griff auch die Race-Behandlung aus #265 nicht: `raceLost` wurde weitergereicht, die äußere Transaktion rollte zurück, und nicht einmal der Nutzer wurde angelegt.

**Fix (Variante b aus der Meldung):** `UserService` verschiebt den Aufruf von `ensurePersonalSpace` jetzt über `TransactionSynchronization#afterCommit` auf den Zeitpunkt nach dem Commit der eigenen Transaktion. Damit ist die `users`-Zeile garantiert committet und für die `REQUIRES_NEW`-Connection sichtbar, wenn der persönliche Space angelegt wird. Ohne aktive Transaktions-Synchronisation (z. B. in reinen Mockito-Tests ohne echten Spring-Transaktionsproxy) erfolgt der Aufruf synchron wie zuvor — `UserServiceTest` bleibt dadurch unverändert grün.

**Warum es durch CI kam:** `SpaceServiceTest` mockt den `PlatformTransactionManager` und deckt nur den Catch-Block ab, nie echte Connection-Wechsel oder Sichtbarkeit. `SpaceServiceIntegrationTest` läuft mit `ddl-auto=create-drop`; `Space.ownerId` ist eine schlichte `UUID`-Spalte ohne `@ManyToOne`, Hibernate legt dafür keinen Fremdschlüssel an — alles FK-abhängige war dort blind.

**Pflichttest:** `UserServicePersonalSpaceIntegrationTest` — echtes Postgres mit dem realen, versionierten Liquibase-Schema (`spring.liquibase.enabled=true`, `ddl-auto=none`), ein Einzelaufruf-Test (reproduziert die Regression bereits ohne Nebenläufigkeit) sowie zwei Tests mit echten Threads (zwei parallele Erstanmeldungen verschiedener Nutzer; zwei parallele `ensurePersonalSpace`-Aufrufe für denselben bereits committeten Nutzer). Nachgewiesen: Der Test schlägt auf dem kaputten Stand (vor diesem Fix, direkt nach #280) mit `fk_spaces_owner`-Verletzung fehl und ist mit dem Fix grün.

**Nebenbefund zur Connection-Pool-Belegung:** Die `REQUIRES_NEW`-Transaktion überlappt jetzt nur noch mit dem kurzen Fenster zwischen physischem Commit und Ressourcen-Freigabe der äußeren Transaktion (`afterCommit` läuft, bevor `afterCompletion` die alte Connection freigibt), statt wie zuvor über die gesamte Dauer der äußeren Transaktion. Das entschärft die vom Melder genannte Sorge um gleichzeitig gehaltene Pool-Connections deutlich, beseitigt sie aber nicht vollständig.

**Blinder Fleck bei FK-abhängigen Tests:** `SpaceServiceIntegrationTest` und vergleichbare Tests mit `ddl-auto=create-drop` prüfen keine Fremdschlüssel-Constraints, weil reine `UUID`-Spalten ohne `@ManyToOne` unter Hibernate-generierter DDL keinen FK erhalten, Liquibase aber schon. Das melde ich separat an den Koordinator als Vorschlag für ein eigenes Issue (FK-abhängige Tests auf ein Liquibase-Schema umstellen, relevant für #201/#202) — lege es hier nicht selbst an.

## Zugehörige Issues

Refs #265
Refs #280

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code, Developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst