### PR TITLE
fix(ci): Fehlzuordnungen im Epic-Report beheben

### DIFF
--- a/.github/scripts/daily_report.py
+++ b/.github/scripts/daily_report.py
@@ -132,24 +132,67 @@ def search_issues(repo: str, qualifier: str) -> list[dict]:
     return items
 
 
-CLOSES_MUSTER = re.compile(
-    r"\b(?:closes|fixes|resolves|schliesst|schließt)\s+#(\d+)", re.IGNORECASE
-)
+# Ticketlisten in Epics folgen der Vorlage "- [ ] #123 titel". Die Nummer muss
+# unmittelbar auf die Checkbox folgen. Epic #60 nummeriert seine Befunde dagegen
+# als "- [ ] **#1 CORS Wildcard Headers**" — solche Marker sind keine
+# Issue-Referenzen und werden durch diese Bedingung ausgeschlossen.
+TICKET_MUSTER = re.compile(r"^\s*[-*]\s*\[[ xX]\]\s*#(\d+)\b", re.MULTILINE)
 
 
 def simplify_issue(item: dict) -> dict:
-    body = (item.get("body") or "").strip()
     return {
         "number": item["number"],
         "title": item["title"],
         "url": item["html_url"],
         "author": (item.get("user") or {}).get("login", ""),
         "labels": [label["name"] for label in item.get("labels", [])],
-        "body": body,
-        # Erlaubt es, einen Pull Request über das von ihm geschlossene Issue
-        # einem Epic zuzuordnen.
-        "closes": sorted({int(n) for n in CLOSES_MUSTER.findall(body)}),
+        "body": (item.get("body") or "").strip(),
+        # Wird für Pull Requests aus der von GitHub gepflegten Verknüpfung
+        # nachgetragen, siehe `add_closing_references`.
+        "closes": [],
     }
+
+
+def add_closing_references(repo: str, pull_requests: list[dict]) -> None:
+    """Trägt die von GitHub verknüpften Issues in die Pull Requests ein.
+
+    Ein Ausdruck auf `Closes #N` im Body ist dafür untauglich: PR-Beschreibungen
+    enthalten solche Zeichenfolgen auch als Beispiel oder Zitat. GitHub pflegt
+    die tatsächliche Verknüpfung selbst; sie wird hier in einer einzigen Abfrage
+    für alle Pull Requests des Tages geholt.
+    """
+    if not pull_requests:
+        return
+
+    besitzer, name = repo.split("/", 1)
+    felder = "\n".join(
+        f'    p{pr["number"]}: pullRequest(number: {pr["number"]}) '
+        "{ closingIssuesReferences(first: 20) { nodes { number } } }"
+        for pr in pull_requests
+    )
+    query = f'{{ repository(owner: "{besitzer}", name: "{name}") {{\n{felder}\n}} }}'
+
+    try:
+        antwort = json.loads(
+            subprocess.run(
+                ["gh", "api", "graphql", "-f", f"query={query}"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+            ).stdout
+        )
+        daten = (antwort.get("data") or {}).get("repository") or {}
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"Verknüpfte Issues nicht abrufbar: {error}", file=sys.stderr)
+        return
+
+    for pull_request in pull_requests:
+        knoten = (daten.get(f"p{pull_request['number']}") or {}).get(
+            "closingIssuesReferences"
+        ) or {}
+        pull_request["closes"] = sorted(
+            eintrag["number"] for eintrag in knoten.get("nodes", [])
+        )
 
 
 def pull_request_stats(repo: str, number: int) -> dict:
@@ -201,22 +244,34 @@ def collect_epics(repo: str) -> list[dict]:
         print(f"Epics konnten nicht erhoben werden: {error}", file=sys.stderr)
         return []
 
-    status_je_nummer = {
-        item["number"]: item.get("state", "open")
+    # Die Issue-Liste enthält auch Pull Requests; diese sind keine Tickets.
+    nur_issues = [
+        item
         for item in alle
-        if isinstance(item, dict) and "number" in item
+        if isinstance(item, dict) and "number" in item and "pull_request" not in item
+    ]
+    status_je_nummer = {item["number"]: item.get("state", "open") for item in nur_issues}
+    bekannte_issues = set(status_je_nummer)
+    epic_nummern = {
+        item["number"]
+        for item in nur_issues
+        if "epic" in {label["name"] for label in item.get("labels", [])}
     }
 
     epics: list[dict] = []
-    for item in alle:
+    for item in nur_issues:
         labels = {label["name"] for label in item.get("labels", [])}
         if "epic" not in labels:
             continue
         tickets = sorted(
             {
                 int(nummer)
-                for nummer in re.findall(r"#(\d+)", item.get("body") or "")
+                for nummer in TICKET_MUSTER.findall(item.get("body") or "")
+                # Ein Epic ist kein Ticket eines anderen Epics, und eine Nummer
+                # ohne zugehöriges Issue ist ein Aufzählungsmarker.
                 if int(nummer) != item["number"]
+                and int(nummer) in bekannte_issues
+                and int(nummer) not in epic_nummern
             }
         )
         if not tickets:
@@ -332,6 +387,7 @@ def collect(repo: str, day: Date) -> dict:
         "ci": ci_status(repo),
         "summary": "",
     }
+    add_closing_references(repo, merged)
     ergebnis.update(assign_to_epics(ergebnis, collect_epics(repo)))
     return ergebnis
 

--- a/docs/tagesreport.md
+++ b/docs/tagesreport.md
@@ -41,9 +41,23 @@ native Sub-Issues im Repository nicht verwendet werden:
 | Schritt | Grundlage |
 | --- | --- |
 | Epics finden | Issues mit dem Label `epic` |
-| Tickets zuordnen | Issue-Nummern im Body des Epics |
-| Pull Requests zuordnen | das über `Closes #N` geschlossene Issue |
+| Tickets zuordnen | Checklisteneinträge `- [ ] #123 titel` im Body des Epics |
+| Pull Requests zuordnen | die von GitHub verknüpften Issues (`closingIssuesReferences`) |
 | Fortschritt | Anteil geschlossener Tickets der Liste |
+
+Damit ein Ticket erkannt wird, muss die Nummer **unmittelbar** auf die Checkbox
+folgen, so wie es die [Epic-Vorlage](../.github/ISSUE_TEMPLATE/epic.md) vorsieht.
+Eine Nummer im Fließtext ist ein Querverweis, kein Ticket. Zusätzlich muss die
+Nummer zu einem existierenden Issue gehören, und Epics zählen nicht als Tickets
+anderer Epics.
+
+Diese Genauigkeit ist nötig, weil `#N` in Markdown mehrdeutig ist: Epic #60
+nummeriert seine Befunde als `- [ ] **#1 CORS Wildcard Headers**`. Ohne die
+Bedingung würde daraus ein Epic mit zwanzig erfundenen Tickets.
+
+Aus demselben Grund wird für Pull Requests **nicht** der Body ausgewertet:
+Beschreibungen enthalten Zeichenfolgen wie `Closes #221` auch als Beispiel oder
+Zitat. Maßgeblich ist allein die Verknüpfung, die GitHub selbst pflegt.
 
 Ein Vorgang, der in keiner Ticketliste steht, wird **nicht** geraten, sondern
 unter „ohne Epic-Bezug" geführt. Wer die Zuordnung verbessern will, trägt die


### PR DESCRIPTION
## Zusammenfassung

Der erste Lauf der epic-orientierten Zusammenfassung (#286) zeigte drei Fehlzuordnungen. Alle gehen auf dieselbe Ursache zurück: Zugehörigkeiten wurden aus Fließtext geraten statt aus strukturierten Daten gelesen.

## Die drei Befunde

**1. Aufzählungsmarker als Ticketnummern**

Epic #60 nummeriert seine Befunde als `- [ ] **#1 CORS Wildcard Headers**`. Da die Issues #1 bis #20 längst geschlossen sind, erschien das Epic als „20 von 20 Tickets erledigt" — mit zwanzig Tickets, die es nie hatte.

**2. Erwähnungen im Fließtext als Tickets**

Jede Zahl der Form `#N` im Body zählte als Ticket. Epic #198 wurde dadurch als Ticket von Epic #224 geführt, weil #224 es im Text erwähnt. Statt 14 hatte #224 scheinbar 17 Tickets.

**3. Beispieltexte als Verknüpfung**

Am deutlichsten sichtbar an diesem PR-Vorgänger selbst: #286 beschreibt in seiner Prüfliste die Testfälle `Closes #221`, `fixes #12 und Closes #13` und `Schließt #99`. Alle wurden als echte Verknüpfungen gelesen:

```
PR #286 closes: [12, 13, 99, 221, 285]   ← vorher
PR #286 closes: [285]                     ← nachher
```

Über #12 landete der PR damit bei Epic #60.

## Die Änderung

| Bereich | vorher | nachher |
| --- | --- | --- |
| Ticketliste | jedes `#N` im Body | nur `- [ ] #123 titel`, Nummer direkt nach der Checkbox |
| Gültigkeit | jede Zahl | nur existierende Issues, keine Epics, keine Pull Requests |
| PR-Zuordnung | Ausdruck auf `Closes #N` im Body | `closingIssuesReferences` von GitHub |

Die Verknüpfungen aller Pull Requests eines Tages werden in **einer** GraphQL-Abfrage geholt.

## Wirkung auf die echten Daten

```
vorher                          nachher
#198  1/25                      #198  1/25
#224  4/17  ← 3 Querverweise    #224  4/14
#60  20/20  ← erfunden          (verschwunden)
```

Stichprobe der neuen Verknüpfungen: `#286 → [285]`, `#280 → [265, 266]`, `#278 → [276]`.

## Prüfung

Ticketmuster gegen die tatsächlich vorkommenden Formate:

| Eingabe | Ergebnis |
| --- | --- |
| `- [x] #225 \`feat(eval): …\`` | 225 |
| `- [ ] #227 \`test(eval): …\`` | 227 |
| `- [ ] **#1 CORS Wildcard Headers**` | keine — korrekt abgewiesen |
| `- [ ] **#14 Fehlende Tests**` | keine — korrekt abgewiesen |
| `Siehe auch #198 im Fließtext` | keine — korrekt abgewiesen |
| `  - [x]   #300  mit Leerraum` | 300 |

Außerdem: Reports im alten Format lassen sich weiterhin rendern, und eine leere PR-Liste erzeugt keine Abfrage.

## Zugehörige Issues

Closes #290

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (keine Anwendungsänderung; gegen die echten Repository-Daten und in sechs Musterfällen geprüft)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF