### PR TITLE
docs(agents): Branch-Regel klarstellen und Reproduktionsnachweis verbindlich machen

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,6 +1,7 @@
 # Git-Workflow-Regeln
 
 - Immer einen Feature-Branch erstellen; niemals direkt auf main committen
+- Branch-Format `feature/<issue-id>_<kurze-beschreibung>` — ausnahmslos, auch bei Fehlerbehebungen und dringenden Korrekturen; kein `fix/`- oder `hotfix/`-Präfix. Die Art der Änderung steht im Conventional-Commit-Typ, nicht im Branch-Namen
 - Conventional-Commits-Format für alle Commit-Nachrichten verwenden
 - Das PR-Template verwenden
 - PRs fokussiert halten: eine logische Änderung pro PR

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -6,6 +6,7 @@
 - Das PR-Template verwenden
 - PRs fokussiert halten: eine logische Änderung pro PR
 - Bei der Behebung eines Issues im PR-Body mit „Closes #N" referenzieren
+- Bei Fehlerbehebungen den **Reproduktionsnachweis** in die PR-Beschreibung aufnehmen: Test gegen den fehlerhaften Stand laufen lassen und das Fehlschlagen mit Fehlermeldung belegen, dann mit dem Fix erneut. Ein grüner Test allein beweist nicht, dass er den Fehler gefangen hätte (siehe `AGENTS.md`, Abschnitt „Reproduktionsnachweis")
 
 ## Git Worktrees für parallele Sessions
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Closes #
 ## Checkliste
 
 - [ ] Tests bestehen lokal
+- [ ] Bei Bugfix: Reproduktionsnachweis erbracht — der Test schlägt auf dem fehlerhaften Stand fehl und besteht mit dem Fix (rote Fehlermeldung unten einfügen)
 - [ ] Dokumentation aktualisiert (falls zutreffend)
 - [ ] Keine Secrets oder Anmeldeinformationen committet
 - [ ] Commit-Nachrichten folgen Conventional Commits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,8 +182,21 @@ Die Unterschrift wird automatisch erfasst und muss nur einmal pro GitHub-Account
 - Code nicht umstrukturieren, sofern nicht ausdrücklich verlangt
 - Vor dem Erstellen neuer Dateien prüfen, ob ähnliche Muster oder Hilfsfunktionen bereits existieren
 - Kleine, fokussierte Commits gegenüber großen bevorzugen
-- Bei der Behebung eines Bugs zuerst einen Test schreiben, der den Bug reproduziert
+- Bei der Behebung eines Bugs zuerst einen Test schreiben, der den Bug reproduziert — und **nachweisen, dass er auf dem fehlerhaften Stand tatsächlich fehlschlägt** (siehe [Reproduktionsnachweis](#reproduktionsnachweis))
 - `docs/decisions/` für Architecture Decision Records vor größeren strukturellen Änderungen lesen
+
+### Reproduktionsnachweis
+
+Ein Test, der den Fehler nicht fangen würde, ist wertlos — und das fällt am Ergebnis nicht auf, weil er ja grün ist.
+
+Deshalb gilt bei jeder Fehlerbehebung: Den Fix vorübergehend zurücknehmen, den Test laufen lassen, das Fehlschlagen belegen, den Fix wiederherstellen, erneut laufen lassen. **Beide Ergebnisse gehören in die PR-Beschreibung**, mit der konkreten Fehlermeldung des roten Laufs.
+
+Typische Ursachen dafür, dass ein Test den Fehler verfehlt:
+
+- **Er prüft eine Bedingung, die vor und nach dem Fix gilt** — etwa „irgendwann wurde invalidiert" statt „zum richtigen Zeitpunkt".
+- **Er läuft gegen ein anderes Schema als die Produktion.** Mit `ddl-auto=create-drop` erzeugt Hibernate keine Fremdschlüssel für einfache `UUID`-Spalten ohne `@ManyToOne`, Liquibase dagegen schon. Für alles FK-abhängige gehört `spring.liquibase.enabled=true` und `ddl-auto=none` in den Test.
+- **Er führt den geänderten Code gar nicht aus** — etwa Liquibase-Changelogs, die in den regulären Integrationstests nicht angewendet werden. Dafür gibt es das Muster in `backend/src/test/java/io/opaa/migration/`.
+- **Er mockt genau die Stelle weg, um die es geht** — ein gemockter `PlatformTransactionManager` führt keine Propagation aus, ein gemockter API-Client validiert keinen Request-Body.
 
 ## Sicherheit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,11 @@ Format: `feature/<issue-id>_<kurze-beschreibung>`
 Jeder Branch ist über seine ID mit einem GitHub-Issue verknüpft.
 
 **Branch-Regel (verbindlich):**
-- Branches immer mit `feature/` erstellen.
+- Branches immer mit `feature/` erstellen — **ausnahmslos**, auch bei Fehlerbehebungen, dringenden Korrekturen und Dokumentationsänderungen. Es gibt kein `fix/`-, `hotfix/`- oder `docs/`-Präfix.
 - Immer die GitHub-Issue-ID im Branch-Namen angeben.
 - Keine generischen Namen wie `feature/workspace` ohne Issue-ID verwenden.
+
+Die Art der Änderung wird über den Conventional-Commit-Typ ausgedrückt (`fix`, `docs`, `chore`, …), nicht über das Branch-Präfix — in der Commit-Nachricht und im PR-Titel. Ein Branch `feature/295_branch-regel-klarstellen` mit dem Commit `docs(agents): …` ist der Normalfall, kein Widerspruch.
 
 ### GitHub-Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ feature/7_add-contributing-guide
 
 Jeder Branch ist über seine ID mit einem GitHub-Issue verknüpft.
 
+Das Präfix `feature/` gilt ausnahmslos — auch für Fehlerbehebungen, dringende Korrekturen und Dokumentationsänderungen. Die Art der Änderung wird über den Conventional-Commit-Typ ausgedrückt (`fix`, `docs`, `chore`, …), wie im zweiten Beispiel oben.
+
 ## Commit-Nachrichten
 
 Wir verwenden [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):


### PR DESCRIPTION
## Zusammenfassung

Zwei Klarstellungen an den Agenten- und Workflow-Regeln, beide ausgelöst durch Befunde aus den Reviews zu Stufe A von #198.

### 1. Branch-Regel gilt ausnahmslos

Beim Hotfix in PR #287 wurde der Branch `fix/280_personal-space-transaction` verwendet. Die Regel in `AGENTS.md` war eindeutig, sagte aber nicht ausdrücklich, dass sie auch für Fehlerbehebungen gilt.

Entscheidung des Maintainers: **Alle** Branches beginnen mit `feature/`. Kein `fix/`-, `hotfix/`- oder `docs/`-Präfix. Die Art der Änderung wird über den Conventional-Commit-Typ ausgedrückt. In `CONTRIBUTING.md` stand mit `feature/15_fix-null-pointer` bereits ein passendes Beispiel — die Absicht war immer so gemeint, nur nicht ausgesprochen.

### 2. Reproduktionsnachweis bei Fehlerbehebungen

**Dreimal in Folge war der Produktivcode fehlerhaft und der zugehörige Test trotzdem grün:**

| PR | Fehler | Warum der Test ihn nicht fing |
|---|---|---|
| #254 | Migration brach auf nicht-leerem Bestand ab | Changelog wurde in den Tests nie ausgeführt |
| #280 | `REQUIRES_NEW` brach jede Erstanmeldung | Testschema kannte den Fremdschlüssel nicht |
| #283 | Cache-Invalidierung vor dem Commit | Test prüft eine Bedingung, die vor und nach dem Fix gilt |

Gefunden hat es jedes Mal erst der Code Reviewer — indem er den Fix zurückdrehte und schaute, ob der Test dann fehlschlägt. `AGENTS.md` verlangte bisher den reproduzierenden Test, aber nicht den Beleg, dass er den Fehler auch fängt.

Neu ist ein Abschnitt „Reproduktionsnachweis" mit den vier bisher beobachteten Ursachen für wirkungslose Tests, eine Regel in `.claude/rules/workflow.md` und ein Checklistenpunkt im PR-Template.

## Zugehörige Issues

Closes #295

## Art der Änderung

- [x] Dokumentation

## Checkliste

- [x] `AGENTS.md`, `.claude/rules/workflow.md`, `CONTRIBUTING.md` und das PR-Template tragen konsistente Aussagen
- [x] Reine Dokumentationsänderung, Pre-Push-Checkliste entfällt

## KI-Agenten-Offenlegung

Erstellt von Claude Opus 5 als Orchestrator, auf Weisung des Maintainers. Auslöser waren Befunde aus den Reviews zu PR #254, #280, #283 und #287.