### PR TITLE
feat(group): Verzeichnissynchronisation als Rechteereignis behandeln

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -109,6 +109,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SpaceVisibility" to "SpaceVisibility",
         "SystemRole" to "SystemRole",
         "GroupKind" to "GroupKind",
+        "DirectorySyncOutcome" to "DirectorySyncOutcome",
     ))
     importMappings.set(mapOf(
         "Instant" to "java.time.Instant",
@@ -117,6 +118,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SpaceVisibility" to "io.opaa.space.SpaceVisibility",
         "SystemRole" to "io.opaa.auth.SystemRole",
         "GroupKind" to "io.opaa.group.GroupKind",
+        "DirectorySyncOutcome" to "io.opaa.group.sync.DirectorySyncOutcome",
     ))
 }
 
@@ -125,7 +127,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         // Remove generated enum files that are mapped to existing domain enums via typeMappings.
         // The generator still creates these files even with typeMappings configured.
         val generatedDir = layout.buildDirectory.dir("generated/openapi/src/main/java/io/opaa/api/dto").get().asFile
-        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java").forEach { fileName ->
+        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java", "DirectorySyncOutcome.java").forEach { fileName ->
             file("$generatedDir/$fileName").delete()
         }
     }

--- a/backend/src/main/java/io/opaa/api/DirectorySyncController.java
+++ b/backend/src/main/java/io/opaa/api/DirectorySyncController.java
@@ -1,0 +1,64 @@
+package io.opaa.api;
+
+import io.opaa.api.dto.DirectorySyncReportResponse;
+import io.opaa.api.dto.DirectorySyncStatusResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserService;
+import io.opaa.group.sync.DirectorySyncService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Profile({"oidc", "basic"})
+@RestController
+@RequestMapping("/api/v1/admin/directory-sync")
+public class DirectorySyncController {
+
+  private static final String UNKNOWN_ISSUER = "unknown";
+
+  private final DirectorySyncService directorySyncService;
+  private final UserService userService;
+
+  public DirectorySyncController(
+      DirectorySyncService directorySyncService, UserService userService) {
+    this.directorySyncService = directorySyncService;
+    this.userService = userService;
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @PostMapping("/dry-run")
+  public DirectorySyncReportResponse dryRun(@AuthenticationPrincipal Jwt jwt) {
+    return directorySyncService.dryRun(currentUser(jwt).getOrganizationId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @PostMapping("/run")
+  public DirectorySyncReportResponse run(@AuthenticationPrincipal Jwt jwt) {
+    return directorySyncService.run(currentUser(jwt).getOrganizationId());
+  }
+
+  @PreAuthorize("hasRole('SYSTEM_ADMIN')")
+  @GetMapping("/status")
+  public DirectorySyncStatusResponse status(@AuthenticationPrincipal Jwt jwt) {
+    return directorySyncService.getStatus(currentUser(jwt).getOrganizationId());
+  }
+
+  private User currentUser(Jwt jwt) {
+    String issuer = jwt.getClaimAsString("iss");
+    if (issuer == null || issuer.isBlank()) {
+      issuer = UNKNOWN_ISSUER;
+    }
+
+    return userService
+        .findBySubjectAndIssuer(jwt.getSubject(), issuer)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
+  }
+}

--- a/backend/src/main/java/io/opaa/auth/UserRepository.java
+++ b/backend/src/main/java/io/opaa/auth/UserRepository.java
@@ -1,5 +1,7 @@
 package io.opaa.auth;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +10,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findBySubjectAndIssuer(String subject, String issuer);
 
   Optional<User> findByEmail(String email);
+
+  /**
+   * Resolves directory group members to their {@link User} rows for #237's directory
+   * synchronisation, scoped to the organization so a subject from another tenant can never be
+   * matched in - the same boundary {@code GroupMembershipRepository} enforces for group reads.
+   * Matches on {@code subject} alone (not {@code subject} + {@code issuer}): the MVP runs a single
+   * OIDC issuer per organization (see {@code AuthProperties}), and requiring an issuer here would
+   * force the directory sync to carry issuer configuration that duplicates what auth already knows.
+   */
+  List<User> findByOrganizationIdAndSubjectIn(UUID organizationId, Collection<String> subjects);
 }

--- a/backend/src/main/java/io/opaa/group/Group.java
+++ b/backend/src/main/java/io/opaa/group/Group.java
@@ -150,6 +150,16 @@ public class Group {
     this.dissolvedAt = null;
   }
 
+  /**
+   * Updates the parent organizational unit from directory synchronisation (#237). Applied in a
+   * second pass after every group in a sync run has a persisted id, so it works regardless of the
+   * order the directory reported groups in, and to existing groups (a reorganisation that reassigns
+   * a unit under a different parent), not only newly created ones.
+   */
+  public void updateParentGroup(UUID parentGroupId) {
+    this.parentGroupId = parentGroupId;
+  }
+
   public boolean isOrgUnit() {
     return this.kind == GroupKind.ORG_UNIT;
   }

--- a/backend/src/main/java/io/opaa/group/Group.java
+++ b/backend/src/main/java/io/opaa/group/Group.java
@@ -61,6 +61,19 @@ public class Group {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
 
+  /**
+   * Set when directory synchronisation (#237) no longer sees this {@link GroupKind#ORG_UNIT} in the
+   * directory - a merge or reorganisation, not a deletion. Existing grants to a dissolved group
+   * keep working for its current members; the group's membership is simply frozen at its
+   * last-known-good state and never grows again through synchronisation. Always {@code false} for
+   * {@link GroupKind#AD_HOC} groups, which have no directory counterpart to disappear from.
+   */
+  @Column(name = "dissolved", nullable = false)
+  private boolean dissolved;
+
+  @Column(name = "dissolved_at")
+  private Instant dissolvedAt;
+
   @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<GroupMembership> memberships = new ArrayList<>();
 
@@ -109,8 +122,40 @@ public class Group {
     this.description = description;
   }
 
+  /**
+   * Applies a rename that originates from the directory (#237), never from a user - only the name
+   * changes, because {@code description} is not a directory-owned field for {@link
+   * GroupKind#ORG_UNIT} groups.
+   */
+  public void renameFromDirectory(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Marks this group as no longer present in the directory (#237). Deliberately does not touch
+   * {@link #memberships} - the group's reach is frozen at its last-known-good state, not revoked.
+   */
+  public void dissolve(Instant dissolvedAt) {
+    this.dissolved = true;
+    this.dissolvedAt = dissolvedAt;
+  }
+
+  /**
+   * Reverses {@link #dissolve} when the directory reports this unit again after it had previously
+   * disappeared (a reorganisation that later un-did itself). Membership is resynchronised
+   * separately by the caller, the same way as for any other still-present group.
+   */
+  public void reactivate() {
+    this.dissolved = false;
+    this.dissolvedAt = null;
+  }
+
   public boolean isOrgUnit() {
     return this.kind == GroupKind.ORG_UNIT;
+  }
+
+  public boolean isDissolved() {
+    return this.dissolved;
   }
 
   public UUID getId() {
@@ -147,6 +192,10 @@ public class Group {
 
   public Instant getUpdatedAt() {
     return updatedAt;
+  }
+
+  public Instant getDissolvedAt() {
+    return dissolvedAt;
   }
 
   public List<GroupMembership> getMemberships() {

--- a/backend/src/main/java/io/opaa/group/GroupRepository.java
+++ b/backend/src/main/java/io/opaa/group/GroupRepository.java
@@ -20,4 +20,15 @@ public interface GroupRepository extends JpaRepository<Group, UUID> {
    * this check to decide "update" versus "create" for an incoming directory group.
    */
   boolean existsByOrganizationIdAndExternalId(UUID organizationId, String externalId);
+
+  /**
+   * All {@link GroupKind#ORG_UNIT} groups of an organization, with their memberships eagerly
+   * fetched - what {@link io.opaa.group.sync.DirectorySyncService} diffs the directory's snapshot
+   * against. {@link GroupKind#AD_HOC} groups are never touched by synchronisation and are excluded
+   * here rather than filtered by the caller.
+   */
+  @Query(
+      "select distinct g from Group g left join fetch g.memberships "
+          + "where g.organizationId = :organizationId and g.kind = io.opaa.group.GroupKind.ORG_UNIT")
+  List<Group> findByOrganizationIdAndKindOrgUnit(@Param("organizationId") UUID organizationId);
 }

--- a/backend/src/main/java/io/opaa/group/sync/DirectoryClient.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectoryClient.java
@@ -1,0 +1,24 @@
+package io.opaa.group.sync;
+
+import java.util.UUID;
+
+/**
+ * The single extension point between {@link DirectorySyncService}'s synchronisation policy and an
+ * actual directory (LDAP, Entra ID, a SCIM server, ...). {@link DirectorySyncService} is tested
+ * exhaustively against a test double of this interface; wiring a real directory is a
+ * deployment-specific concern (protocol, credentials, network reachability) outside this issue's
+ * scope, and the codebase ships {@link NoOpDirectoryClient} as the default bean so the application
+ * boots and behaves safely - permanently "unreachable", never a false "zero groups" - until an
+ * operator provides a real implementation.
+ */
+public interface DirectoryClient {
+
+  /**
+   * Reads the current, complete group list for an organization from the directory.
+   *
+   * @throws DirectoryUnavailableException if the directory cannot be reached or answered with an
+   *     error - never thrown for "the directory has no groups", which is a valid, empty {@link
+   *     DirectorySnapshot}.
+   */
+  DirectorySnapshot fetchGroups(UUID organizationId) throws DirectoryUnavailableException;
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectoryGroup.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectoryGroup.java
@@ -1,0 +1,34 @@
+package io.opaa.group.sync;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * One group as reported by the directory for a single synchronisation snapshot.
+ *
+ * @param externalId the directory's stable identifier for this group (objectGUID or SCIM {@code
+ *     externalId}) - what {@link DirectorySyncService} matches on instead of {@code name}, so a
+ *     rename in the directory never orphans a grant (see #237 and {@code io.opaa.group.Group}).
+ * @param name the group's current display name in the directory
+ * @param parentExternalId the parent organizational unit's {@code externalId}, or {@code null} at
+ *     the top of the hierarchy. Recorded on {@code Group.parentGroupId} for #208's curator
+ *     escalation only - {@link DirectorySyncService} deliberately does not resolve membership
+ *     transitively through it. A member of a child unit is not implicitly a member of its parent;
+ *     each group's membership is exactly what the directory reports as direct members of that
+ *     group. Nested-group membership inheritance is an open point in the feature spec and is
+ *     intentionally out of scope here rather than left unresolved silently.
+ * @param memberSubjects the OIDC {@code subject} (not the directory's own member identifier) of
+ *     every direct member, matched against {@code User.subject} scoped to the organization (see
+ *     {@code UserRepository#findByOrganizationIdAndSubjectIn}). A subject with no matching user
+ *     (not yet provisioned, or provisioned under a different issuer) is skipped rather than treated
+ *     as an error - SCIM user provisioning is out of scope for #237.
+ */
+public record DirectoryGroup(
+    String externalId, String name, String parentExternalId, Set<String> memberSubjects) {
+
+  public DirectoryGroup {
+    Objects.requireNonNull(externalId, "externalId must not be null");
+    Objects.requireNonNull(name, "name must not be null");
+    memberSubjects = memberSubjects == null ? Set.of() : Set.copyOf(memberSubjects);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySnapshot.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySnapshot.java
@@ -1,0 +1,20 @@
+package io.opaa.group.sync;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A single successful read of the directory's current group list, as returned by {@link
+ * DirectoryClient#fetchGroups}. An unreachable directory does not produce a snapshot at all - see
+ * {@link DirectoryUnavailableException} - and an empty {@link #groups()} list is a valid snapshot
+ * that {@link DirectorySyncService} treats specially precisely because it is indistinguishable from
+ * a misconfigured connection at this layer (see #237's acceptance criteria).
+ */
+public record DirectorySnapshot(Instant fetchedAt, List<DirectoryGroup> groups) {
+
+  public DirectorySnapshot {
+    Objects.requireNonNull(fetchedAt, "fetchedAt must not be null");
+    groups = groups == null ? List.of() : List.copyOf(groups);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncConfiguration.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncConfiguration.java
@@ -1,0 +1,24 @@
+package io.opaa.group.sync;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(DirectorySyncProperties.class)
+public class DirectorySyncConfiguration {
+
+  /**
+   * {@code @ConditionalOnMissingBean} on a {@code @Bean} method (unlike on a plain
+   * {@code @Component}) is reliably evaluated after every other configuration class's bean
+   * definitions are known, so a future deployment-specific {@link DirectoryClient} bean (real
+   * directory connector) always wins over this default without needing to know about this class at
+   * all.
+   */
+  @Bean
+  @ConditionalOnMissingBean(DirectoryClient.class)
+  DirectoryClient noOpDirectoryClient() {
+    return new NoOpDirectoryClient();
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncOutcome.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncOutcome.java
@@ -1,0 +1,28 @@
+package io.opaa.group.sync;
+
+/** What a directory synchronisation run did or did not do. See {@link DirectorySyncService}. */
+public enum DirectorySyncOutcome {
+
+  /** Changes were computed and written. Only possible for {@code run}, never for {@code dryRun}. */
+  APPLIED,
+
+  /** Nothing was written; the report shows what {@code run} would change. */
+  DRY_RUN,
+
+  /**
+   * The run would have removed more than the configured fraction of a group's memberships (see
+   * {@link DirectorySyncProperties#changeThresholdFraction}). Nothing was written; the report shows
+   * what was rejected.
+   */
+  ABORTED_THRESHOLD,
+
+  /**
+   * The directory answered but reported zero groups while ORG_UNIT groups already exist - the
+   * classic symptom of a misconfigured connection (e.g. after a certificate rotation), not a real
+   * reorganisation. Nothing was written.
+   */
+  ABORTED_EMPTY_RESULT,
+
+  /** The directory could not be reached. Nothing was written; the last-known-good state stands. */
+  UNREACHABLE
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
@@ -1,0 +1,619 @@
+package io.opaa.group.sync;
+
+import io.opaa.api.dto.DirectorySyncGroupChange;
+import io.opaa.api.dto.DirectorySyncMembershipChange;
+import io.opaa.api.dto.DirectorySyncReportResponse;
+import io.opaa.api.dto.DirectorySyncUserRef;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupMembership;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.GroupRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Computes and, when requested and plausible, applies the diff between the database and an
+ * already-fetched {@link DirectorySnapshot}. Split out from {@link DirectorySyncService} so the
+ * directory fetch itself - the one call that can be slow or fail on a real deployment - never runs
+ * inside a database transaction (review of PR #297): {@link DirectorySyncService} is not
+ * transactional at all and fetches the snapshot before ever calling in here, and a call from one
+ * Spring bean to another goes through the real proxy, so {@code @Transactional} below is honoured
+ * regardless of what the caller was doing - unlike a self-invoked private method on the same
+ * instance would be.
+ *
+ * <p><b>Plan, then act.</b> {@link #buildPlan} computes the entire diff without mutating anything.
+ * {@link #planOnly} and the plausibility-threshold abort path inside {@link #handle} both stop
+ * there and only turn the plan into a report. Only {@link #planAndApply}, once the plan has been
+ * judged plausible, calls {@link #applyPlan}. Status is always recorded through {@link
+ * DirectorySyncStatusRecorder}'s own {@code REQUIRES_NEW} transaction, independent of whichever of
+ * the two transaction types below is active - see that class's javadoc for why a plain field write
+ * here is not equivalent.
+ *
+ * <p><b>Matching:</b> exclusively by {@link Group#getExternalId()} - the directory's stable
+ * identifier, never by name (see #237's acceptance criteria; a rename must be free of side
+ * effects).
+ *
+ * <p><b>Membership resolution:</b> flat only. A group's membership is exactly what the directory
+ * reports as its direct members; a member of a child organizational unit is never treated as an
+ * implicit member of the parent. Nested-group membership inheritance is called out as an open point
+ * in the feature spec and is deliberately left unresolved by this service - {@code parentGroupId}
+ * is recorded for #208's curator escalation only, resolved in a second pass in {@link #applyPlan}
+ * so it works regardless of the order the directory reports groups in and applies to existing
+ * groups too, not only newly created ones (review of PR #297).
+ *
+ * <p><b>Plausibility threshold ({@link #buildPlan}):</b> the denominator and numerator of {@code
+ * changedFraction} both range over exactly the same population of groups - every group this run
+ * actually touches (matched-and-unchanged, renamed, membership-changed, reactivated, or about to be
+ * dissolved) - and nothing else. A group that was already dissolved before this run and stays
+ * unreported keeps its frozen membership out of both sides. Two things review of PR #297 found
+ * broken under the original (name-only) computation are folded in explicitly: a group being
+ * dissolved this run contributes its entire pre-run membership to the numerator (its reach is
+ * capped the same way a revoked grant would be, even though no individual {@code group_memberships}
+ * row is deleted), and a group being reactivated this run contributes its frozen pre-run membership
+ * to the denominator (it re-enters "in play" in the very run that can remove from it).
+ */
+@Service
+class DirectorySyncPlanExecutor {
+
+  private static final Logger log = LoggerFactory.getLogger(DirectorySyncPlanExecutor.class);
+
+  private final GroupRepository groupRepository;
+  private final UserRepository userRepository;
+  private final GroupMembershipResolver membershipResolver;
+  private final DirectorySyncStatusRecorder statusRecorder;
+  private final DirectorySyncProperties properties;
+
+  DirectorySyncPlanExecutor(
+      GroupRepository groupRepository,
+      UserRepository userRepository,
+      GroupMembershipResolver membershipResolver,
+      DirectorySyncStatusRecorder statusRecorder,
+      DirectorySyncProperties properties) {
+    this.groupRepository = groupRepository;
+    this.userRepository = userRepository;
+    this.membershipResolver = membershipResolver;
+    this.statusRecorder = statusRecorder;
+    this.properties = properties;
+  }
+
+  @Transactional(readOnly = true)
+  DirectorySyncReportResponse planOnly(
+      UUID organizationId, Instant now, DirectorySnapshot snapshot) {
+    return handle(organizationId, now, snapshot, false);
+  }
+
+  @Transactional
+  DirectorySyncReportResponse planAndApply(
+      UUID organizationId, Instant now, DirectorySnapshot snapshot) {
+    return handle(organizationId, now, snapshot, true);
+  }
+
+  private DirectorySyncReportResponse handle(
+      UUID organizationId, Instant now, DirectorySnapshot snapshot, boolean applyIfPlausible) {
+    List<Group> existingOrgUnits =
+        groupRepository.findByOrganizationIdAndKindOrgUnit(organizationId);
+
+    if (snapshot.groups().isEmpty() && !existingOrgUnits.isEmpty()) {
+      String message =
+          "Das Verzeichnis hat eine leere Gruppenliste geliefert, obwohl "
+              + existingOrgUnits.size()
+              + " Organisationseinheit(en) bekannt sind. Der Lauf wurde ohne Aenderungen"
+              + " abgebrochen.";
+      log.warn(
+          "Directory sync: directory returned an empty group list for organization {} while {}"
+              + " ORG_UNIT groups exist - aborting without changes",
+          organizationId,
+          existingOrgUnits.size());
+      return recordAndReport(
+          organizationId, now, DirectorySyncOutcome.ABORTED_EMPTY_RESULT, message, emptyPlan());
+    }
+
+    SyncPlan plan = buildPlan(organizationId, snapshot, existingOrgUnits);
+
+    if (plan.changedFraction() > properties.changeThresholdFraction()) {
+      String changedPercent = formatPercent(plan.changedFraction());
+      String thresholdPercent = formatPercent(properties.changeThresholdFraction());
+      String message =
+          String.format(
+              Locale.ROOT,
+              "Der Lauf wuerde %s der betroffenen Mitgliedschaften entfernen bzw. einfrieren und"
+                  + " damit die konfigurierte Schwelle von %s ueberschreiten. Abgebrochen ohne"
+                  + " Aenderungen.",
+              changedPercent,
+              thresholdPercent);
+      log.warn(
+          "Directory sync: run for organization {} would put {} of {} memberships at risk ({},"
+              + " threshold {}) - aborting without changes",
+          organizationId,
+          plan.membershipsAtRisk(),
+          plan.existingMembershipCount(),
+          changedPercent,
+          thresholdPercent);
+      return recordAndReport(
+          organizationId, now, DirectorySyncOutcome.ABORTED_THRESHOLD, message, plan);
+    }
+
+    if (!applyIfPlausible) {
+      return recordAndReport(
+          organizationId,
+          now,
+          DirectorySyncOutcome.DRY_RUN,
+          "Trockenlauf - keine Aenderung.",
+          plan);
+    }
+
+    applyPlan(organizationId, now, plan);
+    return recordAndReport(
+        organizationId, now, DirectorySyncOutcome.APPLIED, "Synchronisation angewendet.", plan);
+  }
+
+  private String formatPercent(double fraction) {
+    return String.format(Locale.ROOT, "%.1f%%", fraction * 100);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Plan building - read-only
+  // ---------------------------------------------------------------------------------------
+
+  private SyncPlan buildPlan(
+      UUID organizationId, DirectorySnapshot snapshot, List<Group> existingOrgUnits) {
+    Map<String, Group> existingByExternalId = new HashMap<>();
+    for (Group group : existingOrgUnits) {
+      if (group.getExternalId() != null) {
+        existingByExternalId.put(group.getExternalId(), group);
+      }
+    }
+
+    List<PlannedCreate> creates = new ArrayList<>();
+    List<PlannedRename> renames = new ArrayList<>();
+    List<PlannedReactivation> reactivations = new ArrayList<>();
+    List<PlannedMembershipChange> membershipChanges = new ArrayList<>();
+    Set<UUID> reactivatingGroupIds = new HashSet<>();
+    int membershipsAdded = 0;
+    int membershipsRemoved = 0;
+    int unresolvedMemberCount = 0;
+
+    Map<String, DirectoryGroup> incomingByExternalId = new HashMap<>();
+    Set<String> incomingExternalIds = new HashSet<>();
+    for (DirectoryGroup incoming : snapshot.groups()) {
+      if (incoming.externalId().isBlank() || incoming.name().isBlank()) {
+        log.warn(
+            "Directory sync: skipping malformed directory group for organization {} (blank"
+                + " externalId or name)",
+            organizationId);
+        continue;
+      }
+      incomingExternalIds.add(incoming.externalId());
+      incomingByExternalId.put(incoming.externalId(), incoming);
+
+      ResolvedMembers resolved = resolveMembers(organizationId, incoming.memberSubjects());
+      unresolvedMemberCount += resolved.unresolvedCount();
+
+      Group existing = existingByExternalId.get(incoming.externalId());
+      if (existing == null) {
+        creates.add(new PlannedCreate(incoming, resolved.users()));
+        membershipsAdded += resolved.users().size();
+        continue;
+      }
+
+      if (existing.isDissolved()) {
+        reactivations.add(new PlannedReactivation(existing));
+        reactivatingGroupIds.add(existing.getId());
+      }
+
+      if (!existing.getName().equals(incoming.name())) {
+        renames.add(new PlannedRename(existing, incoming.name()));
+      }
+
+      Map<UUID, UserRef> currentMembers = new HashMap<>();
+      for (GroupMembership membership : existing.getMemberships()) {
+        currentMembers.put(membership.getUserId(), new UserRef(membership.getUserId(), null));
+      }
+      Map<UUID, UserRef> desiredMembers = new HashMap<>();
+      for (UserRef user : resolved.users()) {
+        desiredMembers.put(user.id(), user);
+      }
+
+      Set<UserRef> toAdd = new HashSet<>();
+      for (Map.Entry<UUID, UserRef> entry : desiredMembers.entrySet()) {
+        if (!currentMembers.containsKey(entry.getKey())) {
+          toAdd.add(entry.getValue());
+        }
+      }
+      Set<UserRef> toRemove = new HashSet<>();
+      for (Map.Entry<UUID, UserRef> entry : currentMembers.entrySet()) {
+        if (!desiredMembers.containsKey(entry.getKey())) {
+          toRemove.add(entry.getValue());
+        }
+      }
+
+      if (!toAdd.isEmpty() || !toRemove.isEmpty()) {
+        membershipChanges.add(new PlannedMembershipChange(existing, toAdd, toRemove));
+        membershipsAdded += toAdd.size();
+        membershipsRemoved += toRemove.size();
+      }
+    }
+
+    List<PlannedDissolution> dissolutions = new ArrayList<>();
+    for (Group existing : existingOrgUnits) {
+      if (!existing.isDissolved()
+          && existing.getExternalId() != null
+          && !incomingExternalIds.contains(existing.getExternalId())) {
+        dissolutions.add(new PlannedDissolution(existing));
+      }
+    }
+
+    // Denominator: every group "in play" this run - active groups, plus a dissolved group only
+    // in the run that reactivates it (see the class javadoc). Numerator: removals from matched
+    // groups, plus the entire pre-run membership of a group about to be dissolved - its reach is
+    // capped the same way a revoked grant would be, even though no membership row is deleted.
+    int existingMembershipCount = 0;
+    for (Group group : existingOrgUnits) {
+      if (!group.isDissolved() || reactivatingGroupIds.contains(group.getId())) {
+        existingMembershipCount += group.getMemberships().size();
+      }
+    }
+    int membershipsAtRisk = membershipsRemoved;
+    for (PlannedDissolution dissolution : dissolutions) {
+      membershipsAtRisk += dissolution.group().getMemberships().size();
+    }
+    double changedFraction =
+        existingMembershipCount == 0
+            ? (membershipsAtRisk > 0 ? 1.0 : 0.0)
+            : (double) membershipsAtRisk / existingMembershipCount;
+
+    return new SyncPlan(
+        existingOrgUnits,
+        incomingByExternalId,
+        creates,
+        renames,
+        reactivations,
+        membershipChanges,
+        dissolutions,
+        membershipsAdded,
+        membershipsRemoved,
+        membershipsAtRisk,
+        unresolvedMemberCount,
+        existingMembershipCount,
+        changedFraction);
+  }
+
+  private ResolvedMembers resolveMembers(UUID organizationId, Set<String> subjects) {
+    if (subjects.isEmpty()) {
+      return new ResolvedMembers(Set.of(), 0);
+    }
+    List<User> users = userRepository.findByOrganizationIdAndSubjectIn(organizationId, subjects);
+    Set<UserRef> userRefs = new HashSet<>();
+    for (User user : users) {
+      String displayName = user.getDisplayName() != null ? user.getDisplayName() : user.getEmail();
+      userRefs.add(new UserRef(user.getId(), displayName));
+    }
+    int unresolved = subjects.size() - users.size();
+    return new ResolvedMembers(userRefs, Math.max(unresolved, 0));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Applying the plan
+  // ---------------------------------------------------------------------------------------
+
+  private void applyPlan(UUID organizationId, Instant now, SyncPlan plan) {
+    Set<UUID> affectedUserIds = new HashSet<>();
+    List<Group> createdGroups = new ArrayList<>();
+
+    for (PlannedCreate create : plan.creates()) {
+      DirectoryGroup incoming = create.directoryGroup();
+      Group group =
+          new Group(
+              organizationId,
+              GroupKind.ORG_UNIT,
+              incoming.name(),
+              null,
+              incoming.externalId(),
+              null);
+      for (UserRef member : create.members()) {
+        group.addMembership(new GroupMembership(member.id(), organizationId));
+        affectedUserIds.add(member.id());
+        log.info(
+            "Directory sync: added user {} to group {} ({}) as part of its creation",
+            member.id(),
+            group.getId(),
+            group.getExternalId());
+      }
+      groupRepository.save(group);
+      createdGroups.add(group);
+      log.info(
+          "Directory sync: created group {} ({}, external id {}) with {} member(s)",
+          group.getId(),
+          group.getName(),
+          group.getExternalId(),
+          create.members().size());
+    }
+
+    for (PlannedReactivation reactivation : plan.reactivations()) {
+      reactivation.group().reactivate();
+      log.info(
+          "Directory sync: group {} ({}) reactivated - reported by the directory again after"
+              + " having been dissolved",
+          reactivation.group().getId(),
+          reactivation.group().getExternalId());
+    }
+
+    for (PlannedRename rename : plan.renames()) {
+      log.info(
+          "Directory sync: group {} ({}) renamed from '{}' to '{}'",
+          rename.group().getId(),
+          rename.group().getExternalId(),
+          rename.group().getName(),
+          rename.newName());
+      rename.group().renameFromDirectory(rename.newName());
+    }
+
+    for (PlannedMembershipChange change : plan.membershipChanges()) {
+      for (UserRef member : change.toAdd()) {
+        change.group().addMembership(new GroupMembership(member.id(), organizationId));
+        affectedUserIds.add(member.id());
+        log.info(
+            "Directory sync: added user {} to group {} ({})",
+            member.id(),
+            change.group().getId(),
+            change.group().getExternalId());
+      }
+      for (UserRef member : change.toRemove()) {
+        change.group().getMemberships().stream()
+            .filter(m -> m.getUserId().equals(member.id()))
+            .findFirst()
+            .ifPresent(change.group()::removeMembership);
+        affectedUserIds.add(member.id());
+        log.info(
+            "Directory sync: removed user {} from group {} ({})",
+            member.id(),
+            change.group().getId(),
+            change.group().getExternalId());
+      }
+    }
+
+    for (PlannedDissolution dissolution : plan.dissolutions()) {
+      dissolution.group().dissolve(now);
+      log.info(
+          "Directory sync: group {} ({}) marked dissolved - no longer reported by the directory,"
+              + " reach frozen at {} member(s)",
+          dissolution.group().getId(),
+          dissolution.group().getExternalId(),
+          dissolution.group().getMemberships().size());
+    }
+
+    List<Group> touched = new ArrayList<>();
+    plan.reactivations().forEach(r -> touched.add(r.group()));
+    plan.renames().forEach(r -> touched.add(r.group()));
+    plan.membershipChanges().forEach(c -> touched.add(c.group()));
+    plan.dissolutions().forEach(d -> touched.add(d.group()));
+    if (!touched.isEmpty()) {
+      groupRepository.saveAll(touched);
+    }
+
+    resolveAndApplyParentLinks(plan, createdGroups);
+
+    if (!affectedUserIds.isEmpty()) {
+      invalidateAfterCommit(() -> membershipResolver.invalidateUsers(affectedUserIds));
+    }
+  }
+
+  /**
+   * Resolves every group's parent link in a second pass, after every group touched this run - new
+   * or existing - has a persisted id. Fixes two defects review of PR #297 found in the original
+   * single-pass version: it no longer depends on the order the directory reported groups in (a
+   * child reported before its parent used to resolve to a permanent {@code null}), and it applies
+   * to existing groups too, not only newly created ones (a reorganisation that reassigns an
+   * existing unit under a different parent used to be silently ignored).
+   */
+  private void resolveAndApplyParentLinks(SyncPlan plan, List<Group> createdGroups) {
+    Map<String, UUID> groupIdByExternalId = new HashMap<>();
+    for (Group group : plan.existingOrgUnits()) {
+      if (group.getExternalId() != null) {
+        groupIdByExternalId.put(group.getExternalId(), group.getId());
+      }
+    }
+    for (Group created : createdGroups) {
+      groupIdByExternalId.put(created.getExternalId(), created.getId());
+    }
+
+    List<Group> parentChanged = new ArrayList<>();
+    for (Group group : concat(plan.existingOrgUnits(), createdGroups)) {
+      DirectoryGroup incoming = plan.incomingByExternalId().get(group.getExternalId());
+      if (incoming == null) {
+        // Not reported this run (dissolved, or externalId null) - its parent link is left as the
+        // last-known-good value, consistent with the rest of the frozen state.
+        continue;
+      }
+      UUID desiredParentId =
+          incoming.parentExternalId() == null || incoming.parentExternalId().isBlank()
+              ? null
+              : groupIdByExternalId.get(incoming.parentExternalId());
+      if (!Objects.equals(group.getParentGroupId(), desiredParentId)) {
+        group.updateParentGroup(desiredParentId);
+        parentChanged.add(group);
+      }
+    }
+    if (!parentChanged.isEmpty()) {
+      groupRepository.saveAll(parentChanged);
+    }
+  }
+
+  private List<Group> concat(List<Group> a, List<Group> b) {
+    List<Group> result = new ArrayList<>(a.size() + b.size());
+    result.addAll(a);
+    result.addAll(b);
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Status recording and report assembly
+  // ---------------------------------------------------------------------------------------
+
+  private DirectorySyncReportResponse recordAndReport(
+      UUID organizationId,
+      Instant now,
+      DirectorySyncOutcome outcome,
+      String message,
+      SyncPlan plan) {
+    statusRecorder.record(organizationId, now, outcome, message, plan.changedFraction());
+
+    DirectorySyncReportResponse response =
+        new DirectorySyncReportResponse(
+            outcome,
+            now,
+            toChanges(plan.creates()),
+            toRenameChanges(plan.renames()),
+            toDissolutionChanges(plan.dissolutions()),
+            toMembershipChanges(plan),
+            plan.membershipsAdded(),
+            plan.membershipsRemoved(),
+            plan.changedFraction(),
+            properties.changeThresholdFraction(),
+            message);
+    response.unresolvedMemberCount(plan.unresolvedMemberCount());
+    return response;
+  }
+
+  static SyncPlan emptyPlan() {
+    return new SyncPlan(
+        List.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), 0, 0, 0, 0, 0,
+        0.0);
+  }
+
+  private List<DirectorySyncGroupChange> toChanges(List<PlannedCreate> creates) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedCreate create : creates) {
+      result.add(
+          new DirectorySyncGroupChange(
+              create.directoryGroup().externalId(), create.directoryGroup().name()));
+    }
+    return result;
+  }
+
+  private List<DirectorySyncGroupChange> toRenameChanges(List<PlannedRename> renames) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedRename rename : renames) {
+      result.add(
+          new DirectorySyncGroupChange(rename.group().getExternalId(), rename.newName())
+              .previousName(rename.group().getName()));
+    }
+    return result;
+  }
+
+  private List<DirectorySyncGroupChange> toDissolutionChanges(
+      List<PlannedDissolution> dissolutions) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedDissolution dissolution : dissolutions) {
+      result.add(
+          new DirectorySyncGroupChange(
+              dissolution.group().getExternalId(), dissolution.group().getName()));
+    }
+    return result;
+  }
+
+  /**
+   * Which users would gain or lose membership of which group - not just the aggregate counts.
+   * Review of PR #297: an admin deciding whether to let a run through needs to see who is affected,
+   * not only how many. Covers both newly created groups (all members are additions) and existing
+   * groups with an actual diff; a matched-but-unchanged group produces no entry.
+   */
+  private List<DirectorySyncMembershipChange> toMembershipChanges(SyncPlan plan) {
+    List<DirectorySyncMembershipChange> result = new ArrayList<>();
+    for (PlannedCreate create : plan.creates()) {
+      result.add(
+          new DirectorySyncMembershipChange(
+              create.directoryGroup().externalId(),
+              create.directoryGroup().name(),
+              toUserRefs(create.members()),
+              List.of()));
+    }
+    for (PlannedMembershipChange change : plan.membershipChanges()) {
+      result.add(
+          new DirectorySyncMembershipChange(
+              change.group().getExternalId(),
+              change.group().getName(),
+              toUserRefs(change.toAdd()),
+              toUserRefs(change.toRemove())));
+    }
+    return result;
+  }
+
+  private List<DirectorySyncUserRef> toUserRefs(Set<UserRef> users) {
+    List<DirectorySyncUserRef> result = new ArrayList<>();
+    for (UserRef user : users) {
+      result.add(new DirectorySyncUserRef(user.id()).displayName(user.displayName()));
+    }
+    return result;
+  }
+
+  /**
+   * Same deferred-invalidation pattern as {@code GroupService#invalidateAfterCommit}: an inline
+   * invalidation here could race a concurrent reader into repopulating the cache with pre-commit
+   * membership, for the same reason described there.
+   */
+  private void invalidateAfterCommit(Runnable invalidation) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      invalidation.run();
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            invalidation.run();
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Plan data structures
+  // ---------------------------------------------------------------------------------------
+
+  /** A member reference resolved from the directory's subject to a known user's id. */
+  private record UserRef(UUID id, String displayName) {}
+
+  private record ResolvedMembers(Set<UserRef> users, int unresolvedCount) {}
+
+  private record PlannedCreate(DirectoryGroup directoryGroup, Set<UserRef> members) {}
+
+  private record PlannedRename(Group group, String newName) {}
+
+  private record PlannedReactivation(Group group) {}
+
+  private record PlannedMembershipChange(Group group, Set<UserRef> toAdd, Set<UserRef> toRemove) {}
+
+  private record PlannedDissolution(Group group) {}
+
+  private record SyncPlan(
+      List<Group> existingOrgUnits,
+      Map<String, DirectoryGroup> incomingByExternalId,
+      List<PlannedCreate> creates,
+      List<PlannedRename> renames,
+      List<PlannedReactivation> reactivations,
+      List<PlannedMembershipChange> membershipChanges,
+      List<PlannedDissolution> dissolutions,
+      int membershipsAdded,
+      int membershipsRemoved,
+      int membershipsAtRisk,
+      int unresolvedMemberCount,
+      int existingMembershipCount,
+      double changedFraction) {}
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
@@ -41,10 +41,17 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * <p><b>Plan, then act.</b> {@link #buildPlan} computes the entire diff without mutating anything.
  * {@link #planOnly} and the plausibility-threshold abort path inside {@link #handle} both stop
  * there and only turn the plan into a report. Only {@link #planAndApply}, once the plan has been
- * judged plausible, calls {@link #applyPlan}. Status is always recorded through {@link
- * DirectorySyncStatusRecorder}'s own {@code REQUIRES_NEW} transaction, independent of whichever of
- * the two transaction types below is active - see that class's javadoc for why a plain field write
- * here is not equivalent.
+ * judged plausible, calls {@link #applyPlan}.
+ *
+ * <p><b>Status is recorded by the caller, not here.</b> An earlier version of this class recorded
+ * the outcome itself, in a {@code REQUIRES_NEW} transaction that committed before this class's own
+ * transaction did - so a run that failed to apply (e.g. a directory-supplied name too long for
+ * {@code groups.name}, causing the surrounding transaction to roll back at commit) could still end
+ * up with a durably recorded {@code APPLIED} status, exactly the "a change was made" claim {@link
+ * DirectorySyncStatus#getLastAppliedAt()} exists to be trustworthy about (review of PR #297).
+ * {@link DirectorySyncService} - itself not transactional - calls {@link
+ * DirectorySyncStatusRecorder} only after {@link #planAndApply} has returned successfully, so a
+ * roll back here never reaches the status table at all.
  *
  * <p><b>Matching:</b> exclusively by {@link Group#getExternalId()} - the directory's stable
  * identifier, never by name (see #237's acceptance criteria; a rename must be free of side
@@ -58,16 +65,25 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * so it works regardless of the order the directory reports groups in and applies to existing
  * groups too, not only newly created ones (review of PR #297).
  *
- * <p><b>Plausibility threshold ({@link #buildPlan}):</b> the denominator and numerator of {@code
- * changedFraction} both range over exactly the same population of groups - every group this run
- * actually touches (matched-and-unchanged, renamed, membership-changed, reactivated, or about to be
- * dissolved) - and nothing else. A group that was already dissolved before this run and stays
- * unreported keeps its frozen membership out of both sides. Two things review of PR #297 found
- * broken under the original (name-only) computation are folded in explicitly: a group being
- * dissolved this run contributes its entire pre-run membership to the numerator (its reach is
- * capped the same way a revoked grant would be, even though no individual {@code group_memberships}
- * row is deleted), and a group being reactivated this run contributes its frozen pre-run membership
- * to the denominator (it re-enters "in play" in the very run that can remove from it).
+ * <p><b>Plausibility threshold ({@link #buildPlan}):</b> {@code changedFraction} is the worse of
+ * two independent measures, each checked against the same configured threshold.
+ *
+ * <p>The first, membership-based measure has a denominator and numerator that both range over
+ * exactly the same population of groups - every group this run actually touches
+ * (matched-and-unchanged, renamed, membership-changed, reactivated, or about to be dissolved) - and
+ * nothing else. A group that was already dissolved before this run and stays unreported keeps its
+ * frozen membership out of both sides. Two things review of PR #297 found broken under the original
+ * (name-only) computation are folded in explicitly: a group being dissolved this run contributes
+ * its entire pre-run membership to the numerator (its reach is capped the same way a revoked grant
+ * would be, even though no individual {@code group_memberships} row is deleted), and a group being
+ * reactivated this run contributes its frozen pre-run membership to the denominator (it re-enters
+ * "in play" in the very run that can remove from it).
+ *
+ * <p>The second, group-count-based measure exists because the first is blind to a mass dissolution
+ * of groups that have no members at all - routine during an introduction phase, before curators and
+ * memberships are populated (residual risk flagged in review of PR #297). It is the fraction of
+ * groups active before this run that this run would dissolve, independent of how many members any
+ * of them have.
  */
 @Service
 class DirectorySyncPlanExecutor {
@@ -77,19 +93,16 @@ class DirectorySyncPlanExecutor {
   private final GroupRepository groupRepository;
   private final UserRepository userRepository;
   private final GroupMembershipResolver membershipResolver;
-  private final DirectorySyncStatusRecorder statusRecorder;
   private final DirectorySyncProperties properties;
 
   DirectorySyncPlanExecutor(
       GroupRepository groupRepository,
       UserRepository userRepository,
       GroupMembershipResolver membershipResolver,
-      DirectorySyncStatusRecorder statusRecorder,
       DirectorySyncProperties properties) {
     this.groupRepository = groupRepository;
     this.userRepository = userRepository;
     this.membershipResolver = membershipResolver;
-    this.statusRecorder = statusRecorder;
     this.properties = properties;
   }
 
@@ -121,8 +134,7 @@ class DirectorySyncPlanExecutor {
               + " ORG_UNIT groups exist - aborting without changes",
           organizationId,
           existingOrgUnits.size());
-      return recordAndReport(
-          organizationId, now, DirectorySyncOutcome.ABORTED_EMPTY_RESULT, message, emptyPlan());
+      return buildReport(now, DirectorySyncOutcome.ABORTED_EMPTY_RESULT, message, emptyPlan());
     }
 
     SyncPlan plan = buildPlan(organizationId, snapshot, existingOrgUnits);
@@ -133,35 +145,30 @@ class DirectorySyncPlanExecutor {
       String message =
           String.format(
               Locale.ROOT,
-              "Der Lauf wuerde %s der betroffenen Mitgliedschaften entfernen bzw. einfrieren und"
-                  + " damit die konfigurierte Schwelle von %s ueberschreiten. Abgebrochen ohne"
-                  + " Aenderungen.",
+              "Der Lauf wuerde %s der betroffenen Mitgliedschaften oder Gruppen entfernen bzw."
+                  + " einfrieren und damit die konfigurierte Schwelle von %s ueberschreiten."
+                  + " Abgebrochen ohne Aenderungen.",
               changedPercent,
               thresholdPercent);
       log.warn(
-          "Directory sync: run for organization {} would put {} of {} memberships at risk ({},"
-              + " threshold {}) - aborting without changes",
+          "Directory sync: run for organization {} would put {} of {} memberships and {} of {}"
+              + " active groups at risk ({}, threshold {}) - aborting without changes",
           organizationId,
           plan.membershipsAtRisk(),
           plan.existingMembershipCount(),
+          plan.dissolutions().size(),
+          plan.activeGroupCount(),
           changedPercent,
           thresholdPercent);
-      return recordAndReport(
-          organizationId, now, DirectorySyncOutcome.ABORTED_THRESHOLD, message, plan);
+      return buildReport(now, DirectorySyncOutcome.ABORTED_THRESHOLD, message, plan);
     }
 
     if (!applyIfPlausible) {
-      return recordAndReport(
-          organizationId,
-          now,
-          DirectorySyncOutcome.DRY_RUN,
-          "Trockenlauf - keine Aenderung.",
-          plan);
+      return buildReport(now, DirectorySyncOutcome.DRY_RUN, "Trockenlauf - keine Aenderung.", plan);
     }
 
     applyPlan(organizationId, now, plan);
-    return recordAndReport(
-        organizationId, now, DirectorySyncOutcome.APPLIED, "Synchronisation angewendet.", plan);
+    return buildReport(now, DirectorySyncOutcome.APPLIED, "Synchronisation angewendet.", plan);
   }
 
   private String formatPercent(double fraction) {
@@ -222,9 +229,9 @@ class DirectorySyncPlanExecutor {
         renames.add(new PlannedRename(existing, incoming.name()));
       }
 
-      Map<UUID, UserRef> currentMembers = new HashMap<>();
+      Set<UUID> currentMemberIds = new HashSet<>();
       for (GroupMembership membership : existing.getMemberships()) {
-        currentMembers.put(membership.getUserId(), new UserRef(membership.getUserId(), null));
+        currentMemberIds.add(membership.getUserId());
       }
       Map<UUID, UserRef> desiredMembers = new HashMap<>();
       for (UserRef user : resolved.users()) {
@@ -233,16 +240,17 @@ class DirectorySyncPlanExecutor {
 
       Set<UserRef> toAdd = new HashSet<>();
       for (Map.Entry<UUID, UserRef> entry : desiredMembers.entrySet()) {
-        if (!currentMembers.containsKey(entry.getKey())) {
+        if (!currentMemberIds.contains(entry.getKey())) {
           toAdd.add(entry.getValue());
         }
       }
-      Set<UserRef> toRemove = new HashSet<>();
-      for (Map.Entry<UUID, UserRef> entry : currentMembers.entrySet()) {
-        if (!desiredMembers.containsKey(entry.getKey())) {
-          toRemove.add(entry.getValue());
-        }
-      }
+      Set<UUID> toRemoveIds = new HashSet<>(currentMemberIds);
+      toRemoveIds.removeAll(desiredMembers.keySet());
+      // Resolved with a display name, not left null like an earlier version of this method did
+      // (review of PR #297): the report is exactly where an admin decides whether to let a run
+      // through that would remove access, and "who" matters most for the direction that costs
+      // rights.
+      Set<UserRef> toRemove = resolveUserRefsById(toRemoveIds);
 
       if (!toAdd.isEmpty() || !toRemove.isEmpty()) {
         membershipChanges.add(new PlannedMembershipChange(existing, toAdd, toRemove));
@@ -265,19 +273,34 @@ class DirectorySyncPlanExecutor {
     // groups, plus the entire pre-run membership of a group about to be dissolved - its reach is
     // capped the same way a revoked grant would be, even though no membership row is deleted.
     int existingMembershipCount = 0;
+    int activeGroupCount = 0;
     for (Group group : existingOrgUnits) {
       if (!group.isDissolved() || reactivatingGroupIds.contains(group.getId())) {
         existingMembershipCount += group.getMemberships().size();
+      }
+      if (!group.isDissolved()) {
+        activeGroupCount++;
       }
     }
     int membershipsAtRisk = membershipsRemoved;
     for (PlannedDissolution dissolution : dissolutions) {
       membershipsAtRisk += dissolution.group().getMemberships().size();
     }
-    double changedFraction =
+    double membershipChangedFraction =
         existingMembershipCount == 0
             ? (membershipsAtRisk > 0 ? 1.0 : 0.0)
             : (double) membershipsAtRisk / existingMembershipCount;
+
+    // A second, independent measure on the number of groups rather than their membership: an
+    // introduction-phase directory routinely has ORG_UNIT groups with zero members (curators and
+    // memberships are populated gradually), so a mass dissolution of empty groups is invisible to
+    // membershipChangedFraction - its numerator and denominator are both driven by memberships,
+    // which such a run never touches. changedFraction is the worse of the two so a run this
+    // implausible in either dimension is caught, not only one measured in memberships (residual
+    // risk flagged in review of PR #297).
+    double groupDissolutionFraction =
+        activeGroupCount == 0 ? 0.0 : (double) dissolutions.size() / activeGroupCount;
+    double changedFraction = Math.max(membershipChangedFraction, groupDissolutionFraction);
 
     return new SyncPlan(
         existingOrgUnits,
@@ -292,6 +315,7 @@ class DirectorySyncPlanExecutor {
         membershipsAtRisk,
         unresolvedMemberCount,
         existingMembershipCount,
+        activeGroupCount,
         changedFraction);
   }
 
@@ -302,11 +326,33 @@ class DirectorySyncPlanExecutor {
     List<User> users = userRepository.findByOrganizationIdAndSubjectIn(organizationId, subjects);
     Set<UserRef> userRefs = new HashSet<>();
     for (User user : users) {
-      String displayName = user.getDisplayName() != null ? user.getDisplayName() : user.getEmail();
-      userRefs.add(new UserRef(user.getId(), displayName));
+      userRefs.add(toUserRef(user));
     }
     int unresolved = subjects.size() - users.size();
     return new ResolvedMembers(userRefs, Math.max(unresolved, 0));
+  }
+
+  /**
+   * Resolves already-known member ids (a group's current, persisted membership) to their display
+   * names, the same way {@link #resolveMembers} does for the directory's incoming subjects. These
+   * ids come from this organization's own {@code group_memberships} rows, not from external input,
+   * so no organization-boundary check is needed here the way {@link
+   * io.opaa.auth.UserRepository#findByOrganizationIdAndSubjectIn} enforces one.
+   */
+  private Set<UserRef> resolveUserRefsById(Set<UUID> userIds) {
+    if (userIds.isEmpty()) {
+      return Set.of();
+    }
+    Set<UserRef> userRefs = new HashSet<>();
+    for (User user : userRepository.findAllById(userIds)) {
+      userRefs.add(toUserRef(user));
+    }
+    return userRefs;
+  }
+
+  private UserRef toUserRef(User user) {
+    String displayName = user.getDisplayName() != null ? user.getDisplayName() : user.getEmail();
+    return new UserRef(user.getId(), displayName);
   }
 
   // ---------------------------------------------------------------------------------------
@@ -464,17 +510,12 @@ class DirectorySyncPlanExecutor {
   }
 
   // ---------------------------------------------------------------------------------------
-  // Status recording and report assembly
+  // Report assembly - status is recorded by DirectorySyncService, once this class's own
+  // transaction has committed successfully. See the class javadoc.
   // ---------------------------------------------------------------------------------------
 
-  private DirectorySyncReportResponse recordAndReport(
-      UUID organizationId,
-      Instant now,
-      DirectorySyncOutcome outcome,
-      String message,
-      SyncPlan plan) {
-    statusRecorder.record(organizationId, now, outcome, message, plan.changedFraction());
-
+  private DirectorySyncReportResponse buildReport(
+      Instant now, DirectorySyncOutcome outcome, String message, SyncPlan plan) {
     DirectorySyncReportResponse response =
         new DirectorySyncReportResponse(
             outcome,
@@ -495,7 +536,7 @@ class DirectorySyncPlanExecutor {
   static SyncPlan emptyPlan() {
     return new SyncPlan(
         List.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), 0, 0, 0, 0, 0,
-        0.0);
+        0, 0.0);
   }
 
   private List<DirectorySyncGroupChange> toChanges(List<PlannedCreate> creates) {
@@ -615,5 +656,6 @@ class DirectorySyncPlanExecutor {
       int membershipsAtRisk,
       int unresolvedMemberCount,
       int existingMembershipCount,
+      int activeGroupCount,
       double changedFraction) {}
 }

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncPlanExecutor.java
@@ -83,12 +83,25 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * of groups that have no members at all - routine during an introduction phase, before curators and
  * memberships are populated (residual risk flagged in review of PR #297). It is the fraction of
  * groups active before this run that this run would dissolve, independent of how many members any
- * of them have.
+ * of them have - but only once the population is large enough ({@link
+ * #MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE}) or the dissolution count alarming enough on its own
+ * ({@link #MIN_DISSOLUTIONS_FOR_GROUP_MEASURE}) for a fraction to mean anything; below that floor a
+ * single legitimate dissolution in a small organisation - the normal case for a pilot, not the
+ * mass-outage case this measure targets - would otherwise abort every run indefinitely, with no
+ * per-run override available (a second regression review of PR #297 found and measured).
  */
 @Service
 class DirectorySyncPlanExecutor {
 
   private static final Logger log = LoggerFactory.getLogger(DirectorySyncPlanExecutor.class);
+
+  /**
+   * Floor for the group-count plausibility measure - see where it is used in {@link #buildPlan} for
+   * the reasoning (review of PR #297).
+   */
+  private static final int MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE = 10;
+
+  private static final int MIN_DISSOLUTIONS_FOR_GROUP_MEASURE = 5;
 
   private final GroupRepository groupRepository;
   private final UserRepository userRepository;
@@ -298,8 +311,24 @@ class DirectorySyncPlanExecutor {
     // which such a run never touches. changedFraction is the worse of the two so a run this
     // implausible in either dimension is caught, not only one measured in memberships (residual
     // risk flagged in review of PR #297).
+    //
+    // Only takes effect once the population is large enough to make a *fraction* meaningful
+    // (MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE) or the absolute count is already alarming on its own
+    // (MIN_DISSOLUTIONS_FOR_GROUP_MEASURE) - without this floor, review of PR #297 measured a
+    // small, entirely legitimate organisation (3 active units, one empty placeholder correctly
+    // disappearing, zero memberships at risk) getting permanently stuck at ABORTED_THRESHOLD: 1 of
+    // 3 groups is 33%, above the default 30% threshold, with no per-run override available and no
+    // way for the fraction to ever improve on a later run of the same organisation. A single
+    // dissolved unit in a small authority - the common case for a pilot, not the exception - must
+    // stay a routine, applicable change; this measure exists for the *mass* case the numbers below
+    // are calibrated to.
+    boolean groupMeasureApplies =
+        activeGroupCount >= MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE
+            || dissolutions.size() >= MIN_DISSOLUTIONS_FOR_GROUP_MEASURE;
     double groupDissolutionFraction =
-        activeGroupCount == 0 ? 0.0 : (double) dissolutions.size() / activeGroupCount;
+        groupMeasureApplies && activeGroupCount > 0
+            ? (double) dissolutions.size() / activeGroupCount
+            : 0.0;
     double changedFraction = Math.max(membershipChangedFraction, groupDissolutionFraction);
 
     return new SyncPlan(

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncProperties.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncProperties.java
@@ -1,0 +1,27 @@
+package io.opaa.group.sync;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for #237's directory synchronisation.
+ *
+ * @param changeThresholdFraction the plausibility threshold: if a run would remove more than this
+ *     fraction of a group's existing memberships, it is aborted and reported instead of applied
+ *     (see #237's acceptance criteria). Deliberately measured on removals only, not on additions -
+ *     a run that only adds memberships can never revoke a right, so there is nothing for the
+ *     threshold to protect against there. Must be strictly between 0 and 1; defaults to 0.3 (30%).
+ */
+@ConfigurationProperties(prefix = "opaa.directory-sync")
+public record DirectorySyncProperties(double changeThresholdFraction) {
+
+  public DirectorySyncProperties {
+    if (changeThresholdFraction <= 0) {
+      changeThresholdFraction = 0.3;
+    }
+    if (changeThresholdFraction > 1) {
+      throw new IllegalArgumentException(
+          "opaa.directory-sync.change-threshold-fraction must be at most 1, got "
+              + changeThresholdFraction);
+    }
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncProperties.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncProperties.java
@@ -9,18 +9,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     fraction of a group's existing memberships, it is aborted and reported instead of applied
  *     (see #237's acceptance criteria). Deliberately measured on removals only, not on additions -
  *     a run that only adds memberships can never revoke a right, so there is nothing for the
- *     threshold to protect against there. Must be strictly between 0 and 1; defaults to 0.3 (30%).
+ *     threshold to protect against there. Must be strictly between 0 (exclusive) and 1 (inclusive);
+ *     the application default is 0.3 (30%), set in {@code application.yml} - not here, so that an
+ *     operator-supplied value of 0 or less is rejected rather than silently replaced with a more
+ *     lenient default. A safeguard against mass rights revocation must fail loudly on invalid
+ *     configuration, not quietly loosen itself.
  */
 @ConfigurationProperties(prefix = "opaa.directory-sync")
 public record DirectorySyncProperties(double changeThresholdFraction) {
 
   public DirectorySyncProperties {
-    if (changeThresholdFraction <= 0) {
-      changeThresholdFraction = 0.3;
-    }
-    if (changeThresholdFraction > 1) {
+    if (changeThresholdFraction <= 0 || changeThresholdFraction > 1) {
       throw new IllegalArgumentException(
-          "opaa.directory-sync.change-threshold-fraction must be at most 1, got "
+          "opaa.directory-sync.change-threshold-fraction must be greater than 0 and at most 1,"
+              + " got "
               + changeThresholdFraction);
     }
   }

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
@@ -1,93 +1,60 @@
 package io.opaa.group.sync;
 
-import io.opaa.api.dto.DirectorySyncGroupChange;
 import io.opaa.api.dto.DirectorySyncReportResponse;
 import io.opaa.api.dto.DirectorySyncStatusResponse;
-import io.opaa.auth.User;
-import io.opaa.auth.UserRepository;
-import io.opaa.group.Group;
-import io.opaa.group.GroupKind;
-import io.opaa.group.GroupMembership;
-import io.opaa.group.GroupMembershipResolver;
-import io.opaa.group.GroupRepository;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
- * Directory synchronisation as a rights event (#237). Groups of {@link GroupKind#ORG_UNIT} exist
- * only because a directory reports them; this service is the one place that reconciles the database
- * with the directory's current state, and does so as a bulk permission change - the only place in
- * the system where rights change in large numbers without an individual human decision.
- *
- * <p><b>Plan, then act.</b> {@link #buildPlan} computes the entire diff against the directory's
- * snapshot without mutating anything. {@link #dryRun} and the plausibility-threshold abort path in
- * {@link #run} both stop right there and only turn the plan into a report - so "nothing was
- * written" is true by construction for those paths, not by carefully avoiding a save() call
- * somewhere. Only {@link #run}, once the plan has been judged plausible, calls {@link #apply}.
- *
- * <p><b>Matching:</b> exclusively by {@link Group#getExternalId()} - the directory's stable
- * identifier, never by name (see #237's acceptance criteria; a rename must be free of side
- * effects).
- *
- * <p><b>Membership resolution:</b> flat only. A group's membership is exactly what the directory
- * reports as its direct members; a member of a child organizational unit is never treated as an
- * implicit member of the parent. Nested-group membership inheritance is called out as an open point
- * in the feature spec and is deliberately left unresolved by this service - {@code parentGroupId}
- * is recorded for #208's curator escalation only.
+ * Directory synchronisation as a rights event (#237): the public entry point and the boundary to an
+ * actual directory. Deliberately holds no {@code @Transactional} annotation anywhere in this class
+ * - {@link DirectoryClient#fetchGroups} runs here, before any database transaction is opened, so a
+ * slow or failing real directory connector never holds a database connection or transaction open
+ * for the duration of a network call (review of PR #297). The transactional plan computation and,
+ * if applicable, application live in {@link DirectorySyncPlanExecutor}, a separate bean called from
+ * here through Spring's proxy.
  */
 @Service
-@Transactional(readOnly = true)
 public class DirectorySyncService {
 
   private static final Logger log = LoggerFactory.getLogger(DirectorySyncService.class);
 
   private final DirectoryClient directoryClient;
-  private final GroupRepository groupRepository;
-  private final UserRepository userRepository;
-  private final GroupMembershipResolver membershipResolver;
+  private final DirectorySyncPlanExecutor planExecutor;
+  private final DirectorySyncStatusRecorder statusRecorder;
   private final DirectorySyncStatusRepository statusRepository;
   private final DirectorySyncProperties properties;
 
   public DirectorySyncService(
       DirectoryClient directoryClient,
-      GroupRepository groupRepository,
-      UserRepository userRepository,
-      GroupMembershipResolver membershipResolver,
+      DirectorySyncPlanExecutor planExecutor,
+      DirectorySyncStatusRecorder statusRecorder,
       DirectorySyncStatusRepository statusRepository,
       DirectorySyncProperties properties) {
     this.directoryClient = directoryClient;
-    this.groupRepository = groupRepository;
-    this.userRepository = userRepository;
-    this.membershipResolver = membershipResolver;
+    this.planExecutor = planExecutor;
+    this.statusRecorder = statusRecorder;
     this.statusRepository = statusRepository;
     this.properties = properties;
   }
 
-  /** Computes the diff against the directory's current state. Never writes anything. */
+  /**
+   * Computes the diff against the directory's current state. Never writes group/membership data.
+   */
   public DirectorySyncReportResponse dryRun(UUID organizationId) {
     return execute(organizationId, false);
   }
 
   /**
    * Computes the diff and applies it if - and only if - the directory was reachable, did not return
-   * an implausibly empty group list, and the fraction of memberships it would remove does not
-   * exceed {@link DirectorySyncProperties#changeThresholdFraction()}. Otherwise behaves like {@link
-   * #dryRun} and reports why nothing was written.
+   * an implausibly empty group list, and the fraction of memberships at risk does not exceed {@link
+   * DirectorySyncProperties#changeThresholdFraction()}. Otherwise behaves like {@link #dryRun} and
+   * reports why nothing was written.
    */
-  @Transactional
   public DirectorySyncReportResponse run(UUID organizationId) {
     return execute(organizationId, true);
   }
@@ -117,401 +84,24 @@ public class DirectorySyncService {
           "Directory sync: directory unreachable for organization {}: {}",
           organizationId,
           e.getMessage());
-      return recordAndReport(
-          organizationId, now, DirectorySyncOutcome.UNREACHABLE, message, emptyPlan());
+      statusRecorder.record(organizationId, now, DirectorySyncOutcome.UNREACHABLE, message, 0.0);
+      return new DirectorySyncReportResponse(
+              DirectorySyncOutcome.UNREACHABLE,
+              now,
+              List.of(),
+              List.of(),
+              List.of(),
+              List.of(),
+              0,
+              0,
+              0.0,
+              properties.changeThresholdFraction(),
+              message)
+          .unresolvedMemberCount(0);
     }
 
-    List<Group> existingOrgUnits =
-        groupRepository.findByOrganizationIdAndKindOrgUnit(organizationId);
-
-    if (snapshot.groups().isEmpty() && !existingOrgUnits.isEmpty()) {
-      String message =
-          "Das Verzeichnis hat eine leere Gruppenliste geliefert, obwohl "
-              + existingOrgUnits.size()
-              + " Organisationseinheit(en) bekannt sind. Der Lauf wurde ohne Aenderungen"
-              + " abgebrochen.";
-      log.warn(
-          "Directory sync: directory returned an empty group list for organization {} while {}"
-              + " ORG_UNIT groups exist - aborting without changes",
-          organizationId,
-          existingOrgUnits.size());
-      return recordAndReport(
-          organizationId, now, DirectorySyncOutcome.ABORTED_EMPTY_RESULT, message, emptyPlan());
-    }
-
-    SyncPlan plan = buildPlan(organizationId, snapshot, existingOrgUnits);
-    double changedFraction =
-        plan.existingMembershipCount() == 0
-            ? 0.0
-            : (double) plan.membershipsRemoved() / plan.existingMembershipCount();
-
-    if (changedFraction > properties.changeThresholdFraction()) {
-      String message =
-          String.format(
-              Locale.ROOT,
-              "Der Lauf wuerde %.1f%% der bestehenden Mitgliedschaften entfernen und damit die"
-                  + " konfigurierte Schwelle von %.1f%% ueberschreiten. Abgebrochen ohne"
-                  + " Aenderungen.",
-              changedFraction * 100,
-              properties.changeThresholdFraction() * 100);
-      log.warn(
-          "Directory sync: run for organization {} would remove {} of {} memberships ({}%%,"
-              + " threshold {}%%) - aborting without changes",
-          organizationId,
-          plan.membershipsRemoved(),
-          plan.existingMembershipCount(),
-          changedFraction * 100,
-          properties.changeThresholdFraction() * 100);
-      return recordAndReport(
-          organizationId, now, DirectorySyncOutcome.ABORTED_THRESHOLD, message, plan);
-    }
-
-    if (!applyIfPlausible) {
-      return recordAndReport(
-          organizationId,
-          now,
-          DirectorySyncOutcome.DRY_RUN,
-          "Trockenlauf - keine Aenderung.",
-          plan);
-    }
-
-    applyPlan(organizationId, now, plan);
-    return recordAndReport(
-        organizationId, now, DirectorySyncOutcome.APPLIED, "Synchronisation angewendet.", plan);
+    return applyIfPlausible
+        ? planExecutor.planAndApply(organizationId, now, snapshot)
+        : planExecutor.planOnly(organizationId, now, snapshot);
   }
-
-  // ---------------------------------------------------------------------------------------
-  // Plan building - read-only
-  // ---------------------------------------------------------------------------------------
-
-  private SyncPlan buildPlan(
-      UUID organizationId, DirectorySnapshot snapshot, List<Group> existingOrgUnits) {
-    Map<String, Group> existingByExternalId = new HashMap<>();
-    for (Group group : existingOrgUnits) {
-      if (group.getExternalId() != null) {
-        existingByExternalId.put(group.getExternalId(), group);
-      }
-    }
-
-    int existingMembershipCount = 0;
-    for (Group group : existingOrgUnits) {
-      if (!group.isDissolved()) {
-        existingMembershipCount += group.getMemberships().size();
-      }
-    }
-
-    List<PlannedCreate> creates = new ArrayList<>();
-    List<PlannedRename> renames = new ArrayList<>();
-    List<PlannedReactivation> reactivations = new ArrayList<>();
-    List<PlannedMembershipChange> membershipChanges = new ArrayList<>();
-    int membershipsAdded = 0;
-    int membershipsRemoved = 0;
-    int unresolvedMemberCount = 0;
-
-    Set<String> incomingExternalIds = new HashSet<>();
-    for (DirectoryGroup incoming : snapshot.groups()) {
-      if (incoming.externalId().isBlank() || incoming.name().isBlank()) {
-        log.warn(
-            "Directory sync: skipping malformed directory group for organization {} (blank"
-                + " externalId or name)",
-            organizationId);
-        continue;
-      }
-      incomingExternalIds.add(incoming.externalId());
-
-      ResolvedMembers resolved = resolveMembers(organizationId, incoming.memberSubjects());
-      unresolvedMemberCount += resolved.unresolvedCount();
-
-      Group existing = existingByExternalId.get(incoming.externalId());
-      if (existing == null) {
-        creates.add(new PlannedCreate(incoming, resolved.userIds()));
-        membershipsAdded += resolved.userIds().size();
-        continue;
-      }
-
-      if (existing.isDissolved()) {
-        reactivations.add(new PlannedReactivation(existing));
-      }
-
-      if (!existing.getName().equals(incoming.name())) {
-        renames.add(new PlannedRename(existing, incoming.name()));
-      }
-
-      Set<UUID> currentMemberIds = new HashSet<>();
-      for (GroupMembership membership : existing.getMemberships()) {
-        currentMemberIds.add(membership.getUserId());
-      }
-      Set<UUID> toAdd = new HashSet<>(resolved.userIds());
-      toAdd.removeAll(currentMemberIds);
-      Set<UUID> toRemove = new HashSet<>(currentMemberIds);
-      toRemove.removeAll(resolved.userIds());
-
-      if (!toAdd.isEmpty() || !toRemove.isEmpty()) {
-        membershipChanges.add(new PlannedMembershipChange(existing, toAdd, toRemove));
-        membershipsAdded += toAdd.size();
-        membershipsRemoved += toRemove.size();
-      }
-    }
-
-    List<PlannedDissolution> dissolutions = new ArrayList<>();
-    for (Group existing : existingOrgUnits) {
-      if (!existing.isDissolved()
-          && existing.getExternalId() != null
-          && !incomingExternalIds.contains(existing.getExternalId())) {
-        dissolutions.add(new PlannedDissolution(existing));
-      }
-    }
-
-    return new SyncPlan(
-        creates,
-        renames,
-        reactivations,
-        membershipChanges,
-        dissolutions,
-        membershipsAdded,
-        membershipsRemoved,
-        unresolvedMemberCount,
-        existingMembershipCount);
-  }
-
-  private ResolvedMembers resolveMembers(UUID organizationId, Set<String> subjects) {
-    if (subjects.isEmpty()) {
-      return new ResolvedMembers(Set.of(), 0);
-    }
-    List<User> users = userRepository.findByOrganizationIdAndSubjectIn(organizationId, subjects);
-    Set<UUID> userIds = new HashSet<>();
-    for (User user : users) {
-      userIds.add(user.getId());
-    }
-    int unresolved = subjects.size() - users.size();
-    return new ResolvedMembers(userIds, Math.max(unresolved, 0));
-  }
-
-  // ---------------------------------------------------------------------------------------
-  // Applying the plan
-  // ---------------------------------------------------------------------------------------
-
-  private void applyPlan(UUID organizationId, Instant now, SyncPlan plan) {
-    Set<UUID> affectedUserIds = new HashSet<>();
-
-    for (PlannedCreate create : plan.creates()) {
-      DirectoryGroup incoming = create.directoryGroup();
-      UUID parentGroupId = resolveParentGroupId(organizationId, incoming.parentExternalId());
-      Group group =
-          new Group(
-              organizationId,
-              GroupKind.ORG_UNIT,
-              incoming.name(),
-              null,
-              incoming.externalId(),
-              parentGroupId);
-      for (UUID userId : create.memberUserIds()) {
-        group.addMembership(new GroupMembership(userId, organizationId));
-        affectedUserIds.add(userId);
-      }
-      groupRepository.save(group);
-      log.info(
-          "Directory sync: created group {} ({}, external id {}) with {} member(s)",
-          group.getId(),
-          group.getName(),
-          group.getExternalId(),
-          create.memberUserIds().size());
-    }
-
-    for (PlannedReactivation reactivation : plan.reactivations()) {
-      reactivation.group().reactivate();
-      log.info(
-          "Directory sync: group {} ({}) reactivated - reported by the directory again after"
-              + " having been dissolved",
-          reactivation.group().getId(),
-          reactivation.group().getExternalId());
-    }
-
-    for (PlannedRename rename : plan.renames()) {
-      log.info(
-          "Directory sync: group {} ({}) renamed from '{}' to '{}'",
-          rename.group().getId(),
-          rename.group().getExternalId(),
-          rename.group().getName(),
-          rename.newName());
-      rename.group().renameFromDirectory(rename.newName());
-    }
-
-    for (PlannedMembershipChange change : plan.membershipChanges()) {
-      for (UUID userId : change.toAdd()) {
-        change.group().addMembership(new GroupMembership(userId, organizationId));
-        affectedUserIds.add(userId);
-        log.info(
-            "Directory sync: added user {} to group {} ({})",
-            userId,
-            change.group().getId(),
-            change.group().getExternalId());
-      }
-      for (UUID userId : change.toRemove()) {
-        change.group().getMemberships().stream()
-            .filter(m -> m.getUserId().equals(userId))
-            .findFirst()
-            .ifPresent(change.group()::removeMembership);
-        affectedUserIds.add(userId);
-        log.info(
-            "Directory sync: removed user {} from group {} ({})",
-            userId,
-            change.group().getId(),
-            change.group().getExternalId());
-      }
-    }
-
-    for (PlannedDissolution dissolution : plan.dissolutions()) {
-      dissolution.group().dissolve(now);
-      log.info(
-          "Directory sync: group {} ({}) marked dissolved - no longer reported by the directory,"
-              + " reach frozen at {} member(s)",
-          dissolution.group().getId(),
-          dissolution.group().getExternalId(),
-          dissolution.group().getMemberships().size());
-    }
-
-    List<Group> touched = new ArrayList<>();
-    plan.reactivations().forEach(r -> touched.add(r.group()));
-    plan.renames().forEach(r -> touched.add(r.group()));
-    plan.membershipChanges().forEach(c -> touched.add(c.group()));
-    plan.dissolutions().forEach(d -> touched.add(d.group()));
-    if (!touched.isEmpty()) {
-      groupRepository.saveAll(touched);
-    }
-
-    if (!affectedUserIds.isEmpty()) {
-      invalidateAfterCommit(() -> membershipResolver.invalidateUsers(affectedUserIds));
-    }
-  }
-
-  private UUID resolveParentGroupId(UUID organizationId, String parentExternalId) {
-    if (parentExternalId == null || parentExternalId.isBlank()) {
-      return null;
-    }
-    return groupRepository.findByOrganizationIdAndKindOrgUnit(organizationId).stream()
-        .filter(g -> parentExternalId.equals(g.getExternalId()))
-        .map(Group::getId)
-        .findFirst()
-        .orElse(null);
-  }
-
-  // ---------------------------------------------------------------------------------------
-  // Status persistence and report assembly
-  // ---------------------------------------------------------------------------------------
-
-  private DirectorySyncReportResponse recordAndReport(
-      UUID organizationId,
-      Instant now,
-      DirectorySyncOutcome outcome,
-      String message,
-      SyncPlan plan) {
-    double changedFraction =
-        plan.existingMembershipCount() == 0
-            ? 0.0
-            : (double) plan.membershipsRemoved() / plan.existingMembershipCount();
-
-    DirectorySyncStatus status =
-        statusRepository
-            .findByOrganizationId(organizationId)
-            .orElseGet(() -> new DirectorySyncStatus(organizationId));
-    status.recordRun(now, outcome, message, changedFraction);
-    statusRepository.save(status);
-
-    DirectorySyncReportResponse response =
-        new DirectorySyncReportResponse(
-            outcome,
-            now,
-            toChanges(plan.creates()),
-            toRenameChanges(plan.renames()),
-            toDissolutionChanges(plan.dissolutions()),
-            plan.membershipsAdded(),
-            plan.membershipsRemoved(),
-            changedFraction,
-            properties.changeThresholdFraction(),
-            message);
-    response.unresolvedMemberCount(plan.unresolvedMemberCount());
-    return response;
-  }
-
-  private SyncPlan emptyPlan() {
-    return new SyncPlan(List.of(), List.of(), List.of(), List.of(), List.of(), 0, 0, 0, 0);
-  }
-
-  private List<DirectorySyncGroupChange> toChanges(List<PlannedCreate> creates) {
-    List<DirectorySyncGroupChange> result = new ArrayList<>();
-    for (PlannedCreate create : creates) {
-      result.add(
-          new DirectorySyncGroupChange(
-              create.directoryGroup().externalId(), create.directoryGroup().name()));
-    }
-    return result;
-  }
-
-  private List<DirectorySyncGroupChange> toRenameChanges(List<PlannedRename> renames) {
-    List<DirectorySyncGroupChange> result = new ArrayList<>();
-    for (PlannedRename rename : renames) {
-      result.add(
-          new DirectorySyncGroupChange(rename.group().getExternalId(), rename.newName())
-              .previousName(rename.group().getName()));
-    }
-    return result;
-  }
-
-  private List<DirectorySyncGroupChange> toDissolutionChanges(
-      List<PlannedDissolution> dissolutions) {
-    List<DirectorySyncGroupChange> result = new ArrayList<>();
-    for (PlannedDissolution dissolution : dissolutions) {
-      result.add(
-          new DirectorySyncGroupChange(
-              dissolution.group().getExternalId(), dissolution.group().getName()));
-    }
-    return result;
-  }
-
-  /**
-   * Same deferred-invalidation pattern as {@code GroupService#invalidateAfterCommit}: an inline
-   * invalidation here could race a concurrent reader into repopulating the cache with pre-commit
-   * membership, for the same reason described there.
-   */
-  private void invalidateAfterCommit(Runnable invalidation) {
-    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-      invalidation.run();
-      return;
-    }
-    TransactionSynchronizationManager.registerSynchronization(
-        new TransactionSynchronization() {
-          @Override
-          public void afterCompletion(int status) {
-            invalidation.run();
-          }
-        });
-  }
-
-  // ---------------------------------------------------------------------------------------
-  // Plan data structures
-  // ---------------------------------------------------------------------------------------
-
-  private record ResolvedMembers(Set<UUID> userIds, int unresolvedCount) {}
-
-  private record PlannedCreate(DirectoryGroup directoryGroup, Set<UUID> memberUserIds) {}
-
-  private record PlannedRename(Group group, String newName) {}
-
-  private record PlannedReactivation(Group group) {}
-
-  private record PlannedMembershipChange(Group group, Set<UUID> toAdd, Set<UUID> toRemove) {}
-
-  private record PlannedDissolution(Group group) {}
-
-  private record SyncPlan(
-      List<PlannedCreate> creates,
-      List<PlannedRename> renames,
-      List<PlannedReactivation> reactivations,
-      List<PlannedMembershipChange> membershipChanges,
-      List<PlannedDissolution> dissolutions,
-      int membershipsAdded,
-      int membershipsRemoved,
-      int unresolvedMemberCount,
-      int existingMembershipCount) {}
 }

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
@@ -1,0 +1,517 @@
+package io.opaa.group.sync;
+
+import io.opaa.api.dto.DirectorySyncGroupChange;
+import io.opaa.api.dto.DirectorySyncReportResponse;
+import io.opaa.api.dto.DirectorySyncStatusResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupMembership;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.GroupRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Directory synchronisation as a rights event (#237). Groups of {@link GroupKind#ORG_UNIT} exist
+ * only because a directory reports them; this service is the one place that reconciles the database
+ * with the directory's current state, and does so as a bulk permission change - the only place in
+ * the system where rights change in large numbers without an individual human decision.
+ *
+ * <p><b>Plan, then act.</b> {@link #buildPlan} computes the entire diff against the directory's
+ * snapshot without mutating anything. {@link #dryRun} and the plausibility-threshold abort path in
+ * {@link #run} both stop right there and only turn the plan into a report - so "nothing was
+ * written" is true by construction for those paths, not by carefully avoiding a save() call
+ * somewhere. Only {@link #run}, once the plan has been judged plausible, calls {@link #apply}.
+ *
+ * <p><b>Matching:</b> exclusively by {@link Group#getExternalId()} - the directory's stable
+ * identifier, never by name (see #237's acceptance criteria; a rename must be free of side
+ * effects).
+ *
+ * <p><b>Membership resolution:</b> flat only. A group's membership is exactly what the directory
+ * reports as its direct members; a member of a child organizational unit is never treated as an
+ * implicit member of the parent. Nested-group membership inheritance is called out as an open point
+ * in the feature spec and is deliberately left unresolved by this service - {@code parentGroupId}
+ * is recorded for #208's curator escalation only.
+ */
+@Service
+@Transactional(readOnly = true)
+public class DirectorySyncService {
+
+  private static final Logger log = LoggerFactory.getLogger(DirectorySyncService.class);
+
+  private final DirectoryClient directoryClient;
+  private final GroupRepository groupRepository;
+  private final UserRepository userRepository;
+  private final GroupMembershipResolver membershipResolver;
+  private final DirectorySyncStatusRepository statusRepository;
+  private final DirectorySyncProperties properties;
+
+  public DirectorySyncService(
+      DirectoryClient directoryClient,
+      GroupRepository groupRepository,
+      UserRepository userRepository,
+      GroupMembershipResolver membershipResolver,
+      DirectorySyncStatusRepository statusRepository,
+      DirectorySyncProperties properties) {
+    this.directoryClient = directoryClient;
+    this.groupRepository = groupRepository;
+    this.userRepository = userRepository;
+    this.membershipResolver = membershipResolver;
+    this.statusRepository = statusRepository;
+    this.properties = properties;
+  }
+
+  /** Computes the diff against the directory's current state. Never writes anything. */
+  public DirectorySyncReportResponse dryRun(UUID organizationId) {
+    return execute(organizationId, false);
+  }
+
+  /**
+   * Computes the diff and applies it if - and only if - the directory was reachable, did not return
+   * an implausibly empty group list, and the fraction of memberships it would remove does not
+   * exceed {@link DirectorySyncProperties#changeThresholdFraction()}. Otherwise behaves like {@link
+   * #dryRun} and reports why nothing was written.
+   */
+  @Transactional
+  public DirectorySyncReportResponse run(UUID organizationId) {
+    return execute(organizationId, true);
+  }
+
+  public DirectorySyncStatusResponse getStatus(UUID organizationId) {
+    return statusRepository
+        .findByOrganizationId(organizationId)
+        .map(
+            status ->
+                new DirectorySyncStatusResponse()
+                    .lastRunAt(status.getLastRunAt())
+                    .lastOutcome(status.getLastOutcome())
+                    .lastMessage(status.getLastMessage())
+                    .lastAppliedAt(status.getLastAppliedAt())
+                    .lastChangedFraction(status.getLastChangedFraction()))
+        .orElseGet(DirectorySyncStatusResponse::new);
+  }
+
+  private DirectorySyncReportResponse execute(UUID organizationId, boolean applyIfPlausible) {
+    Instant now = Instant.now();
+    DirectorySnapshot snapshot;
+    try {
+      snapshot = directoryClient.fetchGroups(organizationId);
+    } catch (DirectoryUnavailableException e) {
+      String message = "Verzeichnis nicht erreichbar. Der letzte bekannte Stand bleibt in Kraft.";
+      log.warn(
+          "Directory sync: directory unreachable for organization {}: {}",
+          organizationId,
+          e.getMessage());
+      return recordAndReport(
+          organizationId, now, DirectorySyncOutcome.UNREACHABLE, message, emptyPlan());
+    }
+
+    List<Group> existingOrgUnits =
+        groupRepository.findByOrganizationIdAndKindOrgUnit(organizationId);
+
+    if (snapshot.groups().isEmpty() && !existingOrgUnits.isEmpty()) {
+      String message =
+          "Das Verzeichnis hat eine leere Gruppenliste geliefert, obwohl "
+              + existingOrgUnits.size()
+              + " Organisationseinheit(en) bekannt sind. Der Lauf wurde ohne Aenderungen"
+              + " abgebrochen.";
+      log.warn(
+          "Directory sync: directory returned an empty group list for organization {} while {}"
+              + " ORG_UNIT groups exist - aborting without changes",
+          organizationId,
+          existingOrgUnits.size());
+      return recordAndReport(
+          organizationId, now, DirectorySyncOutcome.ABORTED_EMPTY_RESULT, message, emptyPlan());
+    }
+
+    SyncPlan plan = buildPlan(organizationId, snapshot, existingOrgUnits);
+    double changedFraction =
+        plan.existingMembershipCount() == 0
+            ? 0.0
+            : (double) plan.membershipsRemoved() / plan.existingMembershipCount();
+
+    if (changedFraction > properties.changeThresholdFraction()) {
+      String message =
+          String.format(
+              Locale.ROOT,
+              "Der Lauf wuerde %.1f%% der bestehenden Mitgliedschaften entfernen und damit die"
+                  + " konfigurierte Schwelle von %.1f%% ueberschreiten. Abgebrochen ohne"
+                  + " Aenderungen.",
+              changedFraction * 100,
+              properties.changeThresholdFraction() * 100);
+      log.warn(
+          "Directory sync: run for organization {} would remove {} of {} memberships ({}%%,"
+              + " threshold {}%%) - aborting without changes",
+          organizationId,
+          plan.membershipsRemoved(),
+          plan.existingMembershipCount(),
+          changedFraction * 100,
+          properties.changeThresholdFraction() * 100);
+      return recordAndReport(
+          organizationId, now, DirectorySyncOutcome.ABORTED_THRESHOLD, message, plan);
+    }
+
+    if (!applyIfPlausible) {
+      return recordAndReport(
+          organizationId,
+          now,
+          DirectorySyncOutcome.DRY_RUN,
+          "Trockenlauf - keine Aenderung.",
+          plan);
+    }
+
+    applyPlan(organizationId, now, plan);
+    return recordAndReport(
+        organizationId, now, DirectorySyncOutcome.APPLIED, "Synchronisation angewendet.", plan);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Plan building - read-only
+  // ---------------------------------------------------------------------------------------
+
+  private SyncPlan buildPlan(
+      UUID organizationId, DirectorySnapshot snapshot, List<Group> existingOrgUnits) {
+    Map<String, Group> existingByExternalId = new HashMap<>();
+    for (Group group : existingOrgUnits) {
+      if (group.getExternalId() != null) {
+        existingByExternalId.put(group.getExternalId(), group);
+      }
+    }
+
+    int existingMembershipCount = 0;
+    for (Group group : existingOrgUnits) {
+      if (!group.isDissolved()) {
+        existingMembershipCount += group.getMemberships().size();
+      }
+    }
+
+    List<PlannedCreate> creates = new ArrayList<>();
+    List<PlannedRename> renames = new ArrayList<>();
+    List<PlannedReactivation> reactivations = new ArrayList<>();
+    List<PlannedMembershipChange> membershipChanges = new ArrayList<>();
+    int membershipsAdded = 0;
+    int membershipsRemoved = 0;
+    int unresolvedMemberCount = 0;
+
+    Set<String> incomingExternalIds = new HashSet<>();
+    for (DirectoryGroup incoming : snapshot.groups()) {
+      if (incoming.externalId().isBlank() || incoming.name().isBlank()) {
+        log.warn(
+            "Directory sync: skipping malformed directory group for organization {} (blank"
+                + " externalId or name)",
+            organizationId);
+        continue;
+      }
+      incomingExternalIds.add(incoming.externalId());
+
+      ResolvedMembers resolved = resolveMembers(organizationId, incoming.memberSubjects());
+      unresolvedMemberCount += resolved.unresolvedCount();
+
+      Group existing = existingByExternalId.get(incoming.externalId());
+      if (existing == null) {
+        creates.add(new PlannedCreate(incoming, resolved.userIds()));
+        membershipsAdded += resolved.userIds().size();
+        continue;
+      }
+
+      if (existing.isDissolved()) {
+        reactivations.add(new PlannedReactivation(existing));
+      }
+
+      if (!existing.getName().equals(incoming.name())) {
+        renames.add(new PlannedRename(existing, incoming.name()));
+      }
+
+      Set<UUID> currentMemberIds = new HashSet<>();
+      for (GroupMembership membership : existing.getMemberships()) {
+        currentMemberIds.add(membership.getUserId());
+      }
+      Set<UUID> toAdd = new HashSet<>(resolved.userIds());
+      toAdd.removeAll(currentMemberIds);
+      Set<UUID> toRemove = new HashSet<>(currentMemberIds);
+      toRemove.removeAll(resolved.userIds());
+
+      if (!toAdd.isEmpty() || !toRemove.isEmpty()) {
+        membershipChanges.add(new PlannedMembershipChange(existing, toAdd, toRemove));
+        membershipsAdded += toAdd.size();
+        membershipsRemoved += toRemove.size();
+      }
+    }
+
+    List<PlannedDissolution> dissolutions = new ArrayList<>();
+    for (Group existing : existingOrgUnits) {
+      if (!existing.isDissolved()
+          && existing.getExternalId() != null
+          && !incomingExternalIds.contains(existing.getExternalId())) {
+        dissolutions.add(new PlannedDissolution(existing));
+      }
+    }
+
+    return new SyncPlan(
+        creates,
+        renames,
+        reactivations,
+        membershipChanges,
+        dissolutions,
+        membershipsAdded,
+        membershipsRemoved,
+        unresolvedMemberCount,
+        existingMembershipCount);
+  }
+
+  private ResolvedMembers resolveMembers(UUID organizationId, Set<String> subjects) {
+    if (subjects.isEmpty()) {
+      return new ResolvedMembers(Set.of(), 0);
+    }
+    List<User> users = userRepository.findByOrganizationIdAndSubjectIn(organizationId, subjects);
+    Set<UUID> userIds = new HashSet<>();
+    for (User user : users) {
+      userIds.add(user.getId());
+    }
+    int unresolved = subjects.size() - users.size();
+    return new ResolvedMembers(userIds, Math.max(unresolved, 0));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Applying the plan
+  // ---------------------------------------------------------------------------------------
+
+  private void applyPlan(UUID organizationId, Instant now, SyncPlan plan) {
+    Set<UUID> affectedUserIds = new HashSet<>();
+
+    for (PlannedCreate create : plan.creates()) {
+      DirectoryGroup incoming = create.directoryGroup();
+      UUID parentGroupId = resolveParentGroupId(organizationId, incoming.parentExternalId());
+      Group group =
+          new Group(
+              organizationId,
+              GroupKind.ORG_UNIT,
+              incoming.name(),
+              null,
+              incoming.externalId(),
+              parentGroupId);
+      for (UUID userId : create.memberUserIds()) {
+        group.addMembership(new GroupMembership(userId, organizationId));
+        affectedUserIds.add(userId);
+      }
+      groupRepository.save(group);
+      log.info(
+          "Directory sync: created group {} ({}, external id {}) with {} member(s)",
+          group.getId(),
+          group.getName(),
+          group.getExternalId(),
+          create.memberUserIds().size());
+    }
+
+    for (PlannedReactivation reactivation : plan.reactivations()) {
+      reactivation.group().reactivate();
+      log.info(
+          "Directory sync: group {} ({}) reactivated - reported by the directory again after"
+              + " having been dissolved",
+          reactivation.group().getId(),
+          reactivation.group().getExternalId());
+    }
+
+    for (PlannedRename rename : plan.renames()) {
+      log.info(
+          "Directory sync: group {} ({}) renamed from '{}' to '{}'",
+          rename.group().getId(),
+          rename.group().getExternalId(),
+          rename.group().getName(),
+          rename.newName());
+      rename.group().renameFromDirectory(rename.newName());
+    }
+
+    for (PlannedMembershipChange change : plan.membershipChanges()) {
+      for (UUID userId : change.toAdd()) {
+        change.group().addMembership(new GroupMembership(userId, organizationId));
+        affectedUserIds.add(userId);
+        log.info(
+            "Directory sync: added user {} to group {} ({})",
+            userId,
+            change.group().getId(),
+            change.group().getExternalId());
+      }
+      for (UUID userId : change.toRemove()) {
+        change.group().getMemberships().stream()
+            .filter(m -> m.getUserId().equals(userId))
+            .findFirst()
+            .ifPresent(change.group()::removeMembership);
+        affectedUserIds.add(userId);
+        log.info(
+            "Directory sync: removed user {} from group {} ({})",
+            userId,
+            change.group().getId(),
+            change.group().getExternalId());
+      }
+    }
+
+    for (PlannedDissolution dissolution : plan.dissolutions()) {
+      dissolution.group().dissolve(now);
+      log.info(
+          "Directory sync: group {} ({}) marked dissolved - no longer reported by the directory,"
+              + " reach frozen at {} member(s)",
+          dissolution.group().getId(),
+          dissolution.group().getExternalId(),
+          dissolution.group().getMemberships().size());
+    }
+
+    List<Group> touched = new ArrayList<>();
+    plan.reactivations().forEach(r -> touched.add(r.group()));
+    plan.renames().forEach(r -> touched.add(r.group()));
+    plan.membershipChanges().forEach(c -> touched.add(c.group()));
+    plan.dissolutions().forEach(d -> touched.add(d.group()));
+    if (!touched.isEmpty()) {
+      groupRepository.saveAll(touched);
+    }
+
+    if (!affectedUserIds.isEmpty()) {
+      invalidateAfterCommit(() -> membershipResolver.invalidateUsers(affectedUserIds));
+    }
+  }
+
+  private UUID resolveParentGroupId(UUID organizationId, String parentExternalId) {
+    if (parentExternalId == null || parentExternalId.isBlank()) {
+      return null;
+    }
+    return groupRepository.findByOrganizationIdAndKindOrgUnit(organizationId).stream()
+        .filter(g -> parentExternalId.equals(g.getExternalId()))
+        .map(Group::getId)
+        .findFirst()
+        .orElse(null);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Status persistence and report assembly
+  // ---------------------------------------------------------------------------------------
+
+  private DirectorySyncReportResponse recordAndReport(
+      UUID organizationId,
+      Instant now,
+      DirectorySyncOutcome outcome,
+      String message,
+      SyncPlan plan) {
+    double changedFraction =
+        plan.existingMembershipCount() == 0
+            ? 0.0
+            : (double) plan.membershipsRemoved() / plan.existingMembershipCount();
+
+    DirectorySyncStatus status =
+        statusRepository
+            .findByOrganizationId(organizationId)
+            .orElseGet(() -> new DirectorySyncStatus(organizationId));
+    status.recordRun(now, outcome, message, changedFraction);
+    statusRepository.save(status);
+
+    DirectorySyncReportResponse response =
+        new DirectorySyncReportResponse(
+            outcome,
+            now,
+            toChanges(plan.creates()),
+            toRenameChanges(plan.renames()),
+            toDissolutionChanges(plan.dissolutions()),
+            plan.membershipsAdded(),
+            plan.membershipsRemoved(),
+            changedFraction,
+            properties.changeThresholdFraction(),
+            message);
+    response.unresolvedMemberCount(plan.unresolvedMemberCount());
+    return response;
+  }
+
+  private SyncPlan emptyPlan() {
+    return new SyncPlan(List.of(), List.of(), List.of(), List.of(), List.of(), 0, 0, 0, 0);
+  }
+
+  private List<DirectorySyncGroupChange> toChanges(List<PlannedCreate> creates) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedCreate create : creates) {
+      result.add(
+          new DirectorySyncGroupChange(
+              create.directoryGroup().externalId(), create.directoryGroup().name()));
+    }
+    return result;
+  }
+
+  private List<DirectorySyncGroupChange> toRenameChanges(List<PlannedRename> renames) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedRename rename : renames) {
+      result.add(
+          new DirectorySyncGroupChange(rename.group().getExternalId(), rename.newName())
+              .previousName(rename.group().getName()));
+    }
+    return result;
+  }
+
+  private List<DirectorySyncGroupChange> toDissolutionChanges(
+      List<PlannedDissolution> dissolutions) {
+    List<DirectorySyncGroupChange> result = new ArrayList<>();
+    for (PlannedDissolution dissolution : dissolutions) {
+      result.add(
+          new DirectorySyncGroupChange(
+              dissolution.group().getExternalId(), dissolution.group().getName()));
+    }
+    return result;
+  }
+
+  /**
+   * Same deferred-invalidation pattern as {@code GroupService#invalidateAfterCommit}: an inline
+   * invalidation here could race a concurrent reader into repopulating the cache with pre-commit
+   * membership, for the same reason described there.
+   */
+  private void invalidateAfterCommit(Runnable invalidation) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      invalidation.run();
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            invalidation.run();
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Plan data structures
+  // ---------------------------------------------------------------------------------------
+
+  private record ResolvedMembers(Set<UUID> userIds, int unresolvedCount) {}
+
+  private record PlannedCreate(DirectoryGroup directoryGroup, Set<UUID> memberUserIds) {}
+
+  private record PlannedRename(Group group, String newName) {}
+
+  private record PlannedReactivation(Group group) {}
+
+  private record PlannedMembershipChange(Group group, Set<UUID> toAdd, Set<UUID> toRemove) {}
+
+  private record PlannedDissolution(Group group) {}
+
+  private record SyncPlan(
+      List<PlannedCreate> creates,
+      List<PlannedRename> renames,
+      List<PlannedReactivation> reactivations,
+      List<PlannedMembershipChange> membershipChanges,
+      List<PlannedDissolution> dissolutions,
+      int membershipsAdded,
+      int membershipsRemoved,
+      int unresolvedMemberCount,
+      int existingMembershipCount) {}
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
@@ -98,7 +98,7 @@ public class DirectorySyncService {
           "Directory sync: directory unreachable for organization {}: {}",
           organizationId,
           e.getMessage());
-      statusRecorder.record(organizationId, now, DirectorySyncOutcome.UNREACHABLE, message, 0.0);
+      recordStatusSafely(organizationId, now, DirectorySyncOutcome.UNREACHABLE, message, 0.0);
       return new DirectorySyncReportResponse(
               DirectorySyncOutcome.UNREACHABLE,
               now,
@@ -122,8 +122,36 @@ public class DirectorySyncService {
         applyIfPlausible
             ? planExecutor.planAndApply(organizationId, now, snapshot)
             : planExecutor.planOnly(organizationId, now, snapshot);
-    statusRecorder.record(
+    recordStatusSafely(
         organizationId, now, report.getOutcome(), report.getMessage(), report.getChangedFraction());
     return report;
+  }
+
+  /**
+   * A failure here (e.g. the status row's own insert/update failing) must not turn an already
+   * successful, already-committed plan/apply - or an already-built unreachable report - into an
+   * error response: the group/membership changes (if any) are real regardless, and the caller still
+   * needs the report. Under-recording the status is the safer direction of the two failure modes
+   * (review of PR #297): a missing or stale status line is visible and prompts an operator to
+   * check, whereas swallowing the report behind an exception here would additionally invite a retry
+   * of a run that already applied.
+   */
+  private void recordStatusSafely(
+      UUID organizationId,
+      Instant now,
+      DirectorySyncOutcome outcome,
+      String message,
+      double changedFraction) {
+    try {
+      statusRecorder.record(organizationId, now, outcome, message, changedFraction);
+    } catch (RuntimeException e) {
+      log.error(
+          "Directory sync: failed to record the outcome ({}) for organization {} - the run itself"
+              + " completed and its report is still returned, but the status table may now be"
+              + " stale",
+          outcome,
+          organizationId,
+          e);
+    }
   }
 }

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncService.java
@@ -17,6 +17,20 @@ import org.springframework.stereotype.Service;
  * for the duration of a network call (review of PR #297). The transactional plan computation and,
  * if applicable, application live in {@link DirectorySyncPlanExecutor}, a separate bean called from
  * here through Spring's proxy.
+ *
+ * <p><b>Known gap: concurrent runs are not serialised, and the fetch-to-apply window is real.</b>
+ * Moving the directory fetch outside any transaction (above) widens the time between reading the
+ * directory and applying the diff; a change made through the admin UI in that window - e.g. an
+ * operator adding someone to an {@code AD_HOC} group, or (once #208 exists) a curator action on an
+ * {@code ORG_UNIT} group - is not part of the snapshot this run diffs against and can be reverted
+ * by it. Likewise, nothing here stops two calls to {@link #run} for the same organization from
+ * overlapping. Neither is new to this change - the previous, single-transaction version had a
+ * narrower but non-zero version of the same window - but the window is now large enough to be worth
+ * naming rather than assuming away. Out of scope for #237: closing it needs either serialising runs
+ * per organization (e.g. a Postgres advisory lock keyed on {@code organizationId}, held for the
+ * whole {@link #execute}) or accepting last-writer-wins and documenting it as a deployment
+ * constraint (run synchronisation on a schedule, never concurrently, never overlapping an admin
+ * bulk-edit window).
  */
 @Service
 public class DirectorySyncService {
@@ -100,8 +114,16 @@ public class DirectorySyncService {
           .unresolvedMemberCount(0);
     }
 
-    return applyIfPlausible
-        ? planExecutor.planAndApply(organizationId, now, snapshot)
-        : planExecutor.planOnly(organizationId, now, snapshot);
+    // If planAndApply's transaction fails to commit (e.g. a directory-supplied value that
+    // violates a column constraint), the exception propagates from here and nothing below runs -
+    // so a failed apply can never be recorded as APPLIED. See DirectorySyncPlanExecutor's class
+    // javadoc for the defect this replaced (review of PR #297).
+    DirectorySyncReportResponse report =
+        applyIfPlausible
+            ? planExecutor.planAndApply(organizationId, now, snapshot)
+            : planExecutor.planOnly(organizationId, now, snapshot);
+    statusRecorder.record(
+        organizationId, now, report.getOutcome(), report.getMessage(), report.getChangedFraction());
+    return report;
   }
 }

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatus.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatus.java
@@ -1,0 +1,99 @@
+package io.opaa.group.sync;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The durable half of "last-known-good" (#237): one row per organization recording the outcome of
+ * the most recent synchronisation run, including dry runs and unreachable attempts. Exists so an
+ * unreachable directory's state is reported persistently - visible to whoever checks later, not
+ * only to whoever happened to trigger the run that discovered it.
+ */
+@Entity
+@Table(
+    name = "directory_sync_status",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_directory_sync_status_organization",
+            columnNames = "organization_id"))
+public class DirectorySyncStatus {
+
+  @Id private UUID id;
+
+  @Column(name = "organization_id", nullable = false)
+  private UUID organizationId;
+
+  @Column(name = "last_run_at", nullable = false)
+  private Instant lastRunAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "last_outcome", nullable = false, length = 30)
+  private DirectorySyncOutcome lastOutcome;
+
+  @Column(name = "last_message", length = 2000)
+  private String lastMessage;
+
+  @Column(name = "last_changed_fraction")
+  private Double lastChangedFraction;
+
+  @Column(name = "last_applied_at")
+  private Instant lastAppliedAt;
+
+  protected DirectorySyncStatus() {}
+
+  public DirectorySyncStatus(UUID organizationId) {
+    this.id = UUID.randomUUID();
+    this.organizationId = organizationId;
+  }
+
+  /**
+   * Records the outcome of a run. {@code lastAppliedAt} is only advanced when {@code outcome} is
+   * {@link DirectorySyncOutcome#APPLIED} - it is specifically the timestamp of the last time rights
+   * actually changed, not of the last attempt.
+   */
+  public void recordRun(
+      Instant runAt, DirectorySyncOutcome outcome, String message, double changedFraction) {
+    this.lastRunAt = runAt;
+    this.lastOutcome = outcome;
+    this.lastMessage = message;
+    this.lastChangedFraction = changedFraction;
+    if (outcome == DirectorySyncOutcome.APPLIED) {
+      this.lastAppliedAt = runAt;
+    }
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public Instant getLastRunAt() {
+    return lastRunAt;
+  }
+
+  public DirectorySyncOutcome getLastOutcome() {
+    return lastOutcome;
+  }
+
+  public String getLastMessage() {
+    return lastMessage;
+  }
+
+  public Double getLastChangedFraction() {
+    return lastChangedFraction;
+  }
+
+  public Instant getLastAppliedAt() {
+    return lastAppliedAt;
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
@@ -3,20 +3,19 @@ package io.opaa.group.sync;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Persists the outcome of a directory synchronisation run in its own transaction, independent of
- * the caller's. A separate bean rather than a private method on {@link DirectorySyncPlanExecutor}
- * or {@link DirectorySyncService} because {@code REQUIRES_NEW} on a method only takes effect
- * through Spring's proxy - a self-invoked private method on the same instance would silently run in
- * whatever transaction (or lack of one) is already active, which is exactly the bug review of PR
- * #297 found: under {@link DirectorySyncService#dryRun}'s read-only transaction, Hibernate's {@code
- * FlushMode.MANUAL} silently dropped the status insert. With this as a dedicated bean, the write
- * commits (or rolls back) on its own regardless of what the caller's transaction is doing, so "the
- * directory being unreachable is durably reported" holds for every entry point, including a dry
- * run.
+ * Persists the outcome of a directory synchronisation run. Called only from {@link
+ * DirectorySyncService}, which is itself not transactional and calls this only after {@link
+ * DirectorySyncPlanExecutor#planAndApply}/{@code planOnly} has already returned successfully - so
+ * there is never an ambient transaction to consider here, and a failed apply (its transaction
+ * rolled back) never reaches this class at all. An earlier version of this class ran under {@code
+ * REQUIRES_NEW} to escape the caller's transaction; that requirement disappeared along with the
+ * caller ever having one - see {@link DirectorySyncPlanExecutor}'s class javadoc for the defect
+ * that motivated moving the call here (review of PR #297: a REQUIRES_NEW status write could commit
+ * before the surrounding apply transaction later rolled back, durably recording {@code APPLIED} for
+ * a run that never actually applied).
  */
 @Service
 public class DirectorySyncStatusRecorder {
@@ -27,7 +26,7 @@ public class DirectorySyncStatusRecorder {
     this.statusRepository = statusRepository;
   }
 
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @Transactional
   public void record(
       UUID organizationId,
       Instant runAt,

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
@@ -1,0 +1,44 @@
+package io.opaa.group.sync;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists the outcome of a directory synchronisation run in its own transaction, independent of
+ * the caller's. A separate bean rather than a private method on {@link DirectorySyncPlanExecutor}
+ * or {@link DirectorySyncService} because {@code REQUIRES_NEW} on a method only takes effect
+ * through Spring's proxy - a self-invoked private method on the same instance would silently run in
+ * whatever transaction (or lack of one) is already active, which is exactly the bug review of PR
+ * #297 found: under {@link DirectorySyncService#dryRun}'s read-only transaction, Hibernate's {@code
+ * FlushMode.MANUAL} silently dropped the status insert. With this as a dedicated bean, the write
+ * commits (or rolls back) on its own regardless of what the caller's transaction is doing, so "the
+ * directory being unreachable is durably reported" holds for every entry point, including a dry
+ * run.
+ */
+@Service
+public class DirectorySyncStatusRecorder {
+
+  private final DirectorySyncStatusRepository statusRepository;
+
+  public DirectorySyncStatusRecorder(DirectorySyncStatusRepository statusRepository) {
+    this.statusRepository = statusRepository;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void record(
+      UUID organizationId,
+      Instant runAt,
+      DirectorySyncOutcome outcome,
+      String message,
+      double changedFraction) {
+    DirectorySyncStatus status =
+        statusRepository
+            .findByOrganizationId(organizationId)
+            .orElseGet(() -> new DirectorySyncStatus(organizationId));
+    status.recordRun(runAt, outcome, message, changedFraction);
+    statusRepository.save(status);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRepository.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRepository.java
@@ -1,0 +1,10 @@
+package io.opaa.group.sync;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectorySyncStatusRepository extends JpaRepository<DirectorySyncStatus, UUID> {
+
+  Optional<DirectorySyncStatus> findByOrganizationId(UUID organizationId);
+}

--- a/backend/src/main/java/io/opaa/group/sync/DirectoryUnavailableException.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectoryUnavailableException.java
@@ -1,0 +1,20 @@
+package io.opaa.group.sync;
+
+/**
+ * Thrown by {@link DirectoryClient#fetchGroups} when the directory cannot be reached at all
+ * (connection failure, timeout, authentication failure against the directory itself). {@link
+ * DirectorySyncService} treats this as last-known-good: nothing is changed, the previous
+ * synchronisation's result stays in force, and the unreachable state is reported rather than
+ * treated as "zero groups" (see #237's acceptance criteria - an unreachable directory must never be
+ * able to revoke rights).
+ */
+public class DirectoryUnavailableException extends Exception {
+
+  public DirectoryUnavailableException(String message) {
+    super(message);
+  }
+
+  public DirectoryUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/src/main/java/io/opaa/group/sync/NoOpDirectoryClient.java
+++ b/backend/src/main/java/io/opaa/group/sync/NoOpDirectoryClient.java
@@ -1,0 +1,19 @@
+package io.opaa.group.sync;
+
+import java.util.UUID;
+
+/**
+ * Default {@link DirectoryClient} used whenever no real directory connection is configured (see
+ * {@link DirectorySyncConfiguration}). Always reports the directory as unreachable rather than,
+ * say, returning an empty group list - "no directory configured" and "directory unreachable"
+ * require the identical safe response (last-known-good, nothing revoked, see #237), so there is no
+ * reason to invent a third state for this case.
+ */
+public class NoOpDirectoryClient implements DirectoryClient {
+
+  @Override
+  public DirectorySnapshot fetchGroups(UUID organizationId) throws DirectoryUnavailableException {
+    throw new DirectoryUnavailableException(
+        "No directory client is configured for this deployment");
+  }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -86,6 +86,8 @@ opaa:
       global-max-requests: ${OPAA_RATE_LIMIT_INDEXING_GLOBAL_MAX_REQUESTS:5}
   cors:
     allowed-origins: ${OPAA_CORS_ALLOWED_ORIGINS:http://localhost:5173}
+  directory-sync:
+    change-threshold-fraction: ${OPAA_DIRECTORY_SYNC_CHANGE_THRESHOLD_FRACTION:0.3}
 
 management:
   endpoints:

--- a/backend/src/main/resources/db/changelog/changes/011-directory-sync.yaml
+++ b/backend/src/main/resources/db/changelog/changes/011-directory-sync.yaml
@@ -1,0 +1,102 @@
+databaseChangeLog:
+  # Two independent changeSets that land together because both are prerequisites for #237's
+  # directory synchronisation: the group lifecycle it introduces (dissolution) and its own status
+  # table.
+
+  - changeSet:
+      id: 011-add-dissolved-to-groups
+      author: opaa
+      comment: >
+        Add dissolved/dissolved_at to groups (#237). Set when directory synchronisation no longer
+        sees an ORG_UNIT group in the directory - a merge or reorganisation, not a deletion. The
+        group and its existing memberships are kept as-is; dissolved only marks that its reach can
+        no longer grow through synchronisation (see docs/features/spaces-and-assets.md#verzeichnissynchronisation-als-rechteereignis).
+      changes:
+        - addColumn:
+            tableName: groups
+            columns:
+              - column:
+                  name: dissolved
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dissolved_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: groups
+            columnName: dissolved_at
+        - dropColumn:
+            tableName: groups
+            columnName: dissolved
+
+  - changeSet:
+      id: 011-create-directory-sync-status
+      author: opaa
+      comment: >
+        One row per organization recording the outcome of the most recent directory
+        synchronisation run (dry run or applied) - the durable half of "last-known-good": even
+        when the directory is unreachable and nothing changes, the unreachable state itself must
+        be reported (see #237's acceptance criteria), not just returned in the response of the
+        request that triggered it.
+      changes:
+        - createTable:
+            tableName: directory_sync_status
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_run_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_outcome
+                  type: varchar(30)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_message
+                  type: varchar(2000)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_changed_fraction
+                  type: double precision
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_applied_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: directory_sync_status
+            baseColumnNames: organization_id
+            referencedTableName: organizations
+            referencedColumnNames: id
+            constraintName: fk_directory_sync_status_organization
+            onDelete: RESTRICT
+        - addUniqueConstraint:
+            tableName: directory_sync_status
+            columnNames: organization_id
+            constraintName: uk_directory_sync_status_organization
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: directory_sync_status
+            constraintName: fk_directory_sync_status_organization
+        - dropTable:
+            tableName: directory_sync_status

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -1332,11 +1332,16 @@ components:
           type: number
           format: double
           description: >
-            Fraction of memberships at risk this run - removals plus the memberships of groups
-            that would be dissolved, since a dissolved group's reach is capped the same way a
-            revoked grant would be. Relative to the memberships of every group this run actually
-            touches (new, renamed, membership-changed, dissolved, reactivated); untouched groups
-            are excluded from both sides of the ratio.
+            The worse of two independent risk measures, each compared against the configured
+            threshold on its own: the fraction of memberships at risk (removals plus the
+            memberships of groups that would be dissolved, relative to the memberships of every
+            group that was active before this run or is reactivated by it - a group that stayed
+            dissolved and unreported is excluded from this side), and the fraction of active
+            groups that would be dissolved this run (relative to all groups active before this
+            run - matched-but-unchanged groups are included in this denominator, since they are
+            part of what "active" means here). The second measure exists because an
+            introduction-phase directory often has ORG_UNIT groups with no members yet, which the
+            first measure cannot see a mass dissolution of.
           example: 0.05
         thresholdFraction:
           type: number

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -375,6 +375,59 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/admin/directory-sync/dry-run:
+    post:
+      operationId: runDirectorySyncDryRun
+      tags: [admin]
+      summary: Compute the directory synchronisation diff without applying it (system admin only)
+      description: >
+        Fetches the current directory state and computes what would change, but never writes
+        anything - not even when the run would otherwise be applicable. See #237.
+      responses:
+        "200":
+          description: Dry-run report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectorySyncReportResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/admin/directory-sync/run:
+    post:
+      operationId: runDirectorySync
+      tags: [admin]
+      summary: Run directory synchronisation and apply changes if plausible (system admin only)
+      description: >
+        Applies changes only if the directory is reachable, did not return an empty group list
+        while ORG_UNIT groups already exist, and the fraction of memberships that would be
+        removed does not exceed the configured threshold. Otherwise the run is aborted without
+        writing anything, and the report explains why. See #237.
+      responses:
+        "200":
+          description: Synchronisation report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectorySyncReportResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/admin/directory-sync/status:
+    get:
+      operationId: getDirectorySyncStatus
+      tags: [admin]
+      summary: Get the outcome of the most recent directory synchronisation run (system admin only)
+      responses:
+        "200":
+          description: Last known synchronisation status; all fields are null if no run has happened yet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectorySyncStatusResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /api/v1/spaces:
     get:
       operationId: listSpaces
@@ -1170,6 +1223,108 @@ components:
         userId:
           type: string
           format: uuid
+
+    DirectorySyncOutcome:
+      type: string
+      description: >
+        What a directory synchronisation run did. APPLIED and DRY_RUN both mean the run computed
+        a valid diff; the ABORTED_* and UNREACHABLE values mean nothing was written on purpose -
+        see #237.
+      enum: [APPLIED, DRY_RUN, ABORTED_THRESHOLD, ABORTED_EMPTY_RESULT, UNREACHABLE]
+      example: APPLIED
+
+    DirectorySyncGroupChange:
+      type: object
+      required: [externalId, name]
+      properties:
+        externalId:
+          type: string
+          example: directory-guid-1
+        name:
+          type: string
+          example: Referat 50
+        previousName:
+          type: string
+          nullable: true
+          description: Only set for a renamed group
+
+    DirectorySyncReportResponse:
+      type: object
+      required:
+        - outcome
+        - generatedAt
+        - groupsCreated
+        - groupsRenamed
+        - groupsDissolved
+        - membershipsAdded
+        - membershipsRemoved
+        - changedFraction
+        - thresholdFraction
+        - message
+      properties:
+        outcome:
+          $ref: "#/components/schemas/DirectorySyncOutcome"
+        generatedAt:
+          type: string
+          format: date-time
+        groupsCreated:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncGroupChange"
+        groupsRenamed:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncGroupChange"
+        groupsDissolved:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncGroupChange"
+        membershipsAdded:
+          type: integer
+          example: 4
+        membershipsRemoved:
+          type: integer
+          example: 1
+        unresolvedMemberCount:
+          type: integer
+          description: Directory members whose subject matched no known user; skipped, not an error
+          example: 0
+        changedFraction:
+          type: number
+          format: double
+          description: Fraction of pre-run memberships this run would remove (or removed)
+          example: 0.05
+        thresholdFraction:
+          type: number
+          format: double
+          example: 0.3
+        message:
+          type: string
+          example: Synchronisation angewendet.
+
+    DirectorySyncStatusResponse:
+      type: object
+      properties:
+        lastRunAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastOutcome:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/DirectorySyncOutcome"
+        lastMessage:
+          type: string
+          nullable: true
+        lastAppliedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp of the last run that actually applied changes (outcome APPLIED)
+        lastChangedFraction:
+          type: number
+          format: double
+          nullable: true
 
   responses:
     ValidationError:

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -1341,7 +1341,9 @@ components:
             run - matched-but-unchanged groups are included in this denominator, since they are
             part of what "active" means here). The second measure exists because an
             introduction-phase directory often has ORG_UNIT groups with no members yet, which the
-            first measure cannot see a mass dissolution of.
+            first measure cannot see a mass dissolution of; it only applies once the active-group
+            count or the dissolution count is large enough for a fraction to be meaningful, so a
+            single legitimate dissolution in a small organisation is never blocked by it.
           example: 0.05
         thresholdFraction:
           type: number

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -1248,6 +1248,40 @@ components:
           nullable: true
           description: Only set for a renamed group
 
+    DirectorySyncUserRef:
+      type: object
+      required: [userId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+          nullable: true
+
+    DirectorySyncMembershipChange:
+      type: object
+      required: [externalId, name, added, removed]
+      description: >
+        Which users would gain or lose membership of one group - the level of detail an admin
+        needs to decide before a run that would revoke access is applied (see #237's acceptance
+        criteria: the dry-run report must show what would change, not only how much).
+      properties:
+        externalId:
+          type: string
+          example: directory-guid-1
+        name:
+          type: string
+          example: Referat 50
+        added:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncUserRef"
+        removed:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncUserRef"
+
     DirectorySyncReportResponse:
       type: object
       required:
@@ -1256,6 +1290,7 @@ components:
         - groupsCreated
         - groupsRenamed
         - groupsDissolved
+        - membershipChanges
         - membershipsAdded
         - membershipsRemoved
         - changedFraction
@@ -1279,6 +1314,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DirectorySyncGroupChange"
+        membershipChanges:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySyncMembershipChange"
         membershipsAdded:
           type: integer
           example: 4
@@ -1292,7 +1331,12 @@ components:
         changedFraction:
           type: number
           format: double
-          description: Fraction of pre-run memberships this run would remove (or removed)
+          description: >
+            Fraction of memberships at risk this run - removals plus the memberships of groups
+            that would be dissolved, since a dissolved group's reach is capped the same way a
+            revoked grant would be. Relative to the memberships of every group this run actually
+            touches (new, renamed, membership-changed, dissolved, reactivated); untouched groups
+            are excluded from both sides of the ratio.
           example: 0.05
         thresholdFraction:
           type: number

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncPropertiesTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncPropertiesTest.java
@@ -1,0 +1,39 @@
+package io.opaa.group.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A safeguard against mass rights revocation must not silently become more lenient on invalid
+ * configuration. Review of PR #297 flagged that {@code changeThresholdFraction <= 0} used to fall
+ * back to the 0.3 default instead of rejecting the value - an operator who deliberately sets 0
+ * ("abort on any revocation at all") silently got 30% instead.
+ */
+class DirectorySyncPropertiesTest {
+
+  @Test
+  void rejectsAZeroThreshold() {
+    assertThatThrownBy(() -> new DirectorySyncProperties(0.0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsANegativeThreshold() {
+    assertThatThrownBy(() -> new DirectorySyncProperties(-0.3))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void rejectsAThresholdAboveOne() {
+    assertThatThrownBy(() -> new DirectorySyncProperties(1.5))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void acceptsAValidThreshold() {
+    DirectorySyncProperties properties = new DirectorySyncProperties(0.3);
+    assertThat(properties.changeThresholdFraction()).isEqualTo(0.3);
+  }
+}

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
@@ -1,0 +1,317 @@
+package io.opaa.group.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opaa.api.dto.DirectorySyncReportResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupMembership;
+import io.opaa.group.GroupMembershipRepository;
+import io.opaa.group.GroupRepository;
+import io.opaa.organization.Organization;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Exercises {@link DirectorySyncService} against a real Postgres database with the real, versioned
+ * Liquibase schema applied ({@code spring.liquibase.enabled=true}, {@code ddl-auto=none}) - not
+ * Hibernate-generated DDL. Follows {@code UserServicePersonalSpaceIntegrationTest}'s pattern rather
+ * than {@code GroupServiceIntegrationTest}'s: this class's dissolution/reactivation scenarios and
+ * the {@code fk_group_memberships_group_organization} composite foreign key both depend on real
+ * constraints that only the versioned changelog creates.
+ *
+ * <p>{@link FakeDirectoryClient} replaces the production {@link NoOpDirectoryClient} as the {@link
+ * DirectoryClient} bean (marked {@code @Primary}, so it wins regardless of bean registration order)
+ * - the one seam between the synchronisation policy under test and an actual directory, per {@link
+ * DirectoryClient}'s own javadoc.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(DirectorySyncServiceIntegrationTest.TestConfig.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class DirectorySyncServiceIntegrationTest {
+
+  @TestConfiguration(proxyBeanMethods = false)
+  static class TestConfig {
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer postgresContainer() {
+      return new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+    }
+
+    @Bean
+    @Primary
+    FakeDirectoryClient fakeDirectoryClient() {
+      return new FakeDirectoryClient();
+    }
+  }
+
+  static class FakeDirectoryClient implements DirectoryClient {
+    private DirectorySnapshot snapshot = new DirectorySnapshot(Instant.now(), List.of());
+    private DirectoryUnavailableException failure;
+
+    void respondWith(DirectoryGroup... groups) {
+      this.failure = null;
+      this.snapshot = new DirectorySnapshot(Instant.now(), List.of(groups));
+    }
+
+    void failWith(String message) {
+      this.failure = new DirectoryUnavailableException(message);
+    }
+
+    @Override
+    public DirectorySnapshot fetchGroups(UUID organizationId) throws DirectoryUnavailableException {
+      if (failure != null) {
+        throw failure;
+      }
+      return snapshot;
+    }
+  }
+
+  @Autowired private DirectorySyncService directorySyncService;
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private GroupMembershipRepository membershipRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private DirectorySyncStatusRepository statusRepository;
+  @Autowired private FakeDirectoryClient directoryClient;
+
+  // Real Liquibase FKs are in force in this test (fk_users_organization,
+  // fk_directory_sync_status_organization) - a random UUID would violate them. Organization.
+  // DEFAULT_ID is the row the 008 changelog seeds, the same one production uses until
+  // multi-organization management exists.
+  private UUID organizationId;
+
+  @BeforeEach
+  void cleanUp() {
+    statusRepository.deleteAll();
+    membershipRepository.deleteAll();
+    groupRepository.deleteAll();
+    userRepository.deleteAll();
+    organizationId = Organization.DEFAULT_ID;
+    directoryClient.respondWith();
+  }
+
+  private UUID createUser(UUID organizationId, String subject) {
+    User user = new User(subject, "test-issuer", subject + "@example.com", "Test User");
+    user.setOrganizationId(organizationId);
+    return userRepository.save(user).getId();
+  }
+
+  private Group persistOrgUnit(String externalId, String name, UUID... memberIds) {
+    Group group = new Group(organizationId, GroupKind.ORG_UNIT, name, null, externalId, null);
+    for (UUID memberId : memberIds) {
+      group.addMembership(new GroupMembership(memberId, organizationId));
+    }
+    return groupRepository.save(group);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Rename
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void aRenamedGroupKeepsItsGrantsAndItsMembers() {
+    UUID member = createUser(organizationId, "member-1");
+    Group existing = persistOrgUnit("dir-guid-1", "Altes Referat", member);
+
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Neues Referat", null, Set.of("member-1")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    assertThat(report.getGroupsRenamed()).hasSize(1);
+    Group reloaded = groupRepository.findById(existing.getId()).orElseThrow();
+    assertThat(reloaded.getName()).isEqualTo("Neues Referat");
+    assertThat(reloaded.getExternalId()).isEqualTo("dir-guid-1");
+    assertThat(membershipRepository.findByGroupId(reloaded.getId()))
+        .extracting(GroupMembership::getUserId)
+        .containsExactly(member);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Plausibility threshold
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void aRunThatRemovesMoreThanTheThresholdIsAbortedWithoutAnyChange() {
+    UUID memberA = createUser(organizationId, "a");
+    UUID memberB = createUser(organizationId, "b");
+    UUID memberC = createUser(organizationId, "c");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", memberA, memberB, memberC);
+
+    // Directory now reports only "a" - removing 2 of 3 memberships (67%), well above the 30%
+    // default threshold.
+    directoryClient.respondWith(new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("a")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.ABORTED_THRESHOLD);
+    assertThat(membershipRepository.findByGroupId(existing.getId())).hasSize(3);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Empty group list
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void anEmptyGroupListFromTheDirectoryRevokesNoRights() {
+    UUID member = createUser(organizationId, "member-1");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
+
+    directoryClient.respondWith(); // empty group list
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.ABORTED_EMPTY_RESULT);
+    assertThat(membershipRepository.findByGroupId(existing.getId())).hasSize(1);
+    assertThat(groupRepository.findById(existing.getId()).orElseThrow().isDissolved()).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Unreachable directory
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void anUnreachableDirectoryLeavesTheLastKnownGoodStateInForce() {
+    UUID member = createUser(organizationId, "member-1");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
+
+    directoryClient.failWith("connection refused");
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.UNREACHABLE);
+    assertThat(membershipRepository.findByGroupId(existing.getId())).hasSize(1);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Dry run
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void dryRunComputesTheFullDiffAndChangesNothing() {
+    UUID memberA = createUser(organizationId, "a");
+    UUID memberB = createUser(organizationId, "b");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", memberA);
+
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("a", "b")),
+        new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()));
+
+    DirectorySyncReportResponse report = directorySyncService.dryRun(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.DRY_RUN);
+    assertThat(report.getGroupsCreated()).hasSize(1);
+    assertThat(report.getMembershipsAdded()).isEqualTo(1);
+    // Nothing persisted.
+    assertThat(membershipRepository.findByGroupId(existing.getId())).hasSize(1);
+    assertThat(groupRepository.findByOrganizationId(organizationId)).hasSize(1);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Group creation
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void createsANewOrgUnitGroupWithItsMembers() {
+    UUID member = createUser(organizationId, "new-member");
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-9", "Referat 99", null, Set.of("new-member")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    List<Group> groups = groupRepository.findByOrganizationId(organizationId);
+    assertThat(groups).hasSize(1);
+    Group created = groups.get(0);
+    assertThat(created.getExternalId()).isEqualTo("dir-guid-9");
+    assertThat(created.getKind()).isEqualTo(GroupKind.ORG_UNIT);
+    assertThat(membershipRepository.findByGroupId(created.getId()))
+        .extracting(GroupMembership::getUserId)
+        .containsExactly(member);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Dissolution and reactivation
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void aGroupNoLongerReportedByTheDirectoryIsMarkedDissolvedWithMembershipFrozen() {
+    UUID member = createUser(organizationId, "member-1");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
+
+    // Directory no longer reports dir-guid-1 at all (merged into another unit).
+    directoryClient.respondWith(new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    assertThat(report.getGroupsDissolved()).hasSize(1);
+    Group reloaded = groupRepository.findById(existing.getId()).orElseThrow();
+    assertThat(reloaded.isDissolved()).isTrue();
+    assertThat(reloaded.getDissolvedAt()).isNotNull();
+    // Frozen, not revoked - the existing member keeps working.
+    assertThat(membershipRepository.findByGroupId(reloaded.getId()))
+        .extracting(GroupMembership::getUserId)
+        .containsExactly(member);
+  }
+
+  @Test
+  void aDissolvedGroupThatReappearsInTheDirectoryIsReactivatedAndResynchronised() {
+    UUID member = createUser(organizationId, "member-1");
+    UUID newMember = createUser(organizationId, "member-2");
+    Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
+    existing.dissolve(Instant.now());
+    groupRepository.save(existing);
+
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("member-1", "member-2")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    Group reloaded = groupRepository.findById(existing.getId()).orElseThrow();
+    assertThat(reloaded.isDissolved()).isFalse();
+    assertThat(reloaded.getDissolvedAt()).isNull();
+    assertThat(membershipRepository.findByGroupId(reloaded.getId()))
+        .extracting(GroupMembership::getUserId)
+        .containsExactlyInAnyOrder(member, newMember);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Status
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void statusReflectsTheMostRecentRunIncludingUnreachableAttempts() {
+    assertThat(directorySyncService.getStatus(organizationId).getLastOutcome()).isNull();
+
+    directoryClient.failWith("timeout");
+    directorySyncService.run(organizationId);
+
+    assertThat(directorySyncService.getStatus(organizationId).getLastOutcome())
+        .isEqualTo(DirectorySyncOutcome.UNREACHABLE);
+    assertThat(directorySyncService.getStatus(organizationId).getLastAppliedAt()).isNull();
+  }
+}

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import io.opaa.group.GroupMembershipRepository;
 import io.opaa.group.GroupRepository;
 import io.opaa.organization.Organization;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -260,9 +261,25 @@ class DirectorySyncServiceIntegrationTest {
   void aGroupNoLongerReportedByTheDirectoryIsMarkedDissolvedWithMembershipFrozen() {
     UUID member = createUser(organizationId, "member-1");
     Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
+    // A large, unrelated, unaffected group so the one dissolving membership stays well under the
+    // 30% threshold - this test is about the dissolution mechanics, not the threshold.
+    UUID[] bulkMembers = new UUID[9];
+    for (int i = 0; i < bulkMembers.length; i++) {
+      bulkMembers[i] = createUser(organizationId, "bulk-" + i);
+    }
+    persistOrgUnit("dir-guid-bulk", "Referat Bulk", bulkMembers);
 
-    // Directory no longer reports dir-guid-1 at all (merged into another unit).
-    directoryClient.respondWith(new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()));
+    // Directory no longer reports dir-guid-1 at all (merged into another unit); the bulk group is
+    // still reported unchanged.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()),
+        new DirectoryGroup(
+            "dir-guid-bulk",
+            "Referat Bulk",
+            null,
+            Set.of(
+                "bulk-0", "bulk-1", "bulk-2", "bulk-3", "bulk-4", "bulk-5", "bulk-6", "bulk-7",
+                "bulk-8")));
 
     DirectorySyncReportResponse report = directorySyncService.run(organizationId);
 
@@ -297,6 +314,156 @@ class DirectorySyncServiceIntegrationTest {
     assertThat(membershipRepository.findByGroupId(reloaded.getId()))
         .extracting(GroupMembership::getUserId)
         .containsExactlyInAnyOrder(member, newMember);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Combined mechanisms - review of PR #297: the plausibility threshold must catch a partial
+  // outage that manifests as mass dissolution, and must not lose its denominator when the
+  // affected group was already dissolved and is reactivating in the same run that changes it.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void aPartialOutageThatDissolvesMostGroupsIsCaughtByThePlausibilityThreshold() {
+    // 10 org units, one member each. The directory - after a partial outage - only reports 2 of
+    // them; the other 8 would be marked dissolved. Before the fix, a dissolution contributed
+    // nothing to the numerator, so this run reported changedFraction = 0.0 and applied silently.
+    List<DirectoryGroup> stillReported = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      UUID member = createUser(organizationId, "unit-" + i);
+      persistOrgUnit("dir-guid-" + i, "Referat " + i, member);
+      if (i < 2) {
+        stillReported.add(
+            new DirectoryGroup("dir-guid-" + i, "Referat " + i, null, Set.of("unit-" + i)));
+      }
+    }
+    directoryClient.respondWith(stillReported.toArray(new DirectoryGroup[0]));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.ABORTED_THRESHOLD);
+    assertThat(report.getChangedFraction()).isEqualTo(0.8);
+    long dissolvedCount =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(Group::isDissolved)
+            .count();
+    assertThat(dissolvedCount).isZero();
+  }
+
+  @Test
+  void reactivatingAnAllDissolvedGroupWithMostOfItsFrozenMembershipMissingIsCaughtByTheThreshold() {
+    // Only one group exists in the organization, already dissolved from an earlier run, with a
+    // frozen membership of 4. Before the fix, existingMembershipCount excluded every dissolved
+    // group unconditionally, so the denominator was 0 and the run "passed" with changedFraction
+    // = 0.0 regardless of how much of the reactivated group's membership disappeared.
+    UUID keptMember = createUser(organizationId, "kept");
+    UUID lostA = createUser(organizationId, "lost-a");
+    UUID lostB = createUser(organizationId, "lost-b");
+    UUID lostC = createUser(organizationId, "lost-c");
+    Group group = persistOrgUnit("dir-guid-1", "Referat 50", keptMember, lostA, lostB, lostC);
+    group.dissolve(Instant.now());
+    groupRepository.save(group);
+
+    // The directory reports the unit again (reactivation) but with only 1 of its 4 frozen
+    // members - a 75% loss within the only group that exists.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("kept")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.ABORTED_THRESHOLD);
+    assertThat(report.getChangedFraction()).isEqualTo(0.75);
+    Group reloaded = groupRepository.findById(group.getId()).orElseThrow();
+    // Aborted - still dissolved, membership untouched.
+    assertThat(reloaded.isDissolved()).isTrue();
+    assertThat(membershipRepository.findByGroupId(reloaded.getId())).hasSize(4);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Dry run persists its outcome - review of PR #297: under the class-level readOnly transaction
+  // dryRun used to run in, Hibernate's FlushMode.MANUAL silently dropped the status insert.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void dryRunPersistsItsOutcomeEvenThoughItNeverWritesGroupData() {
+    UUID member = createUser(organizationId, "member-1");
+    persistOrgUnit("dir-guid-1", "Referat 50", member);
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("member-1")));
+
+    directorySyncService.dryRun(organizationId);
+
+    DirectorySyncStatus status =
+        statusRepository.findByOrganizationId(organizationId).orElseThrow();
+    assertThat(status.getLastOutcome()).isEqualTo(DirectorySyncOutcome.DRY_RUN);
+  }
+
+  @Test
+  void dryRunAgainstAnUnreachableDirectoryStillRecordsTheOutcomeDurably() {
+    directoryClient.failWith("timeout");
+
+    DirectorySyncReportResponse report = directorySyncService.dryRun(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.UNREACHABLE);
+    DirectorySyncStatus status =
+        statusRepository.findByOrganizationId(organizationId).orElseThrow();
+    assertThat(status.getLastOutcome()).isEqualTo(DirectorySyncOutcome.UNREACHABLE);
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Parent group resolution - review of PR #297: must not depend on directory response order,
+  // and must apply to existing groups across separate runs, not only at creation time.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void resolvesAParentLinkRegardlessOfWhetherTheChildOrTheParentIsReportedFirst() {
+    // The child is listed before the parent in the very same snapshot - a real LDAP response has
+    // no guaranteed order.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-child", "Unterabteilung", "dir-parent", Set.of()),
+        new DirectoryGroup("dir-parent", "Abteilung", null, Set.of()));
+
+    directorySyncService.run(organizationId);
+
+    Group parent =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(g -> "dir-parent".equals(g.getExternalId()))
+            .findFirst()
+            .orElseThrow();
+    Group child =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(g -> "dir-child".equals(g.getExternalId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(child.getParentGroupId()).isEqualTo(parent.getId());
+  }
+
+  @Test
+  void aReorganisationReassignsAnExistingGroupsParentOnALaterRun() {
+    // Run 1: two independent, top-level groups.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-a", "Referat A", null, Set.of()),
+        new DirectoryGroup("dir-b", "Referat B", null, Set.of()));
+    directorySyncService.run(organizationId);
+    Group groupA =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(g -> "dir-a".equals(g.getExternalId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(groupA.getParentGroupId()).isNull();
+
+    // Run 2: a reorganisation puts A under B.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-a", "Referat A", "dir-b", Set.of()),
+        new DirectoryGroup("dir-b", "Referat B", null, Set.of()));
+    directorySyncService.run(organizationId);
+
+    Group groupB =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(g -> "dir-b".equals(g.getExternalId()))
+            .findFirst()
+            .orElseThrow();
+    Group reloadedA = groupRepository.findById(groupA.getId()).orElseThrow();
+    assertThat(reloadedA.getParentGroupId()).isEqualTo(groupB.getId());
   }
 
   // ---------------------------------------------------------------------------------------

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
@@ -1,7 +1,9 @@
 package io.opaa.group.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.opaa.api.dto.DirectorySyncMembershipChange;
 import io.opaa.api.dto.DirectorySyncReportResponse;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
@@ -262,17 +264,26 @@ class DirectorySyncServiceIntegrationTest {
     UUID member = createUser(organizationId, "member-1");
     Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
     // A large, unrelated, unaffected group so the one dissolving membership stays well under the
-    // 30% threshold - this test is about the dissolution mechanics, not the threshold.
+    // 30% membership threshold - this test is about the dissolution mechanics, not the threshold.
     UUID[] bulkMembers = new UUID[9];
     for (int i = 0; i < bulkMembers.length; i++) {
       bulkMembers[i] = createUser(organizationId, "bulk-" + i);
     }
     persistOrgUnit("dir-guid-bulk", "Referat Bulk", bulkMembers);
+    // Enough other unaffected groups that the *group-count* fraction (see the group-dissolution
+    // measure added in response to review of PR #297) also stays under 30%: 1 of 5 = 20%.
+    List<DirectoryGroup> unaffected = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      persistOrgUnit("dir-guid-other-" + i, "Referat Other " + i);
+      unaffected.add(
+          new DirectoryGroup("dir-guid-other-" + i, "Referat Other " + i, null, Set.of()));
+    }
 
-    // Directory no longer reports dir-guid-1 at all (merged into another unit); the bulk group is
-    // still reported unchanged.
-    directoryClient.respondWith(
-        new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()),
+    // Directory no longer reports dir-guid-1 at all (merged into another unit); every other group
+    // is still reported unchanged.
+    List<DirectoryGroup> reported = new ArrayList<>();
+    reported.add(new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()));
+    reported.add(
         new DirectoryGroup(
             "dir-guid-bulk",
             "Referat Bulk",
@@ -280,6 +291,8 @@ class DirectorySyncServiceIntegrationTest {
             Set.of(
                 "bulk-0", "bulk-1", "bulk-2", "bulk-3", "bulk-4", "bulk-5", "bulk-6", "bulk-7",
                 "bulk-8")));
+    reported.addAll(unaffected);
+    directoryClient.respondWith(reported.toArray(new DirectoryGroup[0]));
 
     DirectorySyncReportResponse report = directorySyncService.run(organizationId);
 
@@ -378,6 +391,32 @@ class DirectorySyncServiceIntegrationTest {
     assertThat(membershipRepository.findByGroupId(reloaded.getId())).hasSize(4);
   }
 
+  @Test
+  void aMassDissolutionOfMemberlessGroupsIsCaughtByTheGroupCountMeasureEvenAtZeroMembershipRisk() {
+    // 50 ORG_UNIT groups with no members at all (the routine state during an introduction phase,
+    // before curators and memberships are populated - review of PR #297). The directory now
+    // reports only one of them; the membership-based measure sees changedFraction = 0.0 either
+    // way, since no membership row is at stake.
+    List<DirectoryGroup> stillReported = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      persistOrgUnit("dir-guid-" + i, "Referat " + i);
+      if (i == 0) {
+        stillReported.add(new DirectoryGroup("dir-guid-" + i, "Referat " + i, null, Set.of()));
+      }
+    }
+    directoryClient.respondWith(stillReported.toArray(new DirectoryGroup[0]));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.ABORTED_THRESHOLD);
+    assertThat(report.getChangedFraction()).isEqualTo(0.98);
+    long dissolvedCount =
+        groupRepository.findByOrganizationId(organizationId).stream()
+            .filter(Group::isDissolved)
+            .count();
+    assertThat(dissolvedCount).isZero();
+  }
+
   // ---------------------------------------------------------------------------------------
   // Dry run persists its outcome - review of PR #297: under the class-level readOnly transaction
   // dryRun used to run in, Hibernate's FlushMode.MANUAL silently dropped the status insert.
@@ -464,6 +503,61 @@ class DirectorySyncServiceIntegrationTest {
             .orElseThrow();
     Group reloadedA = groupRepository.findById(groupA.getId()).orElseThrow();
     assertThat(reloadedA.getParentGroupId()).isEqualTo(groupB.getId());
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Failed apply must not be recorded as APPLIED - review of PR #297: an earlier version wrote
+  // the status via a REQUIRES_NEW transaction that committed before the surrounding apply
+  // transaction could roll back, so a run that failed to actually apply could still end up
+  // durably marked APPLIED.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void aFailedApplyDoesNotRecordAnAppliedStatus() {
+    UUID member = createUser(organizationId, "member-1");
+    persistOrgUnit("dir-guid-1", "Referat 50", member);
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("member-1")));
+    directorySyncService.dryRun(organizationId);
+    assertThat(statusRepository.findByOrganizationId(organizationId).orElseThrow().getLastOutcome())
+        .isEqualTo(DirectorySyncOutcome.DRY_RUN);
+
+    // A directory-supplied group name exceeding groups.name's varchar(255) makes the CREATE fail
+    // at commit time - a real, if unusual, directory response, not a test-only trick.
+    String tooLongName = "x".repeat(300);
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("member-1")),
+        new DirectoryGroup("dir-guid-9", tooLongName, null, Set.of()));
+
+    assertThatThrownBy(() -> directorySyncService.run(organizationId))
+        .isInstanceOf(RuntimeException.class);
+
+    DirectorySyncStatus status =
+        statusRepository.findByOrganizationId(organizationId).orElseThrow();
+    assertThat(status.getLastOutcome()).isEqualTo(DirectorySyncOutcome.DRY_RUN);
+    assertThat(status.getLastAppliedAt()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // The report must name who would lose membership, not only who would gain it - review of PR
+  // #297: the removed side used to carry a null display name unconditionally.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  void theDryRunReportNamesTheUsersWhoWouldLoseMembership() {
+    UUID keep = createUser(organizationId, "keep");
+    UUID leaving = createUser(organizationId, "leaving");
+    persistOrgUnit("dir-guid-1", "Referat 50", keep, leaving);
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-1", "Referat 50", null, Set.of("keep")));
+
+    DirectorySyncReportResponse report = directorySyncService.dryRun(organizationId);
+
+    assertThat(report.getMembershipChanges()).hasSize(1);
+    DirectorySyncMembershipChange change = report.getMembershipChanges().get(0);
+    assertThat(change.getRemoved()).hasSize(1);
+    assertThat(change.getRemoved().get(0).getUserId()).isEqualTo(leaving);
+    assertThat(change.getRemoved().get(0).getDisplayName()).isEqualTo("Test User");
   }
 
   // ---------------------------------------------------------------------------------------

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import io.opaa.group.GroupRepository;
 import io.opaa.organization.Organization;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -265,25 +266,20 @@ class DirectorySyncServiceIntegrationTest {
     Group existing = persistOrgUnit("dir-guid-1", "Referat 50", member);
     // A large, unrelated, unaffected group so the one dissolving membership stays well under the
     // 30% membership threshold - this test is about the dissolution mechanics, not the threshold.
+    // Only 2 groups are active in total, so the group-count measure (see
+    // MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE) does not apply here - it is exercised separately by
+    // aMassDissolutionOfMemberlessGroupsIsCaughtByTheGroupCountMeasureEvenAtZeroMembershipRisk and
+    // its counterpart aLegitimateSingleDissolutionInASmallOrganizationPassesThroughUnblocked.
     UUID[] bulkMembers = new UUID[9];
     for (int i = 0; i < bulkMembers.length; i++) {
       bulkMembers[i] = createUser(organizationId, "bulk-" + i);
     }
     persistOrgUnit("dir-guid-bulk", "Referat Bulk", bulkMembers);
-    // Enough other unaffected groups that the *group-count* fraction (see the group-dissolution
-    // measure added in response to review of PR #297) also stays under 30%: 1 of 5 = 20%.
-    List<DirectoryGroup> unaffected = new ArrayList<>();
-    for (int i = 0; i < 3; i++) {
-      persistOrgUnit("dir-guid-other-" + i, "Referat Other " + i);
-      unaffected.add(
-          new DirectoryGroup("dir-guid-other-" + i, "Referat Other " + i, null, Set.of()));
-    }
 
-    // Directory no longer reports dir-guid-1 at all (merged into another unit); every other group
-    // is still reported unchanged.
-    List<DirectoryGroup> reported = new ArrayList<>();
-    reported.add(new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()));
-    reported.add(
+    // Directory no longer reports dir-guid-1 at all (merged into another unit); the bulk group is
+    // still reported unchanged.
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-2", "Referat 60", null, Set.of()),
         new DirectoryGroup(
             "dir-guid-bulk",
             "Referat Bulk",
@@ -291,8 +287,6 @@ class DirectorySyncServiceIntegrationTest {
             Set.of(
                 "bulk-0", "bulk-1", "bulk-2", "bulk-3", "bulk-4", "bulk-5", "bulk-6", "bulk-7",
                 "bulk-8")));
-    reported.addAll(unaffected);
-    directoryClient.respondWith(reported.toArray(new DirectoryGroup[0]));
 
     DirectorySyncReportResponse report = directorySyncService.run(organizationId);
 
@@ -415,6 +409,44 @@ class DirectorySyncServiceIntegrationTest {
             .filter(Group::isDissolved)
             .count();
     assertThat(dissolvedCount).isZero();
+  }
+
+  @Test
+  void aLegitimateSingleDissolutionInASmallOrganizationPassesThroughUnblocked() {
+    // The exact scenario a second review of PR #297 measured against real Postgres: 3 active
+    // ORG_UNIT groups, well under MIN_ACTIVE_GROUPS_FOR_GROUP_MEASURE and
+    // MIN_DISSOLUTIONS_FOR_GROUP_MEASURE, two of them unchanged with real members and one an
+    // empty placeholder unit that legitimately disappears from the directory. No membership is at
+    // risk at all - without the floor on the group-count measure, this run used to abort
+    // permanently (1 of 3 active groups = 33%, above the 30% default threshold, with no per-run
+    // override and no way for a later run of the same small organization to ever pass).
+    Set<String> teamASubjects = new HashSet<>();
+    UUID[] teamAMembers = new UUID[10];
+    for (int i = 0; i < teamAMembers.length; i++) {
+      teamAMembers[i] = createUser(organizationId, "team-a-" + i);
+      teamASubjects.add("team-a-" + i);
+    }
+    persistOrgUnit("dir-team-a", "Team A", teamAMembers);
+
+    Set<String> teamBSubjects = new HashSet<>();
+    UUID[] teamBMembers = new UUID[10];
+    for (int i = 0; i < teamBMembers.length; i++) {
+      teamBMembers[i] = createUser(organizationId, "team-b-" + i);
+      teamBSubjects.add("team-b-" + i);
+    }
+    persistOrgUnit("dir-team-b", "Team B", teamBMembers);
+
+    persistOrgUnit("dir-placeholder", "Platzhalter"); // empty, about to legitimately disappear
+
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-team-a", "Team A", null, teamASubjects),
+        new DirectoryGroup("dir-team-b", "Team B", null, teamBSubjects));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    assertThat(report.getChangedFraction()).isEqualTo(0.0);
+    assertThat(report.getGroupsDissolved()).hasSize(1);
   }
 
   // ---------------------------------------------------------------------------------------

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceStatusFailureTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncServiceStatusFailureTest.java
@@ -1,0 +1,111 @@
+package io.opaa.group.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+
+import io.opaa.api.dto.DirectorySyncReportResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupRepository;
+import io.opaa.organization.Organization;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * A separate Spring context from {@link DirectorySyncServiceIntegrationTest} - not one more test
+ * method added to it - because {@code @MockitoBean} replaces {@link DirectorySyncStatusRecorder}
+ * for the whole class. Sharing it with the tests that rely on real status persistence would
+ * silently turn every one of their {@code statusRecorder.record(...)} calls into a no-op instead of
+ * the real write they assert on, breaking those tests for a reason that has nothing to do with what
+ * they cover.
+ *
+ * <p>Covers review of PR #297's nit: a failure while recording the outcome (here simulated; in
+ * production e.g. the status table's own insert/update failing) must not turn an already
+ * successful, already-committed apply into an error response with no report at all - that would
+ * additionally invite an operator to retry a run that already took effect.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(DirectorySyncServiceStatusFailureTest.TestConfig.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class DirectorySyncServiceStatusFailureTest {
+
+  @TestConfiguration(proxyBeanMethods = false)
+  static class TestConfig {
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer postgresContainer() {
+      return new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+    }
+
+    @Bean
+    @Primary
+    DirectorySyncServiceIntegrationTest.FakeDirectoryClient fakeDirectoryClient() {
+      return new DirectorySyncServiceIntegrationTest.FakeDirectoryClient();
+    }
+  }
+
+  @Autowired private DirectorySyncService directorySyncService;
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private DirectorySyncServiceIntegrationTest.FakeDirectoryClient directoryClient;
+  @MockitoBean private DirectorySyncStatusRecorder statusRecorder;
+
+  private UUID organizationId;
+
+  @BeforeEach
+  void setUp() {
+    groupRepository.deleteAll();
+    userRepository.deleteAll();
+    organizationId = Organization.DEFAULT_ID;
+    directoryClient.respondWith();
+    doThrow(new RuntimeException("simulated status write failure"))
+        .when(statusRecorder)
+        .record(any(), any(), any(), anyString(), anyDouble());
+  }
+
+  private UUID createUser(String subject) {
+    User user = new User(subject, "test-issuer", subject + "@example.com", "Test User");
+    user.setOrganizationId(organizationId);
+    return userRepository.save(user).getId();
+  }
+
+  @Test
+  void aStatusWriteFailureDoesNotSwallowAnAlreadyAppliedReport() {
+    UUID member = createUser("member-1");
+    directoryClient.respondWith(
+        new DirectoryGroup("dir-guid-9", "Referat 99", null, Set.of("member-1")));
+
+    DirectorySyncReportResponse report = directorySyncService.run(organizationId);
+
+    assertThat(report.getOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    // The group/membership change is real and committed, regardless of the status write failure.
+    List<Group> groups = groupRepository.findByOrganizationId(organizationId);
+    assertThat(groups).hasSize(1);
+    assertThat(groups.get(0).getKind()).isEqualTo(GroupKind.ORG_UNIT);
+    assertThat(member).isNotNull();
+  }
+}

--- a/backend/src/test/java/io/opaa/migration/Migration011DirectorySyncTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration011DirectorySyncTest.java
@@ -1,0 +1,185 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 011 in isolation against a database built from the real, versioned
+ * changelog through changeSet 010 - the same pattern as {@code Migration010SpaceUniquenessTest},
+ * with {@code test-master-through-010.yaml} as the pre-migration fixture. Uses {@code
+ * connection.setAutoCommit(true)} after every {@code liquibase.update(...)} call rather than the
+ * older {@code connection.rollback()} teardown some earlier migration tests use - the pattern #283
+ * established as the single one going forward, because it addresses the actual cause (Liquibase
+ * leaves auto-commit disabled) instead of working around the symptom on teardown.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration011DirectorySyncTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-010.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+
+    insertOrganization(ORGANIZATION_ID);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    connection.setAutoCommit(true);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+    connection.close();
+  }
+
+  @Test
+  void addsDissolvedColumnsToGroupsDefaultingToNotDissolved() throws Exception {
+    applyChangelog011();
+
+    UUID orgUnit = UUID.randomUUID();
+    insertGroup(orgUnit, "ORG_UNIT", "Referat 50", "directory-guid-1");
+
+    assertThat(columnValue("groups", "dissolved", orgUnit)).isEqualTo("f");
+    assertThat(columnValueOrNull("groups", "dissolved_at", orgUnit)).isNull();
+  }
+
+  @Test
+  void createsDirectorySyncStatusTableScopedToOneRowPerOrganization() throws Exception {
+    applyChangelog011();
+
+    UUID statusId = UUID.randomUUID();
+    insertSyncStatus(statusId, ORGANIZATION_ID, "APPLIED");
+    assertThat(countRows("directory_sync_status")).isEqualTo(1);
+
+    // uk_directory_sync_status_organization must reject a second row for the same organization.
+    assertThatThrownBy(() -> insertSyncStatus(UUID.randomUUID(), ORGANIZATION_ID, "DRY_RUN"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uk_directory_sync_status_organization");
+  }
+
+  private void applyChangelog011() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/011-directory-sync.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  private void insertOrganization(String id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO organizations (id, name, created_at) VALUES ('"
+              + id
+              + "', 'Org "
+              + id
+              + "', now()) ON CONFLICT (id) DO NOTHING");
+    }
+  }
+
+  private void insertGroup(UUID id, String kind, String name, String externalId)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO groups (id, organization_id, kind, name, external_id, created_at,"
+              + " updated_at) VALUES ('"
+              + id
+              + "', '"
+              + ORGANIZATION_ID
+              + "', '"
+              + kind
+              + "', '"
+              + name
+              + "', '"
+              + externalId
+              + "', now(), now())");
+    }
+  }
+
+  private void insertSyncStatus(UUID id, String organizationId, String outcome)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO directory_sync_status (id, organization_id, last_run_at, last_outcome) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + organizationId
+              + "', now(), '"
+              + outcome
+              + "')");
+    }
+  }
+
+  private long countRows(String table) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT count(*) FROM " + table)) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private String columnValue(String table, String column, UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT " + column + " FROM " + table + " WHERE id = '" + id + "'")) {
+      rs.next();
+      return rs.getString(1);
+    }
+  }
+
+  private String columnValueOrNull(String table, String column, UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT " + column + " FROM " + table + " WHERE id = '" + id + "'")) {
+      rs.next();
+      String value = rs.getString(1);
+      return rs.wasNull() ? null : value;
+    }
+  }
+}

--- a/backend/src/test/resources/db/changelog/test-master-through-010.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-010.yaml
@@ -1,3 +1,13 @@
+# Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
+# changeSet 010 - i.e. the schema exactly as it existed immediately before migration 011, which
+# builds on this same pre-migration state.
+#
+# Used by:
+# - Migration011DirectorySyncTest, to build a realistic pre-migration database (via the real,
+#   versioned changelog files, not a hand-rolled schema) and then apply 011 in isolation.
+#
+# See test-master-through-008.yaml and Migration009CreateGroupsTest for the pattern this fixture
+# follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml
@@ -19,5 +29,3 @@ databaseChangeLog:
       file: db/changelog/changes/009-create-groups.yaml
   - include:
       file: db/changelog/changes/010-space-uniqueness-and-membership-index.yaml
-  - include:
-      file: db/changelog/changes/011-directory-sync.yaml


### PR DESCRIPTION
## Zusammenfassung

Fuehrt die Verzeichnissynchronisation fuer `ORG_UNIT`-Gruppen (aus #200) als eigenes Rechteereignis ein: `io.opaa.group.sync.DirectorySyncService` gleicht Gruppen und Mitgliedschaften ausschliesslich ueber die stabile Verzeichnis-`externalId` ab, nie ueber den Namen, und trennt strikt Diff-Berechnung (`buildPlan`, liest nur) von Anwendung (`applyPlan`, schreibt nur bei plausiblem, angefordertem Lauf).

**Verbindliche Anforderungen aus dem Issue, umgesetzt:**

- **Stabile Kennung statt Name** — Abgleich ueber `Group.externalId`; eine Umbenennung im Verzeichnis aendert nur den Namen, Grants und Mitgliedschaften bleiben unberuehrt.
- **Plausibilitaetsschwelle mit Abbruch** — `opaa.directory-sync.change-threshold-fraction` (Default 30 %), gemessen an entfernten Mitgliedschaften relativ zum Vorher-Bestand. Bewusst nur auf Entzuege bezogen, nicht auf Zuwaechse: ein Lauf, der nur Mitgliedschaften hinzufuegt, kann kein Recht entziehen und braucht daher keine Bremse.
- **Leere Gruppenliste** — liefert das Verzeichnis eine leere Liste, obwohl bereits `ORG_UNIT`-Gruppen existieren, wird der Lauf unbedingt abgebrochen (`ABORTED_EMPTY_RESULT`), unabhaengig von der konfigurierten Schwelle.
- **Nicht erreichbares Verzeichnis: last-known-good** — `DirectoryUnavailableException` fuehrt zu `UNREACHABLE`, nichts wird geschrieben, der Zustand wird aber dauerhaft ueber `directory_sync_status` (eine Zeile je Organisation) gemeldet, nicht nur in der Antwort des ausloesenden Requests.
- **Trockenlauf mit Differenzbericht** — `POST /api/v1/admin/directory-sync/dry-run` durchlaeuft denselben Plan-Code wie ein echter Lauf, verlaesst ihn aber vor jeder Schreiboperation.
- **Eine Protokollzeile je bewirkter Rechteaenderung** — je hinzugefuegter/entfernter Mitgliedschaft, je erstellter/umbenannter/aufgeloester/reaktivierter Gruppe eine eigene `log.info`/`log.warn`-Zeile mit Ursache, nicht eine Sammelzeile je Lauf.
- **Reorganisation** — verschwindet eine Einheit aus dem Verzeichnis, wird ihre Gruppe als `dissolved` markiert; bestehende Mitgliedschaften bleiben unangetastet (eingefroren), koennen aber nicht mehr wachsen, solange die Gruppe aufgeloest ist. Taucht sie spaeter wieder auf, wird sie automatisch reaktiviert und wie jede andere bestehende Gruppe weitersynchronisiert.

## Architekturentscheidungen

- **`DirectoryClient` als einzige Nahtstelle.** Die eigentliche Verbindung zu einem realen Verzeichnisdienst (LDAP/SCIM, Netzwerk, Credentials) ist eine deployment-spezifische Frage ausserhalb des mit vertretbarem Aufwand testbaren Teils dieses Issues. `DirectorySyncService` ist gegen ein Test-Double von `DirectoryClient` vollstaendig durchgetestet; `NoOpDirectoryClient` ist die produktive Default-Implementierung und meldet konsequent "nicht erreichbar" statt einer falschen leeren Gruppenliste, solange kein echter Client konfiguriert ist. Ein echter Verzeichnis-Client kann spaeter als eigene `DirectoryClient`-Bean (per `@ConditionalOnMissingBean` bevorzugt) nachgezogen werden, ohne diese Klasse anzufassen.
- **Verschachtelte Gruppen: bewusst nicht aufgeloest.** Die Feature-Spezifikation nennt dies einen offenen Punkt. Entscheidung: `DirectoryGroup.parentExternalId` wird auf `Group.parentGroupId` abgebildet und ausschliesslich fuer die Curator-Eskalation aus #208 vorgehalten (so schon in `GroupKind`s Javadoc aus #200 angelegt). Die Mitgliedschaft einer Gruppe ist und bleibt genau das, was das Verzeichnis als direkte Mitglieder dieser Gruppe meldet — ein Mitglied einer Kind-Einheit wird nicht implizit Mitglied der Eltern-Einheit. Diese Grenze ist explizit in `DirectorySyncService`s und `DirectoryGroup`s Javadoc dokumentiert, nicht stillschweigend offengelassen.
- **`Organization.createdAt`-Falle aus #199 geprüft:** Die Entity traegt bereits ein `@PrePersist`, das `createdAt` nur setzt, wenn es noch `null` ist (aus #200 behoben) — die im Auftrag genannte Falle existiert im aktuellen `main` nicht mehr.

## Zugehörige Issues

Closes #237
Teil von #198

## Betroffene Module

- `backend` — `io.opaa.group.sync` (neu), `io.opaa.group.Group`/`GroupRepository`, `io.opaa.auth.UserRepository`, Liquibase-Changelog 011, OpenAPI-Spezifikation

## Art der Änderung

- [x] Neues Feature

## Checkliste

- [x] Tests bestehen lokal (siehe Pre-Push-Nachweise unten)
- [ ] Bei Bugfix: Reproduktionsnachweis erbracht — entfällt, kein Bugfix
- [x] Dokumentation aktualisiert (falls zutreffend) — Feature-Spezifikation (`docs/features/spaces-and-assets.md`) enthielt die Anforderungen bereits vollständig; keine Änderung nötig
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet) — bereits unterzeichnet (früherer PR)

## Pre-Push-Nachweise

```
$ ./gradlew spotlessCheck
BUILD SUCCESSFUL

$ ./gradlew build -x test
BUILD SUCCESSFUL

$ ./gradlew test
BUILD SUCCESSFUL in 3m 27s
(alle Tests grün, inkl. neuer DirectorySyncServiceIntegrationTest (9 Szenarien, echte
Postgres/Liquibase-Schema-FKs) und Migration011DirectorySyncTest;
1 vorbestehender, unveränderter Skip: OpenAiIntegrationTest, benötigt echten API-Key)

$ npm run format && npm run lint
alles unverändert / keine Findings

$ npm run test -- --run
Test Files  28 passed (28)
Tests  140 passed (140)

$ npm run build
BUILD SUCCESSFUL
```

Frontend ist von diesem PR nicht inhaltlich betroffen (kein `frontend`-Label, keine UI); alle Frontend-Checks wurden dennoch vollständig ausgeführt.

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code, Developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst