### PR TITLE
test(backend): FK-abhängige Space-Tests auf echtes Liquibase-Schema umstellen

### DIFF
--- a/backend/src/test/java/io/opaa/TestcontainersConfiguration.java
+++ b/backend/src/test/java/io/opaa/TestcontainersConfiguration.java
@@ -6,12 +6,18 @@ import org.springframework.context.annotation.Bean;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * Shared {@code pgvector/pgvector:pg18} Testcontainers datasource for integration tests that need a
+ * real Postgres instance instead of Hibernate-generated (or H2) schema. {@code public} so it can be
+ * reused across packages via {@code @Import(TestcontainersConfiguration.class)} instead of
+ * duplicating the container definition per test class - see #288.
+ */
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
   @Bean
   @ServiceConnection
-  PostgreSQLContainer postgresContainer() {
+  public PostgreSQLContainer postgresContainer() {
     return new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
   }
 }

--- a/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
@@ -3,6 +3,7 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.opaa.TestcontainersConfiguration;
 import io.opaa.space.Space;
 import io.opaa.space.SpaceKind;
 import io.opaa.space.SpaceRepository;
@@ -18,15 +19,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.postgresql.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 /**
  * Exercises {@link UserService#findOrCreateUser} against a real Postgres database with the real,
@@ -53,21 +49,12 @@ import org.testcontainers.utility.DockerImageName;
  * guaranteeing the user row is committed and visible by the time the personal space is created.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(UserServicePersonalSpaceIntegrationTest.PostgresTestConfiguration.class)
+@Import(TestcontainersConfiguration.class)
 @ActiveProfiles({"local", "basic"})
 @TestPropertySource(
     properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
 @Testcontainers(disabledWithoutDocker = true)
 class UserServicePersonalSpaceIntegrationTest {
-
-  @TestConfiguration(proxyBeanMethods = false)
-  static class PostgresTestConfiguration {
-    @Bean
-    @ServiceConnection
-    PostgreSQLContainer postgresContainer() {
-      return new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
-    }
-  }
 
   @Autowired private UserService userService;
   @Autowired private SpaceService spaceService;

--- a/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
@@ -27,13 +27,18 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /**
  * Exercises {@link UserService#findOrCreateUser} against a real Postgres database with the real,
  * versioned Liquibase schema applied ({@code spring.liquibase.enabled=true}, {@code ddl-auto=none})
- * - not against Hibernate-generated DDL, and not with a mocked transaction manager. This is
- * deliberate: the regression this test guards against (follow-up to #265/#280) only manifests with
- * real foreign-key constraints and real, separately committed transactions. Neither {@code
- * SpaceServiceIntegrationTest} (Hibernate {@code ddl-auto=create-drop}; plain UUID columns like
- * {@code Space.ownerId} get no foreign key at all under that regime) nor {@code SpaceServiceTest}
- * (mocked {@link org.springframework.transaction.PlatformTransactionManager} - no real connection,
- * no real propagation, no real visibility semantics) can exercise it.
+ * - not against Hibernate-generated DDL, and not with a mocked transaction manager. This class
+ * predates #288 (it was added in #287, on real foreign keys from the start) and its
+ * container/schema setup is the pattern #288 later applied to {@code SpaceServiceIntegrationTest}
+ * and {@code SpaceRepositoryTest}. This is deliberate: the regression this test guards against
+ * (follow-up to #265/#280) only manifests with real foreign-key constraints and real, separately
+ * committed transactions. Even after #288, neither {@code SpaceServiceIntegrationTest} (calls
+ * {@code ensurePersonalSpace} directly on an already-committed user, never from inside {@code
+ * UserService}'s still-open transaction) nor {@code SpaceServiceTest} (mocked {@link
+ * org.springframework.transaction.PlatformTransactionManager} - no real connection, no real
+ * propagation, no real visibility semantics) can exercise it - the regression is specific to the
+ * transaction-ordering interaction between {@code UserService} and {@code SpaceService}, not to
+ * schema alone.
  *
  * <p><b>The regression:</b> {@code SpaceService.ensurePersonalSpace} (#265) runs its insert in its
  * own {@code REQUIRES_NEW} transaction, on its own connection with its own snapshot, so that a

--- a/backend/src/test/java/io/opaa/migration/Migration008RenameWorkspaceToSpaceTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration008RenameWorkspaceToSpaceTest.java
@@ -27,14 +27,12 @@ import org.testcontainers.utility.DockerImageName;
  * workspace data covering all four historical roles and both historical workspace types - not
  * against an empty schema.
  *
- * <p>{@code SpaceServiceIntegrationTest} and {@code SpaceRepositoryTest} run with {@code
- * spring.liquibase.enabled=false} and {@code ddl-auto=create-drop}; their schema comes from
- * Hibernate directly and never executes a single Liquibase changeSet. {@code OpaaApplicationTests}
- * does run the full changelog, but against an empty database - that proves changeset 008 is
- * syntactically applicable, not that a *data* migration survives non-empty legacy data. It is
- * exactly this gap that let a check-constraint ordering bug in {@code
- * 008-remap-space-membership-roles} pass CI: the changeSet failed on any database that had at least
- * one VIEWER or EDITOR membership row.
+ * <p>{@code SpaceServiceIntegrationTest} and {@code SpaceRepositoryTest} run the real, versioned
+ * Liquibase changelog too (since #288) - but against an empty database at context startup, exactly
+ * like {@code OpaaApplicationTests}. That proves changeset 008 is syntactically applicable, not
+ * that a *data* migration survives non-empty legacy data. It is exactly this gap that let a
+ * check-constraint ordering bug in {@code 008-remap-space-membership-roles} pass CI: the changeSet
+ * failed on any database that had at least one VIEWER or EDITOR membership row.
  *
  * <p>This test closes that gap and is meant as a reusable pattern for future data migrations (see
  * #237, #238): apply the real, versioned changelog up to the changeSet immediately preceding the

--- a/backend/src/test/java/io/opaa/migration/package-info.java
+++ b/backend/src/test/java/io/opaa/migration/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * Tests that apply real, versioned Liquibase changelogs in isolation against a Postgres
+ * Testcontainer - not against Hibernate-generated schema and not against an empty database. See
+ * {@code Migration008RenameWorkspaceToSpaceTest} and {@code Migration010SpaceUniquenessTest} for
+ * the established pattern: apply everything up to (and including) the changeSet immediately
+ * preceding the one under test via a fixture changelog such as {@code
+ * test-master-through-XXX.yaml}, seed representative legacy rows directly through JDBC, apply only
+ * the new changelog file, and assert on the resulting schema and data.
+ *
+ * <p><b>Mandatory teardown pattern (#288):</b> {@code Liquibase.update(...)} leaves the JDBC
+ * connection's auto-commit disabled. If a test class needs a clean, schema-less database again
+ * afterwards - either between multiple {@code @Test} methods sharing one container ({@code
+ * Migration010SpaceUniquenessTest}), or simply to release the connection cleanly - it MUST call
+ * {@code connection.setAutoCommit(true)} before running any further statement (schema reset,
+ * seeding, or a later {@code update()} call). This fixes the root cause: every raw JDBC statement
+ * after that point then commits independently, exactly like the application does in production,
+ * instead of silently accumulating in an open transaction that gets rolled back when the connection
+ * closes.
+ *
+ * <p>Do not use {@code connection.rollback()} in {@code tearDown()} as an alternative - it only
+ * discards whatever happened to still be uncommitted at that point and leaves the underlying
+ * auto-commit problem in place for the next statement executed on the same connection. {@code
+ * setAutoCommit(true)} was chosen as the binding pattern for this package during the review of
+ * #283; new migration tests (see #201, #202, #238) must follow it.
+ */
+package io.opaa.migration;

--- a/backend/src/test/java/io/opaa/migration/package-info.java
+++ b/backend/src/test/java/io/opaa/migration/package-info.java
@@ -8,14 +8,20 @@
  * the new changelog file, and assert on the resulting schema and data.
  *
  * <p><b>Mandatory teardown pattern (#288):</b> {@code Liquibase.update(...)} leaves the JDBC
- * connection's auto-commit disabled. If a test class needs a clean, schema-less database again
- * afterwards - either between multiple {@code @Test} methods sharing one container ({@code
- * Migration010SpaceUniquenessTest}), or simply to release the connection cleanly - it MUST call
- * {@code connection.setAutoCommit(true)} before running any further statement (schema reset,
- * seeding, or a later {@code update()} call). This fixes the root cause: every raw JDBC statement
- * after that point then commits independently, exactly like the application does in production,
- * instead of silently accumulating in an open transaction that gets rolled back when the connection
- * closes.
+ * connection's auto-commit disabled. Every test class in this package MUST call {@code
+ * connection.setAutoCommit(true)} immediately after each {@code update()} call - unconditionally,
+ * not only when a further statement happens to be needed afterwards. This fixes the root cause:
+ * every raw JDBC statement after that point then commits independently, exactly like the
+ * application does in production, instead of silently accumulating in an open transaction that gets
+ * rolled back when the connection closes. It is what lets {@code Migration010SpaceUniquenessTest}
+ * reset the schema between {@code @Test} methods sharing one container, and it is required even for
+ * single-method test classes that only close the connection afterwards - the connection must never
+ * be left in a state where a caller has to guess whether auto-commit is on.
+ *
+ * <p>{@code Migration008RenameWorkspaceToSpaceTest} predates this rule (it was written before #283
+ * established it) and does not call {@code setAutoCommit(true)}; this is a known, documented
+ * exception, not a second accepted alternative. Do not copy its {@code tearDown()} - copy {@code
+ * Migration010SpaceUniquenessTest} instead.
  *
  * <p>Do not use {@code connection.rollback()} in {@code tearDown()} as an alternative - it only
  * discards whatever happened to still be uncommitted at that point and leaves the underlying

--- a/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.opaa.space;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opaa.TestcontainersConfiguration;
 import io.opaa.auth.User;
@@ -9,11 +10,13 @@ import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -25,6 +28,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * not create a foreign key for those (Liquibase's {@code fk_spaces_owner} / {@code
  * fk_space_memberships_user} do), so every owner/member id used here must be a real, persisted
  * {@link User}.
+ *
+ * <p>{@link #savingASpaceWithANonExistentOwnerFailsInsteadOfSilentlyPersisting()} and {@link
+ * #savingASpaceWithANonExistentOrganizationFailsInsteadOfSilentlyPersisting()} are the #288
+ * regression guards for this class: {@link SpaceRepository#save} is production code (used directly
+ * by {@link SpaceService} today, and by anything that saves a {@link Space} in the future). Before
+ * #288, saving a {@code Space} with a dangling {@code ownerId}/{@code organizationId} succeeded
+ * silently under Hibernate's {@code ddl-auto=create-drop} schema - there was no foreign key to
+ * violate. Against the real Liquibase schema it now fails loudly with {@code fk_spaces_owner} /
+ * {@code fk_spaces_organization}, exactly like the #280 regression this pattern was built to catch.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -46,11 +58,23 @@ class SpaceRepositoryTest {
     // Deliberately does not delete all organizations: Organization.DEFAULT_ID is seeded once by
     // Liquibase and other tests sharing this Spring context (e.g.
     // UserServicePersonalSpaceIntegrationTest) rely on that row existing (fk_users_organization).
-    // Each test creates its own throwaway organization instead, scoped by a random id.
+    // Each test creates its own throwaway organization instead, scoped by a random id, and removes
+    // it again in tearDown() - see tearDown() below.
     spaceMembershipRepository.deleteAll();
     spaceRepository.deleteAll();
     userRepository.deleteAll();
     org = organizationRepository.save(new Organization(UUID.randomUUID(), "Org")).getId();
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Users created during the test still reference org (fk_users_organization) - delete them
+    // first, then remove only the organization this test created (by id), never
+    // Organization.DEFAULT_ID or organizations created by other tests sharing this context.
+    spaceMembershipRepository.deleteAll();
+    spaceRepository.deleteAll();
+    userRepository.deleteAll();
+    organizationRepository.deleteById(org);
   }
 
   private UUID createUser() {
@@ -143,5 +167,40 @@ class SpaceRepositoryTest {
     assertThat(spaceRepository.findAll())
         .filteredOn(space -> space.getName().equals("Phoenix"))
         .hasSize(2);
+  }
+
+  @Test
+  void savingASpaceWithANonExistentOwnerFailsInsteadOfSilentlyPersisting() {
+    UUID nonExistentOwner = UUID.randomUUID();
+    Space space =
+        new Space(
+            "Ghost",
+            "Owner does not exist",
+            SpaceKind.PROJECT,
+            SpaceVisibility.PRIVATE,
+            nonExistentOwner,
+            org);
+
+    assertThatThrownBy(() -> spaceRepository.saveAndFlush(space))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_spaces_owner");
+  }
+
+  @Test
+  void savingASpaceWithANonExistentOrganizationFailsInsteadOfSilentlyPersisting() {
+    UUID owner = createUser();
+    UUID nonExistentOrganization = UUID.randomUUID();
+    Space space =
+        new Space(
+            "Ghost",
+            "Organization does not exist",
+            SpaceKind.PROJECT,
+            SpaceVisibility.PRIVATE,
+            owner,
+            nonExistentOrganization);
+
+    assertThatThrownBy(() -> spaceRepository.saveAndFlush(space))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_spaces_organization");
   }
 }

--- a/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
@@ -2,36 +2,77 @@ package io.opaa.space;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opaa.TestcontainersConfiguration;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.organization.Organization;
+import io.opaa.organization.OrganizationRepository;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-@DataJpaTest
+/**
+ * Runs against the real, versioned Liquibase schema ({@code spring.liquibase.enabled=true}, {@code
+ * ddl-auto=none}), not Hibernate-generated DDL - see #288. {@code Space.ownerId} and {@code
+ * SpaceMembership.userId} are plain {@code UUID} columns without {@code @ManyToOne}; Hibernate does
+ * not create a foreign key for those (Liquibase's {@code fk_spaces_owner} / {@code
+ * fk_space_memberships_user} do), so every owner/member id used here must be a real, persisted
+ * {@link User}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"local", "basic"})
 @TestPropertySource(
-    properties = {"spring.liquibase.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
 class SpaceRepositoryTest {
-
-  private static final UUID ORG = UUID.randomUUID();
 
   @Autowired private SpaceRepository spaceRepository;
   @Autowired private SpaceMembershipRepository spaceMembershipRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private OrganizationRepository organizationRepository;
+
+  private UUID org;
+
+  @BeforeEach
+  void cleanUp() {
+    // Deliberately does not delete all organizations: Organization.DEFAULT_ID is seeded once by
+    // Liquibase and other tests sharing this Spring context (e.g.
+    // UserServicePersonalSpaceIntegrationTest) rely on that row existing (fk_users_organization).
+    // Each test creates its own throwaway organization instead, scoped by a random id.
+    spaceMembershipRepository.deleteAll();
+    spaceRepository.deleteAll();
+    userRepository.deleteAll();
+    org = organizationRepository.save(new Organization(UUID.randomUUID(), "Org")).getId();
+  }
+
+  private UUID createUser() {
+    User user =
+        new User(UUID.randomUUID().toString(), "test-issuer", "user@example.com", "Test User");
+    user.setOrganizationId(org);
+    return userRepository.save(user).getId();
+  }
 
   @Test
   void findDistinctByMembershipsUserIdReturnsUserSpaces() {
-    UUID userA = UUID.randomUUID();
-    UUID userB = UUID.randomUUID();
+    UUID userA = createUser();
+    UUID userB = createUser();
 
     Space eng =
         new Space(
-            "Engineering", "Engineering docs", SpaceKind.TEAM, SpaceVisibility.PRIVATE, userA, ORG);
-    eng.addMembership(new SpaceMembership(userA, SpaceRole.ADMIN, ORG));
-    eng.addMembership(new SpaceMembership(userB, SpaceRole.CURATOR, ORG));
+            "Engineering", "Engineering docs", SpaceKind.TEAM, SpaceVisibility.PRIVATE, userA, org);
+    eng.addMembership(new SpaceMembership(userA, SpaceRole.ADMIN, org));
+    eng.addMembership(new SpaceMembership(userB, SpaceRole.CURATOR, org));
 
-    Space hr = new Space("HR", "HR docs", SpaceKind.TEAM, SpaceVisibility.PRIVATE, userB, ORG);
-    hr.addMembership(new SpaceMembership(userB, SpaceRole.ADMIN, ORG));
+    Space hr = new Space("HR", "HR docs", SpaceKind.TEAM, SpaceVisibility.PRIVATE, userB, org);
+    hr.addMembership(new SpaceMembership(userB, SpaceRole.ADMIN, org));
 
     spaceRepository.saveAll(List.of(eng, hr));
 
@@ -46,13 +87,13 @@ class SpaceRepositoryTest {
 
   @Test
   void findBySpaceIdReturnsMembersForSpace() {
-    UUID owner = UUID.randomUUID();
-    UUID curator = UUID.randomUUID();
+    UUID owner = createUser();
+    UUID curator = createUser();
     Space space =
         new Space(
-            "Phoenix", "Project space", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, owner, ORG);
-    space.addMembership(new SpaceMembership(owner, SpaceRole.ADMIN, ORG));
-    space.addMembership(new SpaceMembership(curator, SpaceRole.CURATOR, ORG));
+            "Phoenix", "Project space", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, owner, org);
+    space.addMembership(new SpaceMembership(owner, SpaceRole.ADMIN, org));
+    space.addMembership(new SpaceMembership(curator, SpaceRole.CURATOR, org));
 
     Space savedSpace = spaceRepository.save(space);
 
@@ -66,11 +107,11 @@ class SpaceRepositoryTest {
 
   @Test
   void deletingSpaceRemovesMemberships() {
-    UUID owner = UUID.randomUUID();
+    UUID owner = createUser();
     Space space =
         new Space(
-            "Company", "Company-wide space", SpaceKind.TEAM, SpaceVisibility.PRIVATE, owner, ORG);
-    space.addMembership(new SpaceMembership(owner, SpaceRole.ADMIN, ORG));
+            "Company", "Company-wide space", SpaceKind.TEAM, SpaceVisibility.PRIVATE, owner, org);
+    space.addMembership(new SpaceMembership(owner, SpaceRole.ADMIN, org));
 
     Space savedSpace = spaceRepository.save(space);
     UUID spaceId = savedSpace.getId();
@@ -85,16 +126,16 @@ class SpaceRepositoryTest {
 
   @Test
   void twoUsersCanEachOwnAProjectSpaceWithTheSameName() {
-    UUID userA = UUID.randomUUID();
-    UUID userB = UUID.randomUUID();
+    UUID userA = createUser();
+    UUID userB = createUser();
     Space projectA =
         new Space(
-            "Phoenix", "User A's project", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, userA, ORG);
-    projectA.addMembership(new SpaceMembership(userA, SpaceRole.ADMIN, ORG));
+            "Phoenix", "User A's project", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, userA, org);
+    projectA.addMembership(new SpaceMembership(userA, SpaceRole.ADMIN, org));
     Space projectB =
         new Space(
-            "Phoenix", "User B's project", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, userB, ORG);
-    projectB.addMembership(new SpaceMembership(userB, SpaceRole.ADMIN, ORG));
+            "Phoenix", "User B's project", SpaceKind.PROJECT, SpaceVisibility.PRIVATE, userB, org);
+    projectB.addMembership(new SpaceMembership(userB, SpaceRole.ADMIN, org));
 
     List<Space> saved = spaceRepository.saveAll(List.of(projectA, projectB));
 

--- a/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package io.opaa.space;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.opaa.TestcontainersConfiguration;
 import io.opaa.api.dto.SpaceListResponse;
 import io.opaa.api.dto.SpaceMemberRequest;
 import io.opaa.api.dto.SpaceRequest;
@@ -10,56 +11,60 @@ import io.opaa.api.dto.SpaceResponse;
 import io.opaa.api.dto.SpaceUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.organization.Organization;
+import io.opaa.organization.OrganizationRepository;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.server.ResponseStatusException;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.postgresql.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@DataJpaTest
-@Import(SpaceService.class)
-@Testcontainers(disabledWithoutDocker = true)
+/**
+ * Runs against a real Postgres database with the real, versioned Liquibase schema applied ({@code
+ * spring.liquibase.enabled=true}, {@code ddl-auto=none}), not Hibernate-generated DDL - see #288.
+ * {@code Space.ownerId}, {@code SpaceMembership.userId} and every {@code organizationId} are plain
+ * {@code UUID} columns without {@code @ManyToOne}; Hibernate does not create foreign keys for
+ * those, Liquibase does ({@code fk_spaces_owner}, {@code fk_space_memberships_user}, {@code
+ * fk_spaces_organization}, {@code fk_space_memberships_organization}). Every test therefore creates
+ * real {@link Organization} and {@link User} rows instead of using bare random UUIDs.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"local", "basic"})
 @TestPropertySource(
-    properties = {"spring.liquibase.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
 class SpaceServiceIntegrationTest {
-
-  @Container
-  static PostgreSQLContainer postgres =
-      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
-
-  @DynamicPropertySource
-  static void configureDataSource(DynamicPropertyRegistry registry) {
-    registry.add("spring.datasource.url", postgres::getJdbcUrl);
-    registry.add("spring.datasource.username", postgres::getUsername);
-    registry.add("spring.datasource.password", postgres::getPassword);
-  }
 
   @Autowired private SpaceService spaceService;
   @Autowired private SpaceRepository spaceRepository;
   @Autowired private SpaceMembershipRepository membershipRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private OrganizationRepository organizationRepository;
 
   private UUID organizationA;
   private UUID organizationB;
 
   @BeforeEach
   void cleanUp() {
+    // Deliberately does not delete all organizations: Organization.DEFAULT_ID is seeded once by
+    // Liquibase and other tests sharing this Spring context (e.g.
+    // UserServicePersonalSpaceIntegrationTest) rely on that row existing (fk_users_organization).
+    // Each test creates its own throwaway organizations instead, scoped by random ids.
     membershipRepository.deleteAll();
     spaceRepository.deleteAll();
     userRepository.deleteAll();
-    organizationA = UUID.randomUUID();
-    organizationB = UUID.randomUUID();
+    organizationA =
+        organizationRepository.save(new Organization(UUID.randomUUID(), "Org A")).getId();
+    organizationB =
+        organizationRepository.save(new Organization(UUID.randomUUID(), "Org B")).getId();
   }
 
   private UUID createUser(UUID organizationId) {

--- a/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,7 +58,8 @@ class SpaceServiceIntegrationTest {
     // Deliberately does not delete all organizations: Organization.DEFAULT_ID is seeded once by
     // Liquibase and other tests sharing this Spring context (e.g.
     // UserServicePersonalSpaceIntegrationTest) rely on that row existing (fk_users_organization).
-    // Each test creates its own throwaway organizations instead, scoped by random ids.
+    // Each test creates its own throwaway organizations instead, scoped by random ids, and removes
+    // them again in tearDown() - see tearDown() below.
     membershipRepository.deleteAll();
     spaceRepository.deleteAll();
     userRepository.deleteAll();
@@ -65,6 +67,18 @@ class SpaceServiceIntegrationTest {
         organizationRepository.save(new Organization(UUID.randomUUID(), "Org A")).getId();
     organizationB =
         organizationRepository.save(new Organization(UUID.randomUUID(), "Org B")).getId();
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Users created during the test still reference organizationA/organizationB
+    // (fk_users_organization) - delete them first, then remove only the two organizations this
+    // test created (by id), never Organization.DEFAULT_ID or organizations created by other tests
+    // sharing this context.
+    membershipRepository.deleteAll();
+    spaceRepository.deleteAll();
+    userRepository.deleteAll();
+    organizationRepository.deleteAllById(List.of(organizationA, organizationB));
   }
 
   private UUID createUser(UUID organizationId) {


### PR DESCRIPTION
## Zusammenfassung

Stellt die Fremdschlüssel-abhängigen Space-Integrationstests (`SpaceServiceIntegrationTest`, `SpaceRepositoryTest`) von Hibernate-generiertem Schema (`spring.liquibase.enabled=false`, `ddl-auto=create-drop`) auf das echte, versionierte Liquibase-Schema um (`spring.liquibase.enabled=true`, `ddl-auto=none`), nach dem in `UserServicePersonalSpaceIntegrationTest` (#287) etablierten Muster. `Space.ownerId`, `SpaceMembership.userId` und alle `organizationId`-Felder sind schlichte `UUID`-Spalten ohne `@ManyToOne` — Hibernate legt dafür keine Fremdschlüssel an, Liquibase schon (`fk_spaces_owner`, `fk_space_memberships_user`, `fk_spaces_organization`, `fk_space_memberships_organization`). Jeder FK-abhängige Fall war in diesen Suiten bisher ungetestet und genau das war die Wurzel der Regressionen in PR #254 und #280.

**Update nach Review:** Beide Blocker und alle vier Nits aus dem Review sind behoben, siehe Kommentar unten für die Details je Befund.

### Entscheidung: welche Suiten umgestellt wurden und welche nicht

| Suite | Umgestellt? | Begründung |
|---|---|---|
| `SpaceServiceIntegrationTest` | Ja | Erzeugt Spaces/Memberships mit echten Owner-/Member-/Organisations-Bezügen über `SpaceService` — genau der FK-abhängige Fall |
| `SpaceRepositoryTest` | Ja | Gleicher Grund, auf Repository-Ebene |
| `UserServicePersonalSpaceIntegrationTest` (#287) | War bereits umgestellt | Als Muster übernommen; Container-Definition jetzt über die gemeinsame `TestcontainersConfiguration` statt einer eigenen Kopie |
| `SpaceServiceTest` | Bewusst **nicht** umgestellt | Reine Unit-Logik gegen gemockte Repositories (`@Mock`), keine reale Datenbankverbindung, kein Fremdschlüsselbezug — hier bringt Liquibase keinen Mehrwert, nur Laufzeit |
| `QueryIntegrationTest`, `DocumentIndexingIntegrationTest`, `ProviderConfigurationTest`, `MixedProviderConfigurationTest`, `OpenAiIntegrationTest` | **Bereits auf dem Liquibase-Schema, kein Handlungsbedarf** | Keine dieser Klassen setzt `spring.liquibase.enabled=false` — sie nutzen die Anwendungsdefaults (`application.yml`: `ddl-auto: none`, `liquibase.enabled: true`) und liefen von Anfang an gegen das volle Liquibase-Schema. Es gab hier nichts umzustellen. |
| `Migration008RenameWorkspaceToSpaceTest`, `Migration010SpaceUniquenessTest` | Unverändert (liefen bereits gegen echtes Liquibase per Definition) | Wenden Changelogs direkt per JDBC an, kein Hibernate im Spiel |

`TestcontainersConfiguration` (`io.opaa`) ist jetzt `public` statt package-private und wird von allen drei betroffenen Klassen per `@Import` geteilt, statt den Container-Bean ein drittes Mal zu duplizieren (Hinweis aus dem Review von PR #287).

### Nachweis der Wirksamkeit (Abnahmekriterium)

**Ergänzt nach Review:** Der ursprüngliche Nachweis (Revert des #280-Fixes) reproduzierte #287, nicht #288 — `UserServicePersonalSpaceIntegrationTest` lief schon vor diesem PR gegen das Liquibase-Schema und wird hier nicht umgestellt. Der eigentliche Nachweis für die tatsächlich umgestellten Klassen steht jetzt in `SpaceRepositoryTest` selbst, als zwei permanente Regressionswächter:

- `savingASpaceWithANonExistentOwnerFailsInsteadOfSilentlyPersisting()`
- `savingASpaceWithANonExistentOrganizationFailsInsteadOfSilentlyPersisting()`

Beide rufen `spaceRepository.saveAndFlush(space)` auf — Produktivcode (`SpaceRepository` wird von `SpaceService` und jedem zukünftigen Aufrufer verwendet) — mit einer `ownerId` bzw. `organizationId`, die nicht in der Datenbank existiert.

**Rot** (`SpaceRepositoryTest` testweise mit den alten Properties `spring.liquibase.enabled=false`, `ddl-auto=create-drop`, nur die beiden neuen Tests):
```
SpaceRepositoryTest > savingASpaceWithANonExistentOwnerFailsInsteadOfSilentlyPersisting() FAILED
    java.lang.AssertionError: Expecting code to raise a throwable.

SpaceRepositoryTest > savingASpaceWithANonExistentOrganizationFailsInsteadOfSilentlyPersisting() FAILED
    java.lang.AssertionError: Expecting code to raise a throwable.

2 tests completed, 2 failed
```
Der Insert eines Space mit nicht existierendem Owner/Organisation gelang unter dem alten Schema lautlos — exakt die Lücke, die #288 schließt.

**Grün** (mit dem in diesem PR eingeführten Liquibase-Schema, den Properties aus `main`):
```
BUILD SUCCESSFUL in 27s
```
Beide Tests werfen jetzt `DataIntegrityViolationException` mit `fk_spaces_owner` bzw. `fk_spaces_organization` in der Meldung.

Der ursprüngliche #280-Nachweis über `UserServicePersonalSpaceIntegrationTest` bleibt als Beleg dafür im PR, dass das etablierte Muster (#287) grundsätzlich wirkt — er ist nur nicht der Wirksamkeitsnachweis *dieses* PRs.

Zusätzlich beim Umstellen selbst ein reales Cross-Test-Problem gefunden und behoben: Der erste Entwurf von `SpaceServiceIntegrationTest#cleanUp()` rief `organizationRepository.deleteAll()` auf und löschte damit versehentlich die von Liquibase einmalig geseedete Standard-Organisation (`Organization.DEFAULT_ID`), von der `UserServicePersonalSpaceIntegrationTest` abhängt, sobald beide Klassen denselben Spring-Kontext teilen. Der volle Testlauf (`./gradlew test`) deckte das sofort auf (3 Fehlschläge mit `fk_users_organization`-Verletzung); behoben, indem jeder Test nur seine eigenen, frisch angelegten Organisationen anlegt statt alle zu löschen.

### Aufräumen der selbst angelegten Organisationen (Nit 4)

`SpaceServiceIntegrationTest` und `SpaceRepositoryTest` löschen ihre je Testmethode angelegten Organisationen jetzt in `@AfterEach` per ID (nach den davon abhängigen Users/Spaces/Memberships) — `Organization.DEFAULT_ID` bleibt unangetastet. Vorher sammelten sich pro vollem Lauf ~50 Restzeilen in der geteilten Datenbank an; das ist behoben.

### Teardown-Muster für Migrationstests vereinheitlicht (Nit 5)

`backend/src/test/java/io/opaa/migration/package-info.java` (neu) macht `connection.setAutoCommit(true)` nach jedem `Liquibase.update(...)` **unbedingt** verbindlich für dieses Package (nicht nur „falls danach noch etwas gebraucht wird") und dokumentiert die Begründung — das im Review von #283 empfohlene Muster, weil es die Ursache (Liquibase lässt `autoCommit=false` zurück) behebt statt nur das Symptom in `tearDown()` zu kaschieren. `Migration008RenameWorkspaceToSpaceTest` ist als dokumentierte Altlast (vor #283 entstanden) benannt, nicht als zweite gültige Alternative. Adressiert an #201, #202 und #238.

### Laufzeit

- Beide konvertierten Klassen isoliert: **27–32s** (neu, gemeinsamer Kontext) vs. **62s** (alt, zwei separate `@DynamicPropertySource`-Container ohne `@ServiceConnection`-Caching) — die Umstellung ist hier sogar schneller, weil der Kontext jetzt mit `UserServicePersonalSpaceIntegrationTest` geteilt wird.
- Voller Backend-Build (`./gradlew build`, alle 231+2 Tests): **~2m 30s**, wiederholt stabil bei 2m–2m15s (231–233 bestanden, 1 übersprungen ohne Docker).
- **Korrektur (Nit 6):** `OpaaApplicationTests` teilt den Kontext entgegen der ursprünglichen PR-Beschreibung *nicht* — ihr fehlen `@ActiveProfiles`/`@TestPropertySource`, sie hat damit einen eigenen Cache-Key und startet einen eigenen Container. Der geteilte Kontext umfasst `SpaceServiceIntegrationTest`, `SpaceRepositoryTest` und `UserServicePersonalSpaceIntegrationTest`. Am Laufzeit-Fazit ändert das nichts.
- Eine isolierte Baseline-Messung auf dem alten Stand (`git stash`) lieferte in dieser gemeinsam genutzten Umgebung (mehrere parallele Agent-Worktrees, gleicher Docker-Daemon) stark schwankende Werte (9m45s mit 14 infrastrukturbedingten Fehlschlägen durch Verbindungsabbrüche) — kein belastbarer Vergleichswert unter Last.
- Bewertung: Kein spürbarer Laufzeit-Nachteil. Ein über mehrere Suiten geteilter Testcontainer lohnt sich nicht zusätzlich — er existiert durch `@ServiceConnection` + `@Import(TestcontainersConfiguration.class)` bereits: Spring cached identische Kontexte automatisch.

## Was #201, #202 und #238 wissen müssen

- **Muster für FK-abhängige Service-/Repository-Tests:** `@SpringBootTest(webEnvironment = RANDOM_PORT)` + `@Import(TestcontainersConfiguration.class)` + `@ActiveProfiles({"local", "basic"})` + `@TestPropertySource(properties = "OPAA_AUTH_BASIC_SECRET=...")` + `@Testcontainers(disabledWithoutDocker = true)`. Kein `@TestPropertySource` mehr für Liquibase/ddl-auto nötig — das sind bereits die Anwendungsdefaults (`application.yml`). `WebEnvironment.NONE` funktioniert **nicht**, weil `BasicSecurityConfig` einen Web-Anwendungskontext braucht (`HttpSecurity`-Bean fehlt sonst).
- **Jede Organisation/jeder Nutzer muss real persistiert sein**, bevor er als `organizationId`/`ownerId`/`userId` verwendet wird — sonst schlägt der Insert mit der jeweiligen `fk_*`-Verletzung fehl. Bare `UUID.randomUUID()` als Platzhalter für Owner/Member/Organisation funktioniert unter diesem Schema nicht mehr.
- **`organizationRepository.deleteAll()` in `@BeforeEach` niemals verwenden**, solange der Kontext geteilt wird — das löscht die von Liquibase geseedete `Organization.DEFAULT_ID` und reißt jeden Test um, der sich (wie `UserService.findOrCreateUser`) implizit auf ihre Existenz verlässt. Stattdessen pro Test eigene, frische Organisationen mit zufälliger ID anlegen und in `@AfterEach` gezielt per ID wieder entfernen.
- **Teardown-Muster für Migrationstests:** `connection.setAutoCommit(true)` **unbedingt** nach jedem `Liquibase.update(...)`, dokumentiert in `io.opaa.migration.package-info`. `Migration008RenameWorkspaceToSpaceTest` folgt dem nicht — das ist eine dokumentierte Altlast, kein Muster zum Nachahmen.
- **Wirksamkeitsnachweis muss zur eigenen Suite gehören:** Ein Nachweis über eine bereits vorher FK-fähige Klasse belegt nicht die Wirksamkeit der eigenen Umstellung — siehe die Korrektur oben.

## Zugehörige Issues

Closes #288

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [x] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Bei Bugfix: Reproduktionsnachweis erbracht — siehe Abschnitt „Nachweis der Wirksamkeit" oben (kein Bugfix im engeren Sinn, aber derselbe Nachweis erbracht)
- [x] Dokumentation aktualisiert (falls zutreffend) — Javadoc in den umgestellten Testklassen und neues `io.opaa.migration.package-info`
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## Annahmen

- Frontend ist von dieser Änderung nicht betroffen; die Frontend-Schritte der Pre-Push-Checkliste (`npm run format/lint/test/build`) wurden deshalb nicht ausgeführt (kein `node_modules` in diesem frischen Worktree, keine Frontend-Datei geändert).
- `SpaceServiceTest` (reine Unit-Tests mit gemockten Repositories) bewusst nicht umgestellt — dort existiert keine reale Datenbankverbindung und damit kein Fremdschlüsselbezug.

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Opus 5 / Claude Code, Developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
