### PR TITLE
fix(auth): Race bei paralleler Erstanmeldung auf uq_users_subject_issuer behoben

### DIFF
--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -8,10 +8,14 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Profile({"oidc", "basic"})
@@ -21,12 +25,19 @@ public class UserService {
   private final UserRepository userRepository;
   private final SpaceService spaceService;
   private final AuthProperties authProperties;
+  private final TransactionTemplate requiresNewTransactionTemplate;
 
   public UserService(
-      UserRepository userRepository, SpaceService spaceService, AuthProperties authProperties) {
+      UserRepository userRepository,
+      SpaceService spaceService,
+      AuthProperties authProperties,
+      PlatformTransactionManager transactionManager) {
     this.userRepository = userRepository;
     this.spaceService = spaceService;
     this.authProperties = authProperties;
+    this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
+    this.requiresNewTransactionTemplate.setPropagationBehavior(
+        TransactionDefinition.PROPAGATION_REQUIRES_NEW);
   }
 
   @Transactional
@@ -34,29 +45,62 @@ public class UserService {
     User user =
         userRepository
             .findBySubjectAndIssuer(subject, issuer)
-            .map(
-                existing -> {
-                  existing.setLastLoginAt(Instant.now());
-                  if (email != null) {
-                    existing.setEmail(email);
-                  }
-                  if (displayName != null) {
-                    existing.setDisplayName(displayName);
-                  }
-                  return userRepository.save(existing);
-                })
-            .orElseGet(
-                () -> {
-                  User newUser = new User(subject, issuer, email, displayName);
-                  newUser.setOrganizationId(Organization.DEFAULT_ID);
-                  if (isInitialAdmin(email)) {
-                    newUser.setSystemRole(SystemRole.SYSTEM_ADMIN);
-                  }
-                  return userRepository.save(newUser);
-                });
+            .map(existing -> updateExistingUser(existing, email, displayName))
+            .orElseGet(() -> createOrFetchUser(subject, issuer, email, displayName));
 
     ensurePersonalSpaceAfterCommit(user.getId(), user.getOrganizationId());
     return user;
+  }
+
+  private User updateExistingUser(User existing, String email, String displayName) {
+    existing.setLastLoginAt(Instant.now());
+    if (email != null) {
+      existing.setEmail(email);
+    }
+    if (displayName != null) {
+      existing.setDisplayName(displayName);
+    }
+    return userRepository.save(existing);
+  }
+
+  /**
+   * Creates a new user, tolerating the race of two concurrent first logins for the same {@code
+   * subject}/{@code issuer} pair racing past the {@code findBySubjectAndIssuer} check above (#293).
+   *
+   * <p>{@code findOrCreateUser} is itself {@code @Transactional}. On Postgres, a failed statement
+   * aborts the entire enclosing transaction, so catching a {@link DataIntegrityViolationException}
+   * from an insert made on that same connection/transaction would leave every subsequent statement
+   * in {@code findOrCreateUser} - including the read-back of the winner's row below - failing too.
+   * The insert therefore runs in its own {@code REQUIRES_NEW} transaction, on its own connection: a
+   * constraint violation there rolls back only that attempt and leaves the caller's transaction
+   * untouched, so the loser can simply read the row the winner has by now committed, instead of
+   * surfacing a 500 for {@code uq_users_subject_issuer}. Same pattern and reasoning as {@code
+   * SpaceService#ensurePersonalSpace}.
+   *
+   * <p>Unlike {@code ensurePersonalSpace}, this does not need to be deferred to {@code
+   * TransactionSynchronization#afterCommit()} (the fix required for #280/#287): the {@code
+   * REQUIRES_NEW} insert here does not depend on anything the caller's still-open transaction has
+   * written, so there is no visibility problem to work around - it only needs its own row to be
+   * unique, which Postgres enforces regardless of what else is uncommitted on other connections.
+   */
+  private User createOrFetchUser(String subject, String issuer, String email, String displayName) {
+    try {
+      return requiresNewTransactionTemplate.execute(
+          status -> insertUser(subject, issuer, email, displayName));
+    } catch (DataIntegrityViolationException raceLost) {
+      return userRepository.findBySubjectAndIssuer(subject, issuer).orElseThrow(() -> raceLost);
+    }
+  }
+
+  private User insertUser(String subject, String issuer, String email, String displayName) {
+    User newUser = new User(subject, issuer, email, displayName);
+    newUser.setOrganizationId(Organization.DEFAULT_ID);
+    if (isInitialAdmin(email)) {
+      newUser.setSystemRole(SystemRole.SYSTEM_ADMIN);
+    }
+    // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) inside this
+    // REQUIRES_NEW transaction, instead of being deferred to a later flush point outside of it.
+    return userRepository.saveAndFlush(newUser);
   }
 
   /**

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -10,12 +10,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @Profile({"oidc", "basic"})
@@ -25,22 +22,32 @@ public class UserService {
   private final UserRepository userRepository;
   private final SpaceService spaceService;
   private final AuthProperties authProperties;
-  private final TransactionTemplate requiresNewTransactionTemplate;
 
   public UserService(
-      UserRepository userRepository,
-      SpaceService spaceService,
-      AuthProperties authProperties,
-      PlatformTransactionManager transactionManager) {
+      UserRepository userRepository, SpaceService spaceService, AuthProperties authProperties) {
     this.userRepository = userRepository;
     this.spaceService = spaceService;
     this.authProperties = authProperties;
-    this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
-    this.requiresNewTransactionTemplate.setPropagationBehavior(
-        TransactionDefinition.PROPAGATION_REQUIRES_NEW);
   }
 
-  @Transactional
+  /**
+   * Deliberately <b>not</b> {@code @Transactional} (#293 code review). Each {@link UserRepository}
+   * call below already runs in its own implicit transaction (Spring Data's {@code
+   * SimpleJpaRepository} methods are individually {@code @Transactional}), so no explicit
+   * transaction demarcation is needed here, and none is wanted: a shared, still-open outer
+   * transaction would hold one connection for the whole method while {@link #createOrFetchUser}
+   * additionally needed a second, concurrently held connection to attempt its insert without
+   * poisoning the outer one - see the retired {@code createOrFetchUser} Javadoc in the #293 PR
+   * history. Under N concurrent first logins for the same subject, that held two connections per
+   * caller for the outer transaction's whole lifetime; once N reached {@code
+   * hikari.maximum-pool-size} (default 10), every outer transaction had claimed a connection and
+   * held it while waiting on the unique index, no insert attempt could obtain the second connection
+   * it needed, and the whole pool deadlocked until {@code connectionTimeout} - a worse failure than
+   * the 500 this fix set out to remove, and reachable by ordinary login traffic (multiple requests
+   * fire right after the SPA logs in). Without an ambient transaction here, {@link
+   * #createOrFetchUser}'s insert attempt and its fallback read are each just one more short-lived,
+   * independently connection-scoped call - never two connections held by the same caller at once.
+   */
   public User findOrCreateUser(String subject, String issuer, String email, String displayName) {
     User user =
         userRepository
@@ -67,26 +74,18 @@ public class UserService {
    * Creates a new user, tolerating the race of two concurrent first logins for the same {@code
    * subject}/{@code issuer} pair racing past the {@code findBySubjectAndIssuer} check above (#293).
    *
-   * <p>{@code findOrCreateUser} is itself {@code @Transactional}. On Postgres, a failed statement
-   * aborts the entire enclosing transaction, so catching a {@link DataIntegrityViolationException}
-   * from an insert made on that same connection/transaction would leave every subsequent statement
-   * in {@code findOrCreateUser} - including the read-back of the winner's row below - failing too.
-   * The insert therefore runs in its own {@code REQUIRES_NEW} transaction, on its own connection: a
-   * constraint violation there rolls back only that attempt and leaves the caller's transaction
-   * untouched, so the loser can simply read the row the winner has by now committed, instead of
-   * surfacing a 500 for {@code uq_users_subject_issuer}. Same pattern and reasoning as {@code
-   * SpaceService#ensurePersonalSpace}.
-   *
-   * <p>Unlike {@code ensurePersonalSpace}, this does not need to be deferred to {@code
-   * TransactionSynchronization#afterCommit()} (the fix required for #280/#287): the {@code
-   * REQUIRES_NEW} insert here does not depend on anything the caller's still-open transaction has
-   * written, so there is no visibility problem to work around - it only needs its own row to be
-   * unique, which Postgres enforces regardless of what else is uncommitted on other connections.
+   * <p>Because {@link #findOrCreateUser} is deliberately not {@code @Transactional} (see its
+   * Javadoc), {@link #insertUser} below runs in its own short-lived, implicit transaction on its
+   * own connection - not one shared with this method's caller. A {@link
+   * DataIntegrityViolationException} there rolls back only that one insert; nothing here is
+   * poisoned by it, so the loser can simply read the row the winner has by now committed, instead
+   * of surfacing a 500 for {@code uq_users_subject_issuer}. Same fallback-read pattern as {@code
+   * SpaceService#ensurePersonalSpace}, but without that method's {@code REQUIRES_NEW} - there is no
+   * ambient transaction here to escape from in the first place.
    */
   private User createOrFetchUser(String subject, String issuer, String email, String displayName) {
     try {
-      return requiresNewTransactionTemplate.execute(
-          status -> insertUser(subject, issuer, email, displayName));
+      return insertUser(subject, issuer, email, displayName);
     } catch (DataIntegrityViolationException raceLost) {
       return userRepository.findBySubjectAndIssuer(subject, issuer).orElseThrow(() -> raceLost);
     }
@@ -98,27 +97,33 @@ public class UserService {
     if (isInitialAdmin(email)) {
       newUser.setSystemRole(SystemRole.SYSTEM_ADMIN);
     }
-    // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) inside this
-    // REQUIRES_NEW transaction, instead of being deferred to a later flush point outside of it.
+    // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) here, instead of
+    // being deferred to a later flush point where the DataIntegrityViolationException could
+    // surface somewhere other than this try block.
     return userRepository.saveAndFlush(newUser);
   }
 
   /**
-   * Runs {@link SpaceService#ensurePersonalSpace} only after this method's own transaction has
-   * committed the {@code users} row.
+   * Runs {@link SpaceService#ensurePersonalSpace} only after the {@code users} row it needs has
+   * been committed.
    *
-   * <p>{@code findOrCreateUser} is {@code @Transactional} and inserts the new user in a still-open
-   * transaction. {@code ensurePersonalSpace} inserts the personal space in its own {@code
-   * REQUIRES_NEW} transaction (see its Javadoc), which runs on a separate connection with its own
-   * snapshot - a call from inside the still-open outer transaction cannot see the uncommitted
-   * {@code users} row there, so the insert violated {@code fk_spaces_owner} and the whole login
-   * failed (regression from #265, fixed in #280 follow-up). Deferring the call to {@link
-   * TransactionSynchronization#afterCommit()} guarantees the user row is already committed and
-   * visible on any connection by the time the personal space is created.
+   * <p>Historically (#265, fixed in the #280 follow-up), {@code findOrCreateUser} was
+   * {@code @Transactional} and inserted the new user in a still-open transaction; {@code
+   * ensurePersonalSpace} inserts the personal space in its own {@code REQUIRES_NEW} transaction
+   * (see its Javadoc), on a separate connection with its own snapshot that could not see the
+   * uncommitted {@code users} row, so the insert violated {@code fk_spaces_owner} and the whole
+   * login failed. Deferring the call to {@link TransactionSynchronization#afterCommit()} fixed that
+   * by guaranteeing the user row was already committed and visible by the time the personal space
+   * was created.
    *
-   * <p>Falls back to an immediate, synchronous call when no transaction synchronization is active -
-   * this keeps {@code UserServiceTest} working without a real Spring-managed transaction, and would
-   * also apply if this method were ever called outside of a transactional context.
+   * <p>Since {@link #findOrCreateUser} was made deliberately non-{@code @Transactional} (#293 code
+   * review - see its Javadoc), there is no ambient transaction synchronization active here to
+   * register a callback with in the first place: every call below now always takes the immediate,
+   * synchronous branch. That remains correct for the same reason the {@code afterCommit} deferral
+   * did - each {@link UserRepository} call in {@code findOrCreateUser} already committed
+   * independently by the time control reaches here, so the user row this method's caller passes in
+   * is always already visible on any connection, including {@code ensurePersonalSpace}'s {@code
+   * REQUIRES_NEW} one.
    */
   private void ensurePersonalSpaceAfterCommit(UUID userId, UUID organizationId) {
     if (TransactionSynchronizationManager.isSynchronizationActive()) {

--- a/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
@@ -1,0 +1,109 @@
+package io.opaa.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opaa.TestcontainersConfiguration;
+import io.opaa.space.SpaceRepository;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Exercises the exact race described in #293: several real requests for the very first login of the
+ * same {@code subject}/{@code issuer} pair, racing each other inside {@link
+ * UserService#findOrCreateUser} itself - not the personal-space race that {@link
+ * UserServicePersonalSpaceIntegrationTest} already covers for already-distinct users. Runs against
+ * a real Postgres instance with the real, versioned Liquibase schema ({@code
+ * spring.liquibase.enabled=true}, {@code ddl-auto=none}) and real threads, following the pattern
+ * established by {@link UserServicePersonalSpaceIntegrationTest} - a mocked {@link
+ * org.springframework.transaction.PlatformTransactionManager} would only exercise the catch block
+ * and not the actual propagation/visibility semantics the fix depends on.
+ *
+ * <p>Before the fix, {@link #concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser()} fails:
+ * three of the four concurrent {@code findOrCreateUser} calls throw {@link
+ * org.springframework.dao.DataIntegrityViolationException} with {@code duplicate key value violates
+ * unique constraint "users_subject_issuer_unique"} (the constraint backing the migration's {@code
+ * uq_users_subject_issuer}), because {@code findOrCreateUser} checks for an existing user and
+ * inserts a new one without handling the unique-constraint race between the two.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class UserServiceCreationRaceIntegrationTest {
+
+  private static final int CONCURRENT_LOGINS = 4;
+
+  @Autowired private UserService userService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private SpaceRepository spaceRepository;
+
+  @BeforeEach
+  void cleanUp() {
+    spaceRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  @Test
+  void concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser() throws Exception {
+    String subject = UUID.randomUUID().toString();
+    String issuer = "test-issuer";
+
+    CountDownLatch ready = new CountDownLatch(CONCURRENT_LOGINS);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_LOGINS);
+    try {
+      List<Callable<User>> logins =
+          List.of(
+              loginTask(subject, issuer, ready, start),
+              loginTask(subject, issuer, ready, start),
+              loginTask(subject, issuer, ready, start),
+              loginTask(subject, issuer, ready, start));
+
+      List<Future<User>> futures = logins.stream().map(executor::submit).toList();
+      ready.await();
+      start.countDown();
+
+      List<User> results = new java.util.ArrayList<>();
+      for (Future<User> future : futures) {
+        // Any DataIntegrityViolationException on uq_users_subject_issuer surfaces here as the
+        // reproduction of #293 - none of the four calls may fail.
+        results.add(future.get(30, TimeUnit.SECONDS));
+      }
+
+      assertThat(results).extracting(User::getId).doesNotContainNull();
+      assertThat(results.stream().map(User::getId).distinct()).hasSize(1);
+
+      List<User> persisted = userRepository.findAll();
+      assertThat(persisted).hasSize(1);
+      assertThat(persisted.getFirst().getSubject()).isEqualTo(subject);
+      assertThat(persisted.getFirst().getIssuer()).isEqualTo(issuer);
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  private Callable<User> loginTask(
+      String subject, String issuer, CountDownLatch ready, CountDownLatch start) {
+    return () -> {
+      ready.countDown();
+      start.await();
+      return userService.findOrCreateUser(subject, issuer, "race@example.com", "Race Contender");
+    };
+  }
+}

--- a/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
@@ -3,7 +3,10 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opaa.TestcontainersConfiguration;
+import io.opaa.space.Space;
+import io.opaa.space.SpaceKind;
 import io.opaa.space.SpaceRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -12,6 +15,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,11 +37,21 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * and not the actual propagation/visibility semantics the fix depends on.
  *
  * <p>Before the fix, {@link #concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser()} fails:
- * three of the four concurrent {@code findOrCreateUser} calls throw {@link
+ * several of the concurrent {@code findOrCreateUser} calls throw {@link
  * org.springframework.dao.DataIntegrityViolationException} with {@code duplicate key value violates
- * unique constraint "users_subject_issuer_unique"} (the constraint backing the migration's {@code
- * uq_users_subject_issuer}), because {@code findOrCreateUser} checks for an existing user and
- * inserts a new one without handling the unique-constraint race between the two.
+ * unique constraint "uq_users_subject_issuer"}, because {@code findOrCreateUser} checks for an
+ * existing user and inserts a new one without handling the unique-constraint race between the two.
+ *
+ * <p>{@link #CONCURRENT_LOGINS} is deliberately above Hikari's default {@code maximum-pool-size} of
+ * 10, not just above 1: a first version of this fix kept {@code findOrCreateUser}
+ * {@code @Transactional} and ran the insert attempt in its own {@code REQUIRES_NEW} transaction -
+ * each caller then held two connections at once (the outer transaction's and the insert attempt's),
+ * so once the number of concurrent first logins reached the pool size, every connection was claimed
+ * by an outer transaction waiting on the unique index and no insert attempt could obtain the second
+ * connection it needed; the whole pool deadlocked until {@code connectionTimeout} instead of
+ * failing fast (found in code review of #299). {@code findOrCreateUser} is deliberately not
+ * {@code @Transactional} for exactly this reason - see its Javadoc - so this test also guards
+ * against that regression, not only against the original unique-constraint 500.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -47,7 +61,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 class UserServiceCreationRaceIntegrationTest {
 
-  private static final int CONCURRENT_LOGINS = 4;
+  private static final int CONCURRENT_LOGINS = 12;
 
   @Autowired private UserService userService;
   @Autowired private UserRepository userRepository;
@@ -69,20 +83,19 @@ class UserServiceCreationRaceIntegrationTest {
     ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_LOGINS);
     try {
       List<Callable<User>> logins =
-          List.of(
-              loginTask(subject, issuer, ready, start),
-              loginTask(subject, issuer, ready, start),
-              loginTask(subject, issuer, ready, start),
-              loginTask(subject, issuer, ready, start));
+          Stream.generate(() -> loginTask(subject, issuer, ready, start))
+              .limit(CONCURRENT_LOGINS)
+              .toList();
 
       List<Future<User>> futures = logins.stream().map(executor::submit).toList();
       ready.await();
       start.countDown();
 
-      List<User> results = new java.util.ArrayList<>();
+      List<User> results = new ArrayList<>();
       for (Future<User> future : futures) {
-        // Any DataIntegrityViolationException on uq_users_subject_issuer surfaces here as the
-        // reproduction of #293 - none of the four calls may fail.
+        // Any DataIntegrityViolationException on uq_users_subject_issuer, or a connection-pool
+        // timeout, surfaces here as a reproduction of #293 (see the class Javadoc) - none of the
+        // calls may fail.
         results.add(future.get(30, TimeUnit.SECONDS));
       }
 
@@ -91,8 +104,17 @@ class UserServiceCreationRaceIntegrationTest {
 
       List<User> persisted = userRepository.findAll();
       assertThat(persisted).hasSize(1);
-      assertThat(persisted.getFirst().getSubject()).isEqualTo(subject);
-      assertThat(persisted.getFirst().getIssuer()).isEqualTo(issuer);
+      User persistedUser = persisted.getFirst();
+      assertThat(persistedUser.getSubject()).isEqualTo(subject);
+      assertThat(persistedUser.getIssuer()).isEqualTo(issuer);
+
+      // Every one of the CONCURRENT_LOGINS calls reaches findOrCreateUser's afterCommit hook for
+      // the same user - unlike before this fix, where only the single winner of the user-creation
+      // race ever got that far. SpaceService.ensurePersonalSpace's own race handling (#265) must
+      // still collapse all of those into exactly one personal space.
+      List<Space> spaces = spaceRepository.findDistinctByMembershipsUserId(persistedUser.getId());
+      assertThat(spaces).hasSize(1);
+      assertThat(spaces.getFirst().getKind()).isEqualTo(SpaceKind.PERSONAL);
     } finally {
       executor.shutdown();
     }

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -3,6 +3,8 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,27 +12,43 @@ import io.opaa.organization.Organization;
 import io.opaa.space.SpaceService;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * The race-related tests here follow the same simulation approach as {@code SpaceServiceTest}:
+ * {@link UserRepository#findBySubjectAndIssuer} is stubbed to answer as it would for the loser of a
+ * concurrent first login (empty before the insert attempt, present after a concurrent winner has
+ * committed), and {@link UserRepository#saveAndFlush} is stubbed to throw the {@link
+ * DataIntegrityViolationException} that {@code uq_users_subject_issuer} would raise for the losing
+ * insert. The real, multi-threaded reproduction against Postgres lives in {@code
+ * UserServiceCreationRaceIntegrationTest} - a mocked {@link PlatformTransactionManager} does not
+ * execute real propagation and only covers the catch block itself.
+ */
 class UserServiceTest {
 
-  @Mock private UserRepository userRepository;
+  private UserRepository userRepository;
+  private SpaceService spaceService;
+  private AuthProperties authProperties;
+  private UserService userService;
 
-  @Mock private SpaceService spaceService;
-
-  @Mock private AuthProperties authProperties;
-
-  @InjectMocks private UserService userService;
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(UserRepository.class);
+    spaceService = mock(SpaceService.class);
+    authProperties = mock(AuthProperties.class);
+    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
+    userService = new UserService(userRepository, spaceService, authProperties, transactionManager);
+  }
 
   @Test
   void findOrCreateUserCreatesNewUser() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
-    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(userRepository.saveAndFlush(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn(null);
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "test@example.com", "Test");
@@ -59,7 +77,7 @@ class UserServiceTest {
   @Test
   void findOrCreateUserGrantsSystemAdminToInitialAdmin() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
-    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(userRepository.saveAndFlush(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "admin@example.com", "Admin");
@@ -70,7 +88,7 @@ class UserServiceTest {
   @Test
   void findOrCreateUserDoesNotGrantAdminForNonMatchingEmail() {
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
-    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(userRepository.saveAndFlush(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn("admin@example.com");
 
     User user = userService.findOrCreateUser("sub1", "issuer1", "other@example.com", "Other");
@@ -112,5 +130,43 @@ class UserServiceTest {
     // UserService no longer checks existence itself; SpaceService.ensurePersonalSpace is
     // idempotent and is always called, whether the user is new or existing.
     verify(spaceService).ensurePersonalSpace(existing.getId(), Organization.DEFAULT_ID);
+  }
+
+  @Test
+  void findOrCreateUserReadsTheWinnersUserInsteadOfThrowing() {
+    User winner = new User("sub1", "issuer1", "race@example.com", "Race");
+    winner.setOrganizationId(Organization.DEFAULT_ID);
+
+    // First call: this login has not seen a user yet. Second call (the race-loss fallback read):
+    // a concurrent login already committed one while this insert was failing.
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1"))
+        .thenReturn(Optional.empty(), Optional.of(winner));
+    when(userRepository.saveAndFlush(any(User.class)))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint"
+                    + " \"users_subject_issuer_unique\""));
+    when(authProperties.initialAdminEmail()).thenReturn(null);
+
+    User user = userService.findOrCreateUser("sub1", "issuer1", "race@example.com", "Race");
+
+    assertThat(user).isEqualTo(winner);
+    verify(userRepository, times(2)).findBySubjectAndIssuer("sub1", "issuer1");
+  }
+
+  @Test
+  void findOrCreateUserPropagatesViolationsUnrelatedToTheRace() {
+    // The user still cannot be found after the failed insert - so the violation was not caused by
+    // a concurrent winner, and must not be swallowed.
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1"))
+        .thenReturn(Optional.empty(), Optional.empty());
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("some other constraint violation");
+    when(userRepository.saveAndFlush(any(User.class))).thenThrow(violation);
+    when(authProperties.initialAdminEmail()).thenReturn(null);
+
+    assertThatThrownBy(
+            () -> userService.findOrCreateUser("sub1", "issuer1", "race@example.com", "Race"))
+        .isSameAs(violation);
   }
 }

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -15,8 +15,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 
 /**
  * The race-related tests here follow the same simulation approach as {@code SpaceServiceTest}:
@@ -24,9 +22,9 @@ import org.springframework.transaction.TransactionStatus;
  * concurrent first login (empty before the insert attempt, present after a concurrent winner has
  * committed), and {@link UserRepository#saveAndFlush} is stubbed to throw the {@link
  * DataIntegrityViolationException} that {@code uq_users_subject_issuer} would raise for the losing
- * insert. The real, multi-threaded reproduction against Postgres lives in {@code
- * UserServiceCreationRaceIntegrationTest} - a mocked {@link PlatformTransactionManager} does not
- * execute real propagation and only covers the catch block itself.
+ * insert. The real, multi-threaded reproduction against Postgres - including the pool-exhaustion
+ * regression a first, {@code @Transactional} version of this fix introduced and that this class
+ * cannot catch - lives in {@code UserServiceCreationRaceIntegrationTest}.
  */
 class UserServiceTest {
 
@@ -40,9 +38,7 @@ class UserServiceTest {
     userRepository = mock(UserRepository.class);
     spaceService = mock(SpaceService.class);
     authProperties = mock(AuthProperties.class);
-    PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
-    when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
-    userService = new UserService(userRepository, spaceService, authProperties, transactionManager);
+    userService = new UserService(userRepository, spaceService, authProperties);
   }
 
   @Test


### PR DESCRIPTION
## Zusammenfassung

`UserService.findOrCreateUser` prüfte auf einen vorhandenen Nutzer und legte ihn andernfalls an, ohne die Unique-Constraint `uq_users_subject_issuer` zu behandeln. Bei der allerersten Anmeldung eines Nutzers laufen mehrere Requests parallel (`UserProvisioningFilter` bei jedem authentifizierten Request, mehrere Aufrufe der SPA direkt nach dem Login) — mehrere davon scheiterten mit einer 500er-Antwort auf `duplicate key value violates unique constraint "uq_users_subject_issuer"`.

**Ansatz:** Dasselbe Muster wie `SpaceService.ensurePersonalSpace` (#265/#280/#287): Der Insert des neuen Nutzers läuft jetzt in einer eigenen `REQUIRES_NEW`-Transaktion, auf einer eigenen Connection. `findOrCreateUser` ist selbst `@Transactional` — auf Postgres bricht ein fehlgeschlagenes Statement die gesamte umgebende Transaktion ab, ein Catch innerhalb derselben Transaktion/Connection hätte also auch das anschließende Neulesen des Gewinner-Datensatzes unmöglich gemacht. Schlägt die `REQUIRES_NEW`-Transaktion mit `DataIntegrityViolationException` fehl, bleibt die aufrufende Transaktion unberührt, und der Verlierer liest den inzwischen committeten Nutzer einfach neu ein, statt den Fehler durchzureichen.

**Warum kein `TransactionSynchronization#afterCommit` nötig ist** (anders als bei `ensurePersonalSpace`, siehe #280/#287): Der `REQUIRES_NEW`-Insert hier hängt von nichts ab, das die aufrufende Transaktion zuvor geschrieben hat — er benötigt nur, dass sein eigener Datensatz eindeutig ist, was Postgres unabhängig vom Zustand anderer Connections durchsetzt. Es gibt also kein Sichtbarkeitsproblem wie bei `fk_spaces_owner`, das eine Verzögerung auf den Commit-Zeitpunkt erfordern würde.

**Zu `REQUIRES_NEW`, da dieses Muster im Projekt schon zweimal Ärger gemacht hat:**
- Scheitert die innere `REQUIRES_NEW`-Transaktion (Konstellationsverlierer): Die äußere Transaktion (`findOrCreateUser`) ist unberührt, da sie nie selbst das fehlschlagende Statement ausgeführt hat — sie liest anschließend einfach den committeten Gewinner-Datensatz.
- Scheitert die äußere Transaktion später (z. B. beim Registrieren des `afterCommit`-Hooks für `ensurePersonalSpace` oder danach): Der bereits committete Nutzer-Datensatz aus der `REQUIRES_NEW`-Transaktion bleibt bestehen — das ist beabsichtigt und identisch zum bereits etablierten Verhalten von `ensurePersonalSpace`, nicht neu eingeführt durch diesen PR.

## Reproduktionsnachweis

Vor dem Fix (nur `createOrFetchUser` temporär auf direkten Insert ohne Race-Behandlung zurückgesetzt, `UserServiceCreationRaceIntegrationTest` isoliert ausgeführt):

```
UserServiceCreationRaceIntegrationTest > concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser() FAILED
    java.util.concurrent.ExecutionException
        Caused by: org.springframework.dao.DataIntegrityViolationException
            ... could not execute statement [ERROR: duplicate key value violates unique constraint "uq_users_subject_issuer"
  Detail: Key (subject, issuer)=(e348b76b-c514-4255-9a05-638b3a879adc, test-issuer) already exists.]
```

Mit dem Fix wiederhergestellt: `concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser()` bestanden (4 parallele echte Threads, echtes Postgres mit Liquibase-Schema, `spring.liquibase.enabled=true`, `ddl-auto=none`).

## Änderungen

- `UserService.findOrCreateUser` teilt sich jetzt in `updateExistingUser` (unverändert) und `createOrFetchUser` (neu, mit Race-Behandlung via `REQUIRES_NEW` + Catch + Neu-Lesen)
- `UserServiceCreationRaceIntegrationTest` (neu): 4 parallele echte Threads gegen echtes Postgres/Liquibase, Muster `UserServicePersonalSpaceIntegrationTest`
- `UserServiceTest`: umgestellt von `@InjectMocks`/`MockitoExtension` auf manuelle Konstruktion (analog `SpaceServiceTest`), da der Konstruktor jetzt einen `PlatformTransactionManager` erwartet; zwei neue Fälle für Race-Gewinn-Lesen und unabhängige Constraint-Verletzungen

## Weitere Fundstellen desselben Musters (nicht behoben, zur Information)

- `DirectorySyncStatusRecorder.record` (`io.opaa.group.sync`): `statusRepository.findByOrganizationId(...).orElseGet(() -> new DirectorySyncStatus(organizationId))` gegen die Unique-Constraint `uk_directory_sync_status_organization`, ohne Behandlung einer `DataIntegrityViolationException`. Vermutlich geringes Risiko, da Sync-Läufe pro Organisation nicht typischerweise parallel angestoßen werden — aber dasselbe Check-then-Create-Muster wie hier.

## Zugehörige Issues

Closes #293

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Bei Bugfix: Reproduktionsnachweis erbracht — der Test schlägt auf dem fehlerhaften Stand fehl und besteht mit dem Fix (rote Fehlermeldung oben eingefügt)
- [ ] Dokumentation aktualisiert (falls zutreffend) — nicht erforderlich
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet) — bereits unterzeichnet

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code, Developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst