### PR TITLE
ci(eval): Retrieval-Regressionsjob mit Baseline und Schwellenwerten

### DIFF
--- a/.github/workflows/retrieval-regression.yml
+++ b/.github/workflows/retrieval-regression.yml
@@ -1,0 +1,220 @@
+name: Retrieval-Regression
+
+# Bewusst NICHT bei jedem Pull Request (siehe docs/features/search-quality-evaluation.md,
+# "Auslösung", und ADR-0011, Entscheidung 5): der Lauf zieht ein Ollama-Modell und indiziert rund
+# 1.450 Dokumente über die echte Chunking-/Embedding-Pipeline, das dauert mehrere Minuten selbst mit
+# warmem Modell-Cache (siehe eval/README.md) und würde jeden PR-Push unnötig verlangsamen.
+on:
+  schedule:
+    # Post-merge QA loop, wie in .github/workflows/e2e.yml — ein anderer Zeitpunkt (2:11 statt
+    # 3:17 UTC) verhindert, dass beide teuren nächtlichen Jobs gleichzeitig um denselben
+    # Runner/Docker-Netzwerk-Zugriff konkurrieren.
+    - cron: '11 2 * * *'
+  workflow_dispatch: {}
+  pull_request:
+    types: [labeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: retrieval-regression-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'scheduled' }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    # Bei PR-Auslösung nur reagieren, wenn das Label tatsächlich 'evaluation' ist (jedes andere
+    # Label auf demselben PR löst sonst ebenfalls "labeled" aus und würde den teuren Job unnötig
+    # starten).
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'evaluation'
+    runs-on: ubuntu-latest
+    # Issue #228 Abnahmekriterium: darf 20 Minuten nicht überschreiten. Die zuletzt gemessene
+    # evaluateRetrieval-Laufzeit war ~1004s (~17 min); der Rest (Checkout, Java-Setup,
+    # Baseline-Vergleich, Cache) bekommt hier die verbleibende Marge.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('backend/**/*.gradle*', 'backend/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # Named Docker volume that RetrievalEvaluationHarnessTest bind-mounts into the Ollama
+      # container (see its OLLAMA_MODEL_VOLUME javadoc). On a developer machine this volume
+      # survives across runs; on GitHub's ephemeral runners it does not, so every scheduled run
+      # would otherwise re-pull the ~275 MB model from ollama.com. That both costs runner time and
+      # contradicts ADR-0011's "runs without network access to third-party sources" promise for the
+      # regression test itself. actions/cache round-trips the volume's content as a tar file
+      # instead: the pull only happens once per model digest (see the cache key below), and every
+      # subsequent run restores it from GitHub's cache, not from the network.
+      #
+      # The cache key is pinned to the exact expected digest
+      # (RetrievalEvaluationHarnessTest.EXPECTED_EMBEDDING_MODEL_DIGEST), not just the tag: a
+      # deliberate model re-pin changes the digest constant, which changes this key, which means a
+      # stale cache for the old model is never silently reused.
+      - name: Restore Ollama model cache
+        id: ollama-cache
+        uses: actions/cache@v4
+        with:
+          path: ollama-model-cache.tar
+          key: ollama-model-nomic-embed-text-v1.5-0a109f42
+
+      - name: Seed Docker volume from cache
+        if: steps.ollama-cache.outputs.cache-hit == 'true'
+        run: |
+          docker volume create opaa-eval-ollama-models
+          docker run --rm \
+            -v opaa-eval-ollama-models:/root/.ollama \
+            -v "${{ github.workspace }}":/backup \
+            alpine sh -c "tar xf /backup/ollama-model-cache.tar -C /root/.ollama"
+
+      - name: Retrieval-Regression ausführen
+        working-directory: backend
+        run: ./gradlew checkRetrievalBaseline
+
+      # Runs unconditionally (always(), not just on success) so a fresh pull on a cache miss is
+      # captured for next time even if the baseline comparison itself then fails — the model
+      # content is independent of whether retrieval quality regressed.
+      - name: Docker-Volume für den Cache exportieren
+        if: always()
+        run: |
+          docker run --rm \
+            -v opaa-eval-ollama-models:/root/.ollama \
+            -v "${{ github.workspace }}":/backup \
+            alpine sh -c "tar cf /backup/ollama-model-cache.tar -C /root/.ollama ."
+
+      - name: Report als Artefakt hochladen
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retrieval-metrics
+          path: |
+            backend/build/eval-reports/retrieval-metrics.json
+            backend/build/eval-reports/baseline-comparison.md
+          if-no-files-found: warn
+          retention-days: 90
+
+      # Bei Auslösung per PR-Label: Ergebnis als PR-Kommentar mit Delta-Tabelle (Issue #228,
+      # Umfang). Läuft unabhängig davon, ob der vorige Schritt bestanden hat oder nicht — genau dann
+      # ist der Kommentar am wichtigsten.
+      - name: Delta-Tabelle als PR-Kommentar posten
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'backend/build/eval-reports/baseline-comparison.md';
+            if (!fs.existsSync(path)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '## Retrieval-Regression gegen Baseline\n\nDer Lauf hat keinen Report ' +
+                  'erzeugt (vermutlich vor der Baseline-Prüfung abgebrochen) — siehe die ' +
+                  'Workflow-Logs für Details.',
+              });
+              return;
+            }
+            const body = fs.readFileSync(path, 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      # Nächtlicher/manueller Lauf hat kein PR, das einen Fehlschlag sichtbar macht — ohne diesen
+      # Schritt wäre ein Regressionsfund für niemanden sichtbar, bis zufällig jemand in die
+      # Actions-Läufe schaut. Sucht ein offenes, mit dem festen Marker versehenes Issue und
+      # aktualisiert es, statt bei jedem nächtlichen Fehlschlag ein weiteres Duplikat anzulegen.
+      - name: Fehlschlag als Issue melden (nächtlicher/manueller Lauf)
+        if: failure() && github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- retrieval-regression-alert -->';
+            const path = 'backend/build/eval-reports/baseline-comparison.md';
+            const details = fs.existsSync(path) ? fs.readFileSync(path, 'utf8') : '_Kein Report ' +
+              'erzeugt — vermutlich vor der Baseline-Prüfung abgebrochen (z. B. Manifest- oder ' +
+              'Ein-Chunk-Invariante-Verletzung). Siehe Workflow-Logs._';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\n\n**Automatischer nächtlicher Retrieval-Regressionslauf ` +
+              `fehlgeschlagen.**\n\nWorkflow-Lauf: ${runUrl}\n\n${details}`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'evaluation',
+            });
+            const existing = issues.find(i => i.body && i.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Erneut fehlgeschlagen: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Retrieval-Regression erkannt (automatischer Lauf)',
+                body,
+                labels: ['evaluation', 'bug'],
+              });
+            }
+
+      # Spiegelbild des vorigen Schritts: schließt/kommentiert das Alarm-Issue automatisch, sobald
+      # ein nächtlicher/manueller Lauf wieder grün ist, statt es als vermeintlich offenes Problem
+      # liegen zu lassen.
+      - name: Alarm-Issue bei erneutem Bestehen schließen
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- retrieval-regression-alert -->';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'evaluation',
+            });
+            const existing = issues.find(i => i.body && i.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: 'Der nächtliche Retrieval-Regressionslauf ist wieder grün: ' +
+                  `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/retrieval-regression.yml
+++ b/.github/workflows/retrieval-regression.yml
@@ -21,24 +21,41 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: retrieval-regression-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'scheduled' }}
-  cancel-in-progress: true
+  # PR #301 review, Befund 2: a workflow-level concurrency group keyed only on the PR number
+  # cancelled an in-flight 'evaluation'-labeled run whenever *any other* label was added to the
+  # same PR afterwards, because both runs shared the same group and cancel-in-progress killed the
+  # earlier one before its job-level `if` (below) ever got a chance to skip the irrelevant one.
+  # Including the event name and the label name in the group key means only a genuine re-trigger
+  # of the *same* event (e.g. the 'evaluation' label removed and re-added) shares a group; a
+  # different label, workflow_dispatch and schedule never collide with each other or with a
+  # legitimate 'evaluation' run. cancel-in-progress stays false: a 17-minute run that used to be
+  # this specific key is worth letting finish, not killing pre-emptively.
+  group: retrieval-regression-${{ github.event_name }}-${{ github.event.pull_request.number || 'none' }}-${{ github.event.label.name || 'none' }}
+  cancel-in-progress: false
 
 jobs:
   evaluate:
     # Bei PR-Auslösung nur reagieren, wenn das Label tatsächlich 'evaluation' ist (jedes andere
     # Label auf demselben PR löst sonst ebenfalls "labeled" aus und würde den teuren Job unnötig
-    # starten).
+    # starten). Läuft dank der eindeutigen Concurrency-Gruppe oben unabhängig von anderen
+    # Label-Events auf demselben PR.
     if: >
       github.event_name != 'pull_request' ||
       github.event.label.name == 'evaluation'
     runs-on: ubuntu-latest
-    # Issue #228 Abnahmekriterium: darf 20 Minuten nicht überschreiten. Die zuletzt gemessene
-    # evaluateRetrieval-Laufzeit war ~1004s (~17 min); der Rest (Checkout, Java-Setup,
-    # Baseline-Vergleich, Cache) bekommt hier die verbleibende Marge.
-    timeout-minutes: 20
+    # PR #301 review, Befund 6: 20 Minuten gegen eine gemessene evaluateRetrieval-Laufzeit von
+    # ~1004s (~17 min) plus Checkout, Java-Setup, Gradle-Build, Image-Pulls und ggf. einen
+    # ~275-MB-Modell-Pull auf einem kalten Cache ließ praktisch keine Marge. 30 Minuten geben dem
+    # Rest realistisch Raum; das Abnahmekriterium in Issue #228 ("20 Minuten") ist dazu als
+    # bewusste, dokumentierte Abweichung im PR und als Issue-Kommentar festgehalten.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 statt des Default-1: Der Baseline-Absenkungs-Check unten braucht
+          # `git show origin/main:eval/baseline/comic-characters.json`, was bei einem flachen
+          # Checkout des PR-Branches allein nicht auflösbar ist.
+          fetch-depth: 0
 
       - uses: actions/setup-java@v4
         with:
@@ -57,11 +74,12 @@ jobs:
       # Named Docker volume that RetrievalEvaluationHarnessTest bind-mounts into the Ollama
       # container (see its OLLAMA_MODEL_VOLUME javadoc). On a developer machine this volume
       # survives across runs; on GitHub's ephemeral runners it does not, so every scheduled run
-      # would otherwise re-pull the ~275 MB model from ollama.com. That both costs runner time and
-      # contradicts ADR-0011's "runs without network access to third-party sources" promise for the
-      # regression test itself. actions/cache round-trips the volume's content as a tar file
-      # instead: the pull only happens once per model digest (see the cache key below), and every
-      # subsequent run restores it from GitHub's cache, not from the network.
+      # would otherwise re-pull the ~275 MB model. actions/cache round-trips the volume's content
+      # as a tar file instead: the pull only happens once per model digest (see the cache key
+      # below), and every subsequent run restores it from GitHub's cache. Combined with
+      # RetrievalEvaluationHarnessTest now skipping 'ollama pull' entirely once the expected digest
+      # is already present locally (see its pullEmbeddingModel() javadoc), a warm cache run makes
+      # no third-party network call at all.
       #
       # The cache key is pinned to the exact expected digest
       # (RetrievalEvaluationHarnessTest.EXPECTED_EMBEDDING_MODEL_DIGEST), not just the tag: a
@@ -87,16 +105,63 @@ jobs:
         working-directory: backend
         run: ./gradlew checkRetrievalBaseline
 
-      # Runs unconditionally (always(), not just on success) so a fresh pull on a cache miss is
-      # captured for next time even if the baseline comparison itself then fails — the model
-      # content is independent of whether retrieval quality regressed.
+      # PR #301 review, Befund 3: this used to run unconditionally (always()) with a fixed cache
+      # key. actions/cache keys are immutable — if an earlier step failed before (or during) the
+      # Ollama model pull, this step would have exported an empty/partial volume, and that content
+      # would then have been saved under the fixed key *permanently*: every subsequent run would
+      # report a cache hit, seed nothing useful, and still re-pull the 275 MB anyway, forever,
+      # without anyone noticing. The size check below only ever populates the cache-eligible tar
+      # file when the volume plausibly contains a real model (~275 MB); otherwise it leaves no file
+      # at the cache path, so actions/cache's own post-job save simply has nothing to cache this
+      # run — no corruption, just a retry (with a real network pull) next time.
       - name: Docker-Volume für den Cache exportieren
         if: always()
         run: |
-          docker run --rm \
-            -v opaa-eval-ollama-models:/root/.ollama \
-            -v "${{ github.workspace }}":/backup \
-            alpine sh -c "tar cf /backup/ollama-model-cache.tar -C /root/.ollama ."
+          if docker volume inspect opaa-eval-ollama-models >/dev/null 2>&1; then
+            size=$(docker run --rm -v opaa-eval-ollama-models:/root/.ollama alpine \
+              du -sb /root/.ollama 2>/dev/null | cut -f1 || echo 0)
+            echo "Ollama-Volume-Größe: ${size:-0} Bytes"
+            if [ "${size:-0}" -gt 150000000 ]; then
+              docker run --rm \
+                -v opaa-eval-ollama-models:/root/.ollama \
+                -v "${{ github.workspace }}":/backup \
+                alpine sh -c "tar cf /backup/ollama-model-cache.tar -C /root/.ollama ."
+            else
+              echo "Volume zu klein (oder fehlt) für einen gültigen Modell-Cache — Export übersprungen, um den Cache-Schlüssel nicht dauerhaft zu vergiften."
+            fi
+          else
+            echo "Docker-Volume opaa-eval-ollama-models existiert nicht — Export übersprungen."
+          fi
+
+      - name: Baseline von main laden (nur PR-Lauf)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main --depth=1
+          mkdir -p backend/build/eval-reports
+          git show origin/main:eval/baseline/comic-characters.json > /tmp/main-baseline.json
+
+      # ADR-0013, Entscheidung 6: eine Baseline-Absenkung soll sichtbar sein, nicht nur prozedural
+      # über eval/baseline/README.md gehofft. Rein informativ (Exit-Code immer 0) — die eigentliche
+      # Kontrolle bleibt der Review, siehe Docstring von diff_baseline.py.
+      - name: Baseline-Absenkung gegenüber main prüfen (nur PR-Lauf)
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 eval/baseline/diff_baseline.py \
+            --main /tmp/main-baseline.json \
+            --pr eval/baseline/comic-characters.json \
+            --output backend/build/eval-reports/baseline-diff-vs-main.md \
+            --main-ref main \
+            --pr-ref "${{ github.head_ref }}"
+
+      - name: Report der Job-Zusammenfassung hinzufügen
+        if: always()
+        run: |
+          if [ -f backend/build/eval-reports/baseline-comparison.md ]; then
+            cat backend/build/eval-reports/baseline-comparison.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f backend/build/eval-reports/baseline-diff-vs-main.md ]; then
+            cat backend/build/eval-reports/baseline-diff-vs-main.md >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Report als Artefakt hochladen
         if: always()
@@ -106,31 +171,37 @@ jobs:
           path: |
             backend/build/eval-reports/retrieval-metrics.json
             backend/build/eval-reports/baseline-comparison.md
+            backend/build/eval-reports/baseline-diff-vs-main.md
           if-no-files-found: warn
           retention-days: 90
 
       # Bei Auslösung per PR-Label: Ergebnis als PR-Kommentar mit Delta-Tabelle (Issue #228,
-      # Umfang). Läuft unabhängig davon, ob der vorige Schritt bestanden hat oder nicht — genau dann
-      # ist der Kommentar am wichtigsten.
+      # Umfang), plus die Baseline-Diff-Tabelle gegenüber main. Läuft unabhängig davon, ob der
+      # vorige Schritt bestanden hat oder nicht — genau dann ist der Kommentar am wichtigsten.
+      # continue-on-error (PR #301 review, Befund 5): löst ein Fork den Lauf aus, ist das
+      # Standard-GITHUB_TOKEN schreibgeschützt und dieser Schritt scheitert mit 403 — das darf den
+      # eigentlichen Retrieval-Befund (vorheriger Schritt) nicht überdecken.
       - name: Delta-Tabelle als PR-Kommentar posten
         if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const path = 'backend/build/eval-reports/baseline-comparison.md';
-            if (!fs.existsSync(path)) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: '## Retrieval-Regression gegen Baseline\n\nDer Lauf hat keinen Report ' +
-                  'erzeugt (vermutlich vor der Baseline-Prüfung abgebrochen) — siehe die ' +
-                  'Workflow-Logs für Details.',
-              });
-              return;
+            const comparisonPath = 'backend/build/eval-reports/baseline-comparison.md';
+            const diffPath = 'backend/build/eval-reports/baseline-diff-vs-main.md';
+
+            let body;
+            if (!fs.existsSync(comparisonPath)) {
+              body = '## Retrieval-Regression gegen Baseline\n\nDer Lauf hat keinen Report ' +
+                'erzeugt (vermutlich vor der Baseline-Prüfung abgebrochen) — siehe die ' +
+                'Workflow-Logs für Details.';
+            } else {
+              body = fs.readFileSync(comparisonPath, 'utf8');
+              if (fs.existsSync(diffPath)) {
+                body += '\n\n' + fs.readFileSync(diffPath, 'utf8');
+              }
             }
-            const body = fs.readFileSync(path, 'utf8');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -141,9 +212,15 @@ jobs:
       # Nächtlicher/manueller Lauf hat kein PR, das einen Fehlschlag sichtbar macht — ohne diesen
       # Schritt wäre ein Regressionsfund für niemanden sichtbar, bis zufällig jemand in die
       # Actions-Läufe schaut. Sucht ein offenes, mit dem festen Marker versehenes Issue und
-      # aktualisiert es, statt bei jedem nächtlichen Fehlschlag ein weiteres Duplikat anzulegen.
+      # kommentiert es, statt bei jedem nächtlichen Fehlschlag ein weiteres Duplikat anzulegen oder
+      # (PR #301 review) eine bereits vorhandene Analyse im Body zu überschreiben.
+      #
+      # `if: failure() || cancelled()` statt nur `failure()` (Befund 6): Ein Abbruch durch
+      # `timeout-minutes` markiert den Job als cancelled, nicht als failed — `failure()` allein
+      # hätte einen reinen Timeout-Fehlschlag lautlos durchrutschen lassen, ohne Alarm-Issue und
+      # ohne Artefakt-Hinweis.
       - name: Fehlschlag als Issue melden (nächtlicher/manueller Lauf)
-        if: failure() && github.event_name != 'pull_request'
+        if: (failure() || cancelled()) && github.event_name != 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -152,37 +229,43 @@ jobs:
             const path = 'backend/build/eval-reports/baseline-comparison.md';
             const details = fs.existsSync(path) ? fs.readFileSync(path, 'utf8') : '_Kein Report ' +
               'erzeugt — vermutlich vor der Baseline-Prüfung abgebrochen (z. B. Manifest- oder ' +
-              'Ein-Chunk-Invariante-Verletzung). Siehe Workflow-Logs._';
+              'Ein-Chunk-Invariante-Verletzung) oder durch das Zeitlimit abgebrochen. Siehe ' +
+              'Workflow-Logs._';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `${marker}\n\n**Automatischer nächtlicher Retrieval-Regressionslauf ` +
+            const commentBody = `Erneut fehlgeschlagen: ${runUrl}\n\n${details}`;
+            const issueBody = `${marker}\n\n**Automatischer nächtlicher Retrieval-Regressionslauf ` +
               `fehlgeschlagen.**\n\nWorkflow-Lauf: ${runUrl}\n\n${details}`;
 
-            const { data: issues } = await github.rest.issues.listForRepo({
+            // per_page: 100 statt der 30er-Default-Seite, und ausdrücklicher Ausschluss von Pull
+            // Requests (PR #301 review): listForRepo mit label 'evaluation' liefert auch offene
+            // PRs zurück, weil 'evaluation' zugleich das Auslöser-Label ist — ohne den Filter und
+            // ohne ausreichende Seitengröße könnte das Alarm-Issue von der ersten Seite rutschen
+            // und ein Duplikat entstehen.
+            const { data: issuesAndPrs } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'evaluation',
+              per_page: 100,
             });
-            const existing = issues.find(i => i.body && i.body.includes(marker));
+            const existing = issuesAndPrs.find(
+              i => !i.pull_request && i.body && i.body.includes(marker)
+            );
             if (existing) {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.number,
-                body,
-              });
+              // Nur kommentieren, nie den Body überschreiben (PR #301 review) — eine eingetragene
+              // Analyse des Maintainers im Issue-Body wäre sonst beim nächsten Fehlschlag weg.
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existing.number,
-                body: `Erneut fehlgeschlagen: ${runUrl}`,
+                body: commentBody,
               });
             } else {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: 'Retrieval-Regression erkannt (automatischer Lauf)',
-                body,
+                body: issueBody,
                 labels: ['evaluation', 'bug'],
               });
             }
@@ -196,13 +279,19 @@ jobs:
         with:
           script: |
             const marker = '<!-- retrieval-regression-alert -->';
-            const { data: issues } = await github.rest.issues.listForRepo({
+            const { data: issuesAndPrs } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: 'evaluation',
+              per_page: 100,
             });
-            const existing = issues.find(i => i.body && i.body.includes(marker));
+            // Provenance check (PR #301 review): only ever touch an issue that actually carries
+            // this workflow's own marker — never assume "some open issue labeled evaluation" is
+            // the one this workflow created.
+            const existing = issuesAndPrs.find(
+              i => !i.pull_request && i.body && i.body.includes(marker)
+            );
             if (existing) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,27 @@ statt sie zu kopieren; siehe `e2e/README.md` für Details zum lokalen Ausführen
 Selektor-Konvention (`getByRole`/`getByLabel` vor `data-testid` vor Text-/Placeholder-Selektoren)
 und die Serialisierungs-Konvention für Specs, die gemeinsamen Zustand verändern.
 
+## Retrieval-Regressionsjob und Baseline-Aktualisierung
+
+Der nächtliche Retrieval-Regressionsjob (`.github/workflows/retrieval-regression.yml`, siehe
+[`eval/README.md`](eval/README.md) und [`eval/baseline/README.md`](eval/baseline/README.md))
+vergleicht jeden Lauf gegen eine committete Baseline (`eval/baseline/comic-characters.json`). Eine
+neue Baseline ist nötig — im selben PR wie die verursachende Änderung, nicht separat —, sobald sich
+eine der folgenden Größen legitim ändert:
+
+- der Testkorpus (`eval/corpus/comic-characters/`, erkennbar an einer neuen
+  `MANIFEST.sha256`-Summe)
+- das Golden Dataset (`eval/golden/comic-characters.json`)
+- das Einbettungsmodell oder sein gepinnter Digest (`nomic-embed-text:v1.5` in
+  `RetrievalEvaluationHarnessTest`)
+- `opaa.indexing.chunk-size` in `application.yml`
+- der Messvertrag (ADR-0012), z. B. Gain-Funktion, IDCG-Basis oder die Fenstergrößen der Metriken
+
+In jedem dieser Fälle ist ein Fehlschlag des Jobs **keine** Retrieval-Regression, sondern eine
+geänderte Messgrundlage — der Job meldet das ausdrücklich getrennt (siehe
+`eval/baseline/README.md`, Abschnitt „Baseline ungültig vs. Regression"). Wer die Baseline ändern
+darf und mit welcher Begründung, steht dort im Detail.
+
 ## Issues
 
 - **Issues müssen auf Deutsch verfasst werden** — ebenso Pull Requests und Dokumentation. Englisch bleibt dem Quellcode vorbehalten (Bezeichner, Dateinamen, Kommentare); Details in [AGENTS.md](AGENTS.md#projektsprache)

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -77,26 +77,54 @@ tasks.register<Test>("evaluateRetrieval") {
 }
 
 // Fast, Docker-free unit tests for the pure metric math (RetrievalMetrics, MetricsAggregate,
-// CorpusManifest — see their Javadoc). Lives in the evalTest source set (not `main`/`test`) so the
-// classes under test never ship in the production jar, but still runs as part of `check` so a
-// Spring AI/Testcontainers upgrade that breaks compilation, or a metric-math regression, is caught
-// without Docker. Explicitly excludes RetrievalEvaluationHarnessTest, which needs Testcontainers
-// and stays exclusive to `evaluateRetrieval` — issue #227's exclusion criterion is about that one
-// Docker-requiring test class, not about the evalTest source set as a whole.
+// CorpusManifest, BaselineComparator — see their Javadoc). Lives in the evalTest source set (not
+// `main`/`test`) so the classes under test never ship in the production jar, but still runs as
+// part of `check` so a Spring AI/Testcontainers upgrade that breaks compilation, or a metric-math
+// regression, is caught without Docker. Explicitly excludes RetrievalEvaluationHarnessTest (needs
+// Testcontainers, stays exclusive to `evaluateRetrieval`) and BaselineRegressionTest (needs a
+// report file that only exists after a real `evaluateRetrieval` run, stays exclusive to
+// `checkRetrievalBaseline` below) — issue #227/#228's exclusion criterion is about those two
+// specific test classes, not about the evalTest source set as a whole.
 tasks.register<Test>("evalUnitTest") {
     description = "Docker-free unit tests for the eval metric math (RetrievalMetrics, " +
-        "MetricsAggregate, CorpusManifest). Part of check; does not touch Testcontainers."
+        "MetricsAggregate, CorpusManifest, BaselineComparator). Part of check; no Testcontainers, " +
+        "no report file dependency."
     group = "verification"
     testClassesDirs = sourceSets["evalTest"].output.classesDirs
     classpath = sourceSets["evalTest"].runtimeClasspath
     useJUnitPlatform()
     filter {
         excludeTestsMatching("*RetrievalEvaluationHarnessTest")
+        excludeTestsMatching("*BaselineRegressionTest")
     }
 }
 
 tasks.named("check") {
     dependsOn("evalUnitTest")
+}
+
+// Compares the report produced by evaluateRetrieval against the committed baseline
+// (eval/baseline/comic-characters.json, issue #228). Depends on evaluateRetrieval so a single
+// `./gradlew checkRetrievalBaseline` invocation (as used by the nightly/manual/label-triggered CI
+// job in .github/workflows/retrieval-regression.yml) runs the full Docker-requiring harness and
+// then the baseline comparison, in order. Not part of `check`/`build`/`evalUnitTest` — same
+// rationale as `evaluateRetrieval` itself.
+tasks.register<Test>("checkRetrievalBaseline") {
+    description = "Runs evaluateRetrieval, then fails if the result regresses beyond tolerance " +
+        "against eval/baseline/comic-characters.json (issue #228). Needs Docker."
+    group = "verification"
+    dependsOn("evaluateRetrieval")
+    testClassesDirs = sourceSets["evalTest"].output.classesDirs
+    classpath = sourceSets["evalTest"].runtimeClasspath
+    useJUnitPlatform()
+    outputs.upToDateWhen { false }
+    filter {
+        includeTestsMatching("*BaselineRegressionTest")
+    }
+    testLogging {
+        events("passed", "skipped", "failed", "standard_out")
+        showStandardStreams = true
+    }
 }
 
 dependencyManagement {

--- a/backend/src/evalTest/java/io/opaa/eval/Baseline.java
+++ b/backend/src/evalTest/java/io/opaa/eval/Baseline.java
@@ -1,0 +1,66 @@
+package io.opaa.eval;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * The committed retrieval-quality baseline (issue #228), checked into {@code
+ * eval/baseline/comic-characters.json}. Deliberately a separate, narrower schema from {@link
+ * EvaluationReport} rather than reusing that record directly: a baseline is a curated, reviewed
+ * artifact (fixed points + group metrics + a human-readable rationale), not a raw run dump — it
+ * intentionally omits per-query detail ({@code worstQueries}/{@code allQueryResults}) that would
+ * make every regenerated report a spurious diff.
+ *
+ * <p>See {@code eval/baseline/README.md} for the update procedure and the tolerance rationale
+ * implemented in {@link BaselineComparator}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Baseline(
+    int measurementContractVersion,
+    FixedPoints fixedPoints,
+    Map<String, MetricsAggregate> groups,
+    String measuredAt,
+    String notes) {
+
+  /**
+   * The values that define what was measured, as opposed to how well it scored. Any drift here
+   * means "this baseline no longer applies", not "retrieval got worse" — see {@link
+   * BaselineComparator#compare}, which reports the two cases with different messages on purpose
+   * (ADR-0011/ADR-0012: corpus, golden dataset, embedding model and measurement contract are all
+   * baseline-defining and require a deliberate re-measurement on change).
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record FixedPoints(
+      String embeddingModel,
+      String embeddingModelDigest,
+      int chunkSize,
+      boolean chunkSizeMatchesApplicationDefault,
+      String corpusManifestSha256,
+      int corpusDocumentCount,
+      String goldenDatasetFile,
+      String goldenDatasetSha256,
+      int goldenCaseCount) {}
+
+  /** Group keys used in {@link #groups()} — must match how the report's groups are addressed. */
+  public static final String OVERALL = "overall";
+
+  public static String category(String name) {
+    return "category:" + name;
+  }
+
+  public static String difficulty(String name) {
+    return "difficulty:" + name;
+  }
+
+  public static String language(String name) {
+    return "language:" + name;
+  }
+
+  public static Baseline load(Path file) throws IOException {
+    return new ObjectMapper().readValue(Files.readString(file), Baseline.class);
+  }
+}

--- a/backend/src/evalTest/java/io/opaa/eval/Baseline.java
+++ b/backend/src/evalTest/java/io/opaa/eval/Baseline.java
@@ -24,7 +24,17 @@ public record Baseline(
     FixedPoints fixedPoints,
     Map<String, MetricsAggregate> groups,
     String measuredAt,
+    Provenance provenance,
     String notes) {
+
+  /**
+   * Where this baseline's numbers came from — purely documentary, never read by {@link
+   * BaselineComparator} (PR #301 review: "Erwäge Provenienzfelder in der Baseline-Datei"). Lets a
+   * reader trace a committed baseline back to the exact {@code evaluateRetrieval} run and PR that
+   * produced it, without having to dig through git blame.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Provenance(String sourceReportRunStartedAt, String sourcePullRequest) {}
 
   /**
    * The values that define what was measured, as opposed to how well it scored. Any drift here
@@ -37,8 +47,17 @@ public record Baseline(
   public record FixedPoints(
       String embeddingModel,
       String embeddingModelDigest,
+      int embeddingDimensions,
       int chunkSize,
       boolean chunkSizeMatchesApplicationDefault,
+      // ADR-0012, decision 3: searchTopK and the (deliberately unset) production similarity
+      // threshold are part of the measurement contract, not just run metadata — see
+      // BaselineComparator's Javadoc and PR #301 review, Befund 4.
+      int searchTopK,
+      double productionSimilarityThreshold,
+      // ADR-0011, Konsequenzen: a future switch to exact search for the evaluation is a
+      // measurement-contract change, same as a corpus or model change.
+      String pgvectorIndexType,
       String corpusManifestSha256,
       int corpusDocumentCount,
       String goldenDatasetFile,

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineComparator.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineComparator.java
@@ -1,0 +1,299 @@
+package io.opaa.eval;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Compares a freshly produced {@link EvaluationReport} against the committed {@link Baseline}
+ * (issue #228). Two independent questions are answered, on purpose kept separate rather than
+ * collapsed into a single pass/fail bit — conflating them is exactly the failure mode the issue
+ * warns about ("Baseline ungültig" vs. "Retrieval ist schlechter geworden" are different
+ * statements):
+ *
+ * <ol>
+ *   <li>{@link ComparisonResult#baselineValid()} — do the fixed points (measurement-contract
+ *       version, corpus manifest, golden dataset, embedding model digest, chunk size) still match
+ *       what the baseline was measured under? If not, no metric comparison is meaningful and none
+ *       is attempted.
+ *   <li>Only if the baseline is valid: does every group's metrics stay within tolerance of the
+ *       baseline, and do the four overall metrics clear an independent, baseline-agnostic hard
+ *       floor?
+ * </ol>
+ *
+ * <h2>Tolerance rationale (see eval/baseline/README.md for the full writeup)</h2>
+ *
+ * A single absolute tolerance across all groups does not work: 0.05 is noise against {@code
+ * attribute_lookup}'s baseline of ~0.94 but is nearly the entire signal for {@code numeric_range}'s
+ * baseline of ~0.06 (see the #228 issue description). A single relative tolerance does not work
+ * either — a relative fraction of a near-zero baseline collapses to a near-zero tolerance, so the
+ * smallest legitimate fluctuation would fail the group. This harness therefore combines three terms
+ * per group and metric:
+ *
+ * <pre>
+ *   tolerance = clamp(
+ *       max(RELATIVE_FRACTION * baselineValue, ONE_CASE_GUARD_FRACTION / n, ABSOLUTE_FLOOR),
+ *       upperBound = ABSOLUTE_CAP)
+ * </pre>
+ *
+ * <ul>
+ *   <li>{@code RELATIVE_FRACTION * baselineValue} scales the tolerance to the group's own score
+ *       level — the dominant term for mid/high-scoring groups (attribute_lookup,
+ *       entity_description, easy).
+ *   <li>{@code ONE_CASE_GUARD_FRACTION / n} scales inversely with group size, per the #228
+ *       instruction that small groups (numeric_range, n=16) fluctuate more per case than large ones
+ *       and must get a correspondingly larger tolerance, not a smaller one. It becomes the dominant
+ *       term for exactly the small, low-scoring groups where the relative term alone would collapse
+ *       to near zero.
+ *   <li>{@code ABSOLUTE_FLOOR} is a minimum floor so no group — however large and however
+ *       high-scoring — ever gets an unreasonably tight tolerance from the other two terms alone.
+ *   <li>{@code ABSOLUTE_CAP} bounds the tolerance from above so a high baseline value cannot
+ *       license an arbitrarily large drop before the job notices.
+ * </ul>
+ *
+ * The three independent, byte-identical measurement runs recorded in the #228 PR (two by the
+ * author, one by the reviewer on different hardware) justify tolerances this tight: the HNSW
+ * approximation risk ADR-0011 calls out does not manifest at this corpus size, so a wider margin
+ * would only let real regressions through without buying additional stability.
+ */
+public final class BaselineComparator {
+
+  static final double RELATIVE_FRACTION = 0.12;
+  static final double ONE_CASE_GUARD_FRACTION = 1.0;
+  static final double ABSOLUTE_FLOOR = 0.02;
+  static final double ABSOLUTE_CAP = 0.05;
+
+  /**
+   * Independent, baseline-agnostic sanity bound applied only to the four overall (micro-averaged)
+   * metrics — see class Javadoc. Deliberately far below the current baseline (Hit@5=0.521,
+   * MRR=0.461, nDCG@10=0.445, Recall@10=0.490): the baseline-relative tolerance above is expected
+   * to catch real regressions long before these floors would trigger. Their purpose is to catch
+   * catastrophic breakage (e.g. an empty or misconfigured vector store) that would still need to be
+   * caught even if the baseline file itself were somehow wrong.
+   */
+  static final double HARD_FLOOR_HIT_RATE = 0.30;
+
+  static final double HARD_FLOOR_MRR = 0.25;
+  static final double HARD_FLOOR_NDCG = 0.25;
+  static final double HARD_FLOOR_RECALL = 0.25;
+
+  private BaselineComparator() {}
+
+  public record FixedPointMismatch(String field, String baselineValue, String currentValue) {
+    @Override
+    public String toString() {
+      return String.format(
+          Locale.ROOT, "%s: Baseline=%s, aktuell=%s", field, baselineValue, currentValue);
+    }
+  }
+
+  public record MetricCheck(
+      String group,
+      String metric,
+      int n,
+      double baselineValue,
+      double currentValue,
+      double delta,
+      double tolerance,
+      boolean withinTolerance,
+      double hardFloor,
+      boolean passesHardFloor) {
+
+    public boolean passed() {
+      return withinTolerance && passesHardFloor;
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          Locale.ROOT,
+          "%-24s %-10s Baseline=%.3f Ist=%.3f Delta=%+.3f Toleranz=%.3f%s%s",
+          group,
+          metric,
+          baselineValue,
+          currentValue,
+          delta,
+          tolerance,
+          withinTolerance ? "" : " [TOLERANZ VERLETZT]",
+          passesHardFloor ? "" : " [UNTERGRENZE VERLETZT]");
+    }
+  }
+
+  public record ComparisonResult(
+      boolean baselineValid,
+      List<FixedPointMismatch> fixedPointMismatches,
+      boolean oneChunkInvariantHolds,
+      List<EvaluationReport.OneChunkInvariantResult.Violation> oneChunkInvariantViolations,
+      List<MetricCheck> checks) {
+
+    public boolean passed() {
+      return baselineValid
+          && oneChunkInvariantHolds
+          && checks.stream().allMatch(MetricCheck::passed);
+    }
+
+    public List<MetricCheck> failedChecks() {
+      return checks.stream().filter(c -> !c.passed()).toList();
+    }
+  }
+
+  public static ComparisonResult compare(Baseline baseline, EvaluationReport report) {
+    List<FixedPointMismatch> mismatches = fixedPointMismatches(baseline, report);
+    boolean baselineValid = mismatches.isEmpty();
+    var invariant = report.oneChunkInvariant();
+
+    List<MetricCheck> checks = new ArrayList<>();
+    if (baselineValid) {
+      checkGroup(checks, Baseline.OVERALL, report.overall(), baseline.groups(), true);
+      report
+          .byCategory()
+          .forEach(
+              (name, agg) ->
+                  checkGroup(checks, Baseline.category(name), agg, baseline.groups(), false));
+      report
+          .byDifficulty()
+          .forEach(
+              (name, agg) ->
+                  checkGroup(checks, Baseline.difficulty(name), agg, baseline.groups(), false));
+      report
+          .byLanguage()
+          .forEach(
+              (name, agg) ->
+                  checkGroup(checks, Baseline.language(name), agg, baseline.groups(), false));
+    }
+
+    return new ComparisonResult(
+        baselineValid, mismatches, invariant.holds(), invariant.violations(), checks);
+  }
+
+  private static List<FixedPointMismatch> fixedPointMismatches(
+      Baseline baseline, EvaluationReport report) {
+    List<FixedPointMismatch> mismatches = new ArrayList<>();
+    var fp = baseline.fixedPoints();
+    var cfg = report.runConfiguration();
+
+    addIfDiffers(
+        mismatches,
+        "measurementContractVersion",
+        String.valueOf(baseline.measurementContractVersion()),
+        String.valueOf(report.measurementContractVersion()));
+    addIfDiffers(mismatches, "embeddingModel", fp.embeddingModel(), cfg.embeddingModel());
+    addIfDiffers(
+        mismatches, "embeddingModelDigest", fp.embeddingModelDigest(), cfg.embeddingModelDigest());
+    addIfDiffers(
+        mismatches, "chunkSize", String.valueOf(fp.chunkSize()), String.valueOf(cfg.chunkSize()));
+    addIfDiffers(
+        mismatches,
+        "chunkSizeMatchesApplicationDefault",
+        String.valueOf(fp.chunkSizeMatchesApplicationDefault()),
+        String.valueOf(cfg.chunkSizeMatchesApplicationDefault()));
+    addIfDiffers(
+        mismatches, "corpusManifestSha256", fp.corpusManifestSha256(), cfg.corpusManifestSha256());
+    addIfDiffers(
+        mismatches,
+        "corpusDocumentCount",
+        String.valueOf(fp.corpusDocumentCount()),
+        String.valueOf(cfg.corpusDocumentCount()));
+    addIfDiffers(mismatches, "goldenDatasetFile", fp.goldenDatasetFile(), cfg.goldenDatasetFile());
+    addIfDiffers(
+        mismatches, "goldenDatasetSha256", fp.goldenDatasetSha256(), cfg.goldenDatasetSha256());
+    addIfDiffers(
+        mismatches,
+        "goldenCaseCount",
+        String.valueOf(fp.goldenCaseCount()),
+        String.valueOf(cfg.goldenCaseCount()));
+    return List.copyOf(mismatches);
+  }
+
+  private static void addIfDiffers(
+      List<FixedPointMismatch> mismatches,
+      String field,
+      String baselineValue,
+      String currentValue) {
+    if (!java.util.Objects.equals(baselineValue, currentValue)) {
+      mismatches.add(new FixedPointMismatch(field, baselineValue, currentValue));
+    }
+  }
+
+  private static void checkGroup(
+      List<MetricCheck> checks,
+      String groupKey,
+      MetricsAggregate current,
+      java.util.Map<String, MetricsAggregate> baselineGroups,
+      boolean applyHardFloor) {
+    MetricsAggregate base = baselineGroups.get(groupKey);
+    if (base == null) {
+      throw new IllegalStateException(
+          "Baseline has no entry for group '"
+              + groupKey
+              + "' — the golden dataset gained a new category/difficulty/language value without a "
+              + "baseline re-measurement (see eval/baseline/README.md).");
+    }
+    addMetricCheck(
+        checks,
+        groupKey,
+        "hitRateAt5",
+        current.n(),
+        base.hitRateAt5(),
+        current.hitRateAt5(),
+        applyHardFloor ? HARD_FLOOR_HIT_RATE : Double.NEGATIVE_INFINITY);
+    addMetricCheck(
+        checks,
+        groupKey,
+        "mrr",
+        current.n(),
+        base.mrr(),
+        current.mrr(),
+        applyHardFloor ? HARD_FLOOR_MRR : Double.NEGATIVE_INFINITY);
+    addMetricCheck(
+        checks,
+        groupKey,
+        "ndcgAt10",
+        current.n(),
+        base.ndcgAt10(),
+        current.ndcgAt10(),
+        applyHardFloor ? HARD_FLOOR_NDCG : Double.NEGATIVE_INFINITY);
+    addMetricCheck(
+        checks,
+        groupKey,
+        "recallAt10",
+        current.n(),
+        base.recallAt10(),
+        current.recallAt10(),
+        applyHardFloor ? HARD_FLOOR_RECALL : Double.NEGATIVE_INFINITY);
+  }
+
+  private static void addMetricCheck(
+      List<MetricCheck> checks,
+      String group,
+      String metric,
+      int n,
+      double baselineValue,
+      double currentValue,
+      double hardFloor) {
+    double delta = currentValue - baselineValue;
+    double tolerance = toleranceFor(baselineValue, n);
+    boolean withinTolerance = delta >= -tolerance;
+    boolean passesHardFloor = currentValue >= hardFloor;
+    checks.add(
+        new MetricCheck(
+            group,
+            metric,
+            n,
+            baselineValue,
+            currentValue,
+            delta,
+            tolerance,
+            withinTolerance,
+            hardFloor,
+            passesHardFloor));
+  }
+
+  /** The tolerance formula documented in the class Javadoc, exposed for unit testing. */
+  static double toleranceFor(double baselineValue, int n) {
+    double relative = RELATIVE_FRACTION * baselineValue;
+    double oneCaseGuard = n <= 0 ? ABSOLUTE_CAP : ONE_CASE_GUARD_FRACTION / n;
+    double raw = Math.max(relative, Math.max(oneCaseGuard, ABSOLUTE_FLOOR));
+    return Math.min(raw, ABSOLUTE_CAP);
+  }
+}

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineComparator.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineComparator.java
@@ -1,8 +1,12 @@
 package io.opaa.eval;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Compares a freshly produced {@link EvaluationReport} against the committed {@link Baseline}
@@ -13,69 +17,80 @@ import java.util.Locale;
  *
  * <ol>
  *   <li>{@link ComparisonResult#baselineValid()} — do the fixed points (measurement-contract
- *       version, corpus manifest, golden dataset, embedding model digest, chunk size) still match
- *       what the baseline was measured under? If not, no metric comparison is meaningful and none
- *       is attempted.
+ *       version, corpus manifest, golden dataset, embedding model digest, chunk size, {@code
+ *       searchTopK}, {@code pgvectorIndexType}, embedding dimensions, production similarity
+ *       threshold) still match what the baseline was measured under? If not, no metric comparison
+ *       is meaningful and none is attempted.
  *   <li>Only if the baseline is valid: does every group's metrics stay within tolerance of the
- *       baseline, and do the four overall metrics clear an independent, baseline-agnostic hard
+ *       baseline, and do the four overall metrics clear an independent, baseline-relative hard
  *       floor?
  * </ol>
  *
- * <h2>Tolerance rationale (see eval/baseline/README.md for the full writeup)</h2>
+ * <h2>Tolerance formula (ADR-0013)</h2>
  *
- * A single absolute tolerance across all groups does not work: 0.05 is noise against {@code
- * attribute_lookup}'s baseline of ~0.94 but is nearly the entire signal for {@code numeric_range}'s
- * baseline of ~0.06 (see the #228 issue description). A single relative tolerance does not work
- * either — a relative fraction of a near-zero baseline collapses to a near-zero tolerance, so the
- * smallest legitimate fluctuation would fail the group. This harness therefore combines three terms
- * per group and metric:
+ * The tolerance policy in this class implements ADR-0013's decision, not an ad hoc formula: it is a
+ * project-level statement of what "no regression" means, and any change to it is an ADR change, not
+ * a code review comment. See {@code docs/decisions/0013-fehlerkriterium-retrieval-regression.md}
+ * for the full rationale (including the PR #301 review this superseded). Summary:
  *
  * <pre>
- *   tolerance = clamp(
- *       max(RELATIVE_FRACTION * baselineValue, ONE_CASE_GUARD_FRACTION / n, ABSOLUTE_FLOOR),
- *       upperBound = ABSOLUTE_CAP)
+ *   tolerance = min( K_MIN / n_eff, RELATIVE_CAP_FRACTION * baselineValue )
  * </pre>
  *
  * <ul>
- *   <li>{@code RELATIVE_FRACTION * baselineValue} scales the tolerance to the group's own score
- *       level — the dominant term for mid/high-scoring groups (attribute_lookup,
- *       entity_description, easy).
- *   <li>{@code ONE_CASE_GUARD_FRACTION / n} scales inversely with group size, per the #228
- *       instruction that small groups (numeric_range, n=16) fluctuate more per case than large ones
- *       and must get a correspondingly larger tolerance, not a smaller one. It becomes the dominant
- *       term for exactly the small, low-scoring groups where the relative term alone would collapse
- *       to near zero.
- *   <li>{@code ABSOLUTE_FLOOR} is a minimum floor so no group — however large and however
- *       high-scoring — ever gets an unreasonably tight tolerance from the other two terms alone.
- *   <li>{@code ABSOLUTE_CAP} bounds the tolerance from above so a high baseline value cannot
- *       license an arbitrarily large drop before the job notices.
+ *   <li>{@code K_MIN / n_eff} ("case-based" term) expresses the tolerance as "how many independent
+ *       cases would have to flip to call this a regression" rather than as a fixed metric-point
+ *       amount. {@code n_eff} is {@link MetricsAggregate#distinctExpectedDocumentSets()} — the
+ *       number of *distinct* expected-document sets in the group, not the raw case count — because
+ *       several golden-dataset cases share an identical expected set (see that field's Javadoc), so
+ *       the raw case count overstates how many independent observations back the group's average.
+ *   <li>{@code RELATIVE_CAP_FRACTION * baselineValue} ("relative cap") additionally bounds the
+ *       case-based term for low-scoring groups: without it, a small {@code n_eff} would license an
+ *       arbitrarily large *relative* drop on a near-zero baseline (e.g. {@code numeric_range}'s
+ *       nDCG@10 of 0.063) purely because the group is small — exactly the failure mode ADR-0013
+ *       replaces. The cap can only tighten the tolerance, never loosen it.
  * </ul>
  *
- * The three independent, byte-identical measurement runs recorded in the #228 PR (two by the
- * author, one by the reviewer on different hardware) justify tolerances this tight: the HNSW
- * approximation risk ADR-0011 calls out does not manifest at this corpus size, so a wider margin
- * would only let real regressions through without buying additional stability.
+ * There is deliberately no separate absolute floor or cap term (unlike the tolerance formula this
+ * replaced): ADR-0013 found that a single absolute bound binds at both ends of the score range at
+ * once — too loose for weak, low-{@code n} groups and, simultaneously, exactly at the one-case
+ * boundary for others. Expressing the tolerance in cases and combining it with a relative (not
+ * absolute) cap avoids that collision. ADR-0013's own "Offen" section acknowledges this still does
+ * not fully protect every metric in the smallest, weakest groups against a single case flipping
+ * (e.g. {@code category:numeric_range}'s {@code hitRateAt5}) — that residual edge case is tracked
+ * there, not silently claimed as solved here.
+ *
+ * <p>Comparisons apply a small epsilon (see {@link #EPSILON}) so a boundary case that is
+ * mathematically exactly on the tolerance line does not fail on floating-point rounding alone (PR
+ * #301 review: {@code category:entity_description}'s {@code hitRateAt5} landed on {@code 12/20 −
+ * 0.65 = −0.05000000000000004} against a tolerance of exactly {@code 0.05}).
  */
 public final class BaselineComparator {
 
-  static final double RELATIVE_FRACTION = 0.12;
-  static final double ONE_CASE_GUARD_FRACTION = 1.0;
-  static final double ABSOLUTE_FLOOR = 0.02;
-  static final double ABSOLUTE_CAP = 0.05;
+  /** Two independent cases flipping is treated as noise; a third is a finding (ADR-0013). */
+  static final double K_MIN = 2.0;
+
+  /** No group/metric tolerates more than a 25% relative drop from its baseline (ADR-0013). */
+  static final double RELATIVE_CAP_FRACTION = 0.25;
 
   /**
-   * Independent, baseline-agnostic sanity bound applied only to the four overall (micro-averaged)
-   * metrics — see class Javadoc. Deliberately far below the current baseline (Hit@5=0.521,
-   * MRR=0.461, nDCG@10=0.445, Recall@10=0.490): the baseline-relative tolerance above is expected
-   * to catch real regressions long before these floors would trigger. Their purpose is to catch
-   * catastrophic breakage (e.g. an empty or misconfigured vector store) that would still need to be
-   * caught even if the baseline file itself were somehow wrong.
+   * Independent, baseline-relative sanity bound applied only to the four overall (micro-averaged)
+   * metrics — see class Javadoc and ADR-0013, decision 4. Deliberately expressed as a fraction of
+   * the *currently committed* baseline value, not a fixed absolute number: a fixed floor erodes
+   * silently as the baseline itself is (legitimately or not) lowered over successive PRs, while a
+   * baseline-relative floor tightens or loosens together with whatever is currently committed. Its
+   * purpose remains a second, independent-of-the-primary-tolerance-formula backstop against
+   * catastrophic breakage (e.g. an empty or misconfigured vector store), not the primary regression
+   * signal — the tolerance above is expected to trigger long before this floor would.
    */
-  static final double HARD_FLOOR_HIT_RATE = 0.30;
+  static final double HARD_FLOOR_FRACTION_OF_BASELINE = 0.8;
 
-  static final double HARD_FLOOR_MRR = 0.25;
-  static final double HARD_FLOOR_NDCG = 0.25;
-  static final double HARD_FLOOR_RECALL = 0.25;
+  /**
+   * Epsilon for the boundary comparison — see class Javadoc, last paragraph. Deliberately much
+   * smaller than any tolerance value in use (smallest is on the order of 1e-2), so it only absorbs
+   * floating-point noise and never meaningfully widens the tolerance itself.
+   */
+  static final double EPSILON = 1e-9;
 
   private BaselineComparator() {}
 
@@ -144,22 +159,54 @@ public final class BaselineComparator {
 
     List<MetricCheck> checks = new ArrayList<>();
     if (baselineValid) {
+      Set<String> visitedGroups = new LinkedHashSet<>();
+
       checkGroup(checks, Baseline.OVERALL, report.overall(), baseline.groups(), true);
+      visitedGroups.add(Baseline.OVERALL);
+
       report
           .byCategory()
           .forEach(
-              (name, agg) ->
-                  checkGroup(checks, Baseline.category(name), agg, baseline.groups(), false));
+              (name, agg) -> {
+                String key = Baseline.category(name);
+                checkGroup(checks, key, agg, baseline.groups(), false);
+                visitedGroups.add(key);
+              });
       report
           .byDifficulty()
           .forEach(
-              (name, agg) ->
-                  checkGroup(checks, Baseline.difficulty(name), agg, baseline.groups(), false));
+              (name, agg) -> {
+                String key = Baseline.difficulty(name);
+                checkGroup(checks, key, agg, baseline.groups(), false);
+                visitedGroups.add(key);
+              });
       report
           .byLanguage()
           .forEach(
-              (name, agg) ->
-                  checkGroup(checks, Baseline.language(name), agg, baseline.groups(), false));
+              (name, agg) -> {
+                String key = Baseline.language(name);
+                checkGroup(checks, key, agg, baseline.groups(), false);
+                visitedGroups.add(key);
+              });
+
+      // Symmetric check (PR #301 review): the loops above only ever notice a group the *report*
+      // has that the baseline lacks (via the throw in checkGroup). A report whose byCategory (or
+      // byDifficulty/byLanguage) map came back empty or partial — a harness bug, not a legitimate
+      // measurement — would otherwise silently run only the four overall checks and pass. Since
+      // group names come from golden-dataset content and the golden dataset's hash is itself a
+      // fixed point checked above, a mismatch here is only possible via a bug, never a legitimate
+      // corpus/dataset change — so it is a hard failure, not a tolerance case.
+      Set<String> missingFromReport = new TreeSet<>(baseline.groups().keySet());
+      missingFromReport.removeAll(visitedGroups);
+      if (!missingFromReport.isEmpty()) {
+        throw new IllegalStateException(
+            "The report is missing group(s) the baseline expects: "
+                + missingFromReport
+                + ". The golden-dataset hash matched the baseline, so these categories/"
+                + "difficulties/languages must exist in the golden dataset — this indicates a "
+                + "harness bug (e.g. an incompletely populated report), not a legitimate change, "
+                + "and is therefore not treated as a tolerance case.");
+      }
     }
 
     return new ComparisonResult(
@@ -181,12 +228,33 @@ public final class BaselineComparator {
     addIfDiffers(
         mismatches, "embeddingModelDigest", fp.embeddingModelDigest(), cfg.embeddingModelDigest());
     addIfDiffers(
+        mismatches,
+        "embeddingDimensions",
+        String.valueOf(fp.embeddingDimensions()),
+        String.valueOf(cfg.embeddingDimensions()));
+    addIfDiffers(
         mismatches, "chunkSize", String.valueOf(fp.chunkSize()), String.valueOf(cfg.chunkSize()));
     addIfDiffers(
         mismatches,
         "chunkSizeMatchesApplicationDefault",
         String.valueOf(fp.chunkSizeMatchesApplicationDefault()),
         String.valueOf(cfg.chunkSizeMatchesApplicationDefault()));
+    // ADR-0012, decision 3: searchTopK=10 and the deliberate omission of the production similarity
+    // threshold are both part of the measurement contract (PR #301 review, Befund 4) — a change to
+    // either would silently change what every metric means, not just how well retrieval scored.
+    addIfDiffers(
+        mismatches,
+        "searchTopK",
+        String.valueOf(fp.searchTopK()),
+        String.valueOf(cfg.searchTopK()));
+    addIfDiffers(
+        mismatches,
+        "productionSimilarityThreshold",
+        String.valueOf(fp.productionSimilarityThreshold()),
+        String.valueOf(cfg.productionSimilarityThreshold()));
+    // ADR-0011, Konsequenzen: switching the evaluation to exact search instead of HNSW is a
+    // foreseen future change to the measurement itself, not a retrieval-quality change.
+    addIfDiffers(mismatches, "pgvectorIndexType", fp.pgvectorIndexType(), cfg.pgvectorIndexType());
     addIfDiffers(
         mismatches, "corpusManifestSha256", fp.corpusManifestSha256(), cfg.corpusManifestSha256());
     addIfDiffers(
@@ -219,7 +287,7 @@ public final class BaselineComparator {
       List<MetricCheck> checks,
       String groupKey,
       MetricsAggregate current,
-      java.util.Map<String, MetricsAggregate> baselineGroups,
+      Map<String, MetricsAggregate> baselineGroups,
       boolean applyHardFloor) {
     MetricsAggregate base = baselineGroups.get(groupKey);
     if (base == null) {
@@ -229,6 +297,7 @@ public final class BaselineComparator {
               + "' — the golden dataset gained a new category/difficulty/language value without a "
               + "baseline re-measurement (see eval/baseline/README.md).");
     }
+    int nEff = base.distinctExpectedDocumentSets();
     addMetricCheck(
         checks,
         groupKey,
@@ -236,15 +305,10 @@ public final class BaselineComparator {
         current.n(),
         base.hitRateAt5(),
         current.hitRateAt5(),
-        applyHardFloor ? HARD_FLOOR_HIT_RATE : Double.NEGATIVE_INFINITY);
+        nEff,
+        applyHardFloor);
     addMetricCheck(
-        checks,
-        groupKey,
-        "mrr",
-        current.n(),
-        base.mrr(),
-        current.mrr(),
-        applyHardFloor ? HARD_FLOOR_MRR : Double.NEGATIVE_INFINITY);
+        checks, groupKey, "mrr", current.n(), base.mrr(), current.mrr(), nEff, applyHardFloor);
     addMetricCheck(
         checks,
         groupKey,
@@ -252,7 +316,8 @@ public final class BaselineComparator {
         current.n(),
         base.ndcgAt10(),
         current.ndcgAt10(),
-        applyHardFloor ? HARD_FLOOR_NDCG : Double.NEGATIVE_INFINITY);
+        nEff,
+        applyHardFloor);
     addMetricCheck(
         checks,
         groupKey,
@@ -260,7 +325,8 @@ public final class BaselineComparator {
         current.n(),
         base.recallAt10(),
         current.recallAt10(),
-        applyHardFloor ? HARD_FLOOR_RECALL : Double.NEGATIVE_INFINITY);
+        nEff,
+        applyHardFloor);
   }
 
   private static void addMetricCheck(
@@ -270,11 +336,14 @@ public final class BaselineComparator {
       int n,
       double baselineValue,
       double currentValue,
-      double hardFloor) {
+      int nEff,
+      boolean applyHardFloor) {
     double delta = currentValue - baselineValue;
-    double tolerance = toleranceFor(baselineValue, n);
-    boolean withinTolerance = delta >= -tolerance;
-    boolean passesHardFloor = currentValue >= hardFloor;
+    double tolerance = toleranceFor(baselineValue, nEff);
+    boolean withinTolerance = delta >= -tolerance - EPSILON;
+    double hardFloor =
+        applyHardFloor ? HARD_FLOOR_FRACTION_OF_BASELINE * baselineValue : Double.NEGATIVE_INFINITY;
+    boolean passesHardFloor = currentValue >= hardFloor - EPSILON;
     checks.add(
         new MetricCheck(
             group,
@@ -289,11 +358,10 @@ public final class BaselineComparator {
             passesHardFloor));
   }
 
-  /** The tolerance formula documented in the class Javadoc, exposed for unit testing. */
-  static double toleranceFor(double baselineValue, int n) {
-    double relative = RELATIVE_FRACTION * baselineValue;
-    double oneCaseGuard = n <= 0 ? ABSOLUTE_CAP : ONE_CASE_GUARD_FRACTION / n;
-    double raw = Math.max(relative, Math.max(oneCaseGuard, ABSOLUTE_FLOOR));
-    return Math.min(raw, ABSOLUTE_CAP);
+  /** The tolerance formula documented in the class Javadoc (ADR-0013), exposed for unit testing. */
+  static double toleranceFor(double baselineValue, int nEff) {
+    double caseBased = K_MIN / Math.max(nEff, 1);
+    double relativeCap = RELATIVE_CAP_FRACTION * baselineValue;
+    return Math.min(caseBased, relativeCap);
   }
 }

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineComparatorTest.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineComparatorTest.java
@@ -10,43 +10,50 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
- * Docker-free unit tests for the tolerance formula and fixed-point comparison in {@link
+ * Docker-free unit tests for the tolerance formula (ADR-0013) and fixed-point comparison in {@link
  * BaselineComparator} — see its Javadoc for the rationale. Part of {@code evalUnitTest}, wired into
  * {@code check}.
  */
 class BaselineComparatorTest {
 
   @Test
-  void toleranceIsDominatedByRelativeTermForLargeHighScoringGroups() {
-    // attribute_lookup-like: n=30, ndcg=0.942 → relative term (0.113) dominates but is capped.
-    assertThat(BaselineComparator.toleranceFor(0.942, 30)).isEqualTo(0.05, within(1e-9));
+  void toleranceIsDominatedByTheCaseBasedTermForModerateNAndHighBaselineValues() {
+    // attribute_lookup-like: n_eff=30, ndcg=0.942 → case-based (2/30=0.0667) beats the relative cap
+    // (0.25*0.942=0.2355).
+    assertThat(BaselineComparator.toleranceFor(0.942, 30)).isEqualTo(2.0 / 30, within(1e-9));
   }
 
   @Test
-  void toleranceIsDominatedByOneCaseGuardForSmallLowScoringGroups() {
-    // numeric_range-like: n=16, ndcg=0.063 → relative term (0.00756) and floor (0.02) both lose to
-    // the 1/n guard (0.0625), which then gets capped.
-    assertThat(BaselineComparator.toleranceFor(0.063, 16)).isEqualTo(0.05, within(1e-9));
+  void relativeCapDominatesForLowBaselineValuesEvenWithSmallGroups() {
+    // numeric_range-like: n_eff=15, ndcg=0.063 → the case-based term alone (2/15=0.1333) would
+    // license a ~211% relative drop on this tiny baseline; the relative cap (0.25*0.063=0.01575)
+    // reins that in — this is the exact scenario ADR-0013 decision 3 exists for.
+    assertThat(BaselineComparator.toleranceFor(0.063, 15)).isEqualTo(0.25 * 0.063, within(1e-9));
   }
 
   @Test
-  void toleranceFallsBackToAbsoluteFloorWhenBothOtherTermsAreTiny() {
-    // Large n, very low baseline value: relative term and 1/n term both collapse, floor kicks in.
-    assertThat(BaselineComparator.toleranceFor(0.01, 500)).isEqualTo(0.02, within(1e-9));
+  void relativeCapNeverWidensTheCaseBasedTerm() {
+    // A very small n_eff with a very high baseline value: case-based (2/5=0.4) would exceed 100%
+    // of the baseline value; the relative cap (0.25*0.9=0.225) still wins, keeping the tolerance
+    // sane regardless of how small the group is.
+    assertThat(BaselineComparator.toleranceFor(0.9, 5)).isEqualTo(0.225, within(1e-9));
   }
 
   @Test
-  void toleranceUsesRelativeTermWhenItIsTheMiddleValue() {
-    // crosslingual-like: n=34, ndcg=0.302 → relative (0.03624) beats both 1/n (0.0294) and floor
-    // (0.02), and stays below the cap.
-    assertThat(BaselineComparator.toleranceFor(0.302, 34)).isEqualTo(0.03624, within(1e-9));
+  void oneCaseFlipNoLongerFalselyFailsTheEntityDescriptionBoundaryCase() {
+    // PR #301 review: with the old formula, 12/20 - 0.65 == -0.05000000000000004 against a
+    // tolerance of exactly 0.05 failed on floating-point rounding alone. The new tolerance
+    // (2/20=0.1) comfortably covers a single case flip (1/20=0.05) with margin to spare, and the
+    // epsilon in addMetricCheck absorbs any remaining boundary rounding.
+    double tolerance = BaselineComparator.toleranceFor(0.650, 20);
+    assertThat(tolerance).isEqualTo(0.1, within(1e-9));
+    assertThat(tolerance).isGreaterThan(1.0 / 20);
   }
 
   @Test
   void detectsCorpusManifestDrift() {
-    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
-    EvaluationReport report =
-        reportWith(runConfiguration("m1", "d1", 1000, true, "corpus-b", "golden-a"));
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
+    EvaluationReport report = reportWith(runConfiguration("m1", "d1", "corpus-b", "golden-a"));
 
     var result = BaselineComparator.compare(baseline, report);
 
@@ -62,9 +69,8 @@ class BaselineComparatorTest {
 
   @Test
   void detectsEmbeddingModelDigestDrift() {
-    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
-    EvaluationReport report =
-        reportWith(runConfiguration("m1", "d2", 1000, true, "corpus-a", "golden-a"));
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
+    EvaluationReport report = reportWith(runConfiguration("m1", "d2", "corpus-a", "golden-a"));
 
     var result = BaselineComparator.compare(baseline, report);
 
@@ -75,10 +81,46 @@ class BaselineComparatorTest {
   }
 
   @Test
+  void detectsSearchTopKDrift() {
+    // ADR-0012 decision 3 / PR #301 review, Befund 4: searchTopK is part of the measurement
+    // contract, not just run metadata — a topK change must invalidate the baseline, not be silently
+    // compared as if it were a regression.
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
+    RunConfiguration cfg = runConfiguration("m1", "d1", "corpus-a", "golden-a");
+    RunConfiguration withDifferentTopK =
+        new RunConfiguration(
+            cfg.embeddingProvider(),
+            cfg.embeddingModel(),
+            cfg.embeddingModelDigest(),
+            cfg.ollamaImage(),
+            cfg.embeddingDimensions(),
+            cfg.chunkSize(),
+            cfg.chunkSizeMatchesApplicationDefault(),
+            50,
+            cfg.productionSimilarityThreshold(),
+            cfg.similarityThresholdNote(),
+            cfg.pgvectorIndexType(),
+            cfg.corpusManifestSha256(),
+            cfg.corpusDocumentCount(),
+            cfg.goldenDatasetFile(),
+            cfg.goldenDatasetSha256(),
+            cfg.goldenCaseCount(),
+            cfg.runStartedAt(),
+            cfg.runDurationSeconds());
+    EvaluationReport report = reportWith(withDifferentTopK);
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.baselineValid()).isFalse();
+    assertThat(result.fixedPointMismatches())
+        .extracting(BaselineComparator.FixedPointMismatch::field)
+        .containsExactly("searchTopK");
+  }
+
+  @Test
   void passesWhenFixedPointsMatchAndMetricsAreWithinTolerance() {
-    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
-    EvaluationReport report =
-        reportWith(runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
+    EvaluationReport report = reportWith(runConfiguration("m1", "d1", "corpus-a", "golden-a"));
 
     var result = BaselineComparator.compare(baseline, report);
 
@@ -90,11 +132,11 @@ class BaselineComparatorTest {
 
   @Test
   void failsWhenAMetricDropsBelowTolerance() {
-    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
     EvaluationReport report =
         reportWith(
-            runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"),
-            new MetricsAggregate(121, 0.10, 0.10, 0.10, 0.10, 1.0));
+            runConfiguration("m1", "d1", "corpus-a", "golden-a"),
+            new MetricsAggregate(121, 0.10, 0.10, 0.10, 0.10, 1.0, 94));
 
     var result = BaselineComparator.compare(baseline, report);
 
@@ -105,11 +147,38 @@ class BaselineComparatorTest {
   }
 
   @Test
-  void failsWhenOneChunkInvariantIsViolated() {
-    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+  void hardFloorIsRelativeToTheCommittedBaselineValue() {
+    // ADR-0013 decision 4: the hard floor is 80% of the *committed* baseline value, not a fixed
+    // absolute number. A current value just above 80% of baseline passes the hard floor even
+    // though it is (deliberately, for this test) far outside the tolerance, so the *tolerance*
+    // check is what actually fails it — the hard floor is a separate, looser backstop.
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
     EvaluationReport report =
         reportWith(
-            runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"),
+            runConfiguration("m1", "d1", "corpus-a", "golden-a"),
+            new MetricsAggregate(121, 0.45, 0.45, 0.45, 0.45, 1.0, 94));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    var hitRateCheck =
+        result.checks().stream()
+            .filter(c -> c.group().equals(Baseline.OVERALL) && c.metric().equals("hitRateAt5"))
+            .findFirst()
+            .orElseThrow();
+    // 0.8 * 0.521 = 0.4168 — 0.45 clears the hard floor...
+    assertThat(hitRateCheck.hardFloor()).isCloseTo(0.8 * 0.521, within(1e-9));
+    assertThat(hitRateCheck.passesHardFloor()).isTrue();
+    // ...but still fails the (much tighter) baseline-relative tolerance.
+    assertThat(hitRateCheck.withinTolerance()).isFalse();
+    assertThat(result.passed()).isFalse();
+  }
+
+  @Test
+  void failsWhenOneChunkInvariantIsViolated() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(
+            runConfiguration("m1", "d1", "corpus-a", "golden-a"),
             overallMetrics(),
             new OneChunkInvariantResult(
                 1458, List.of(new OneChunkInvariantResult.Violation("comic-0999_x.md", 2))));
@@ -120,24 +189,51 @@ class BaselineComparatorTest {
     assertThat(result.passed()).isFalse();
   }
 
+  @Test
+  void failsWhenReportIsMissingAGroupThatIsPresentInTheBaseline() {
+    // PR #301 review: a report whose byCategory/byDifficulty/byLanguage came back empty or partial
+    // must not silently pass with only the four overall checks run.
+    Baseline baseline =
+        new Baseline(
+            1,
+            fixedPoints("m1", "d1", "corpus-a", "golden-a"),
+            Map.of(
+                Baseline.OVERALL,
+                overallMetrics(),
+                Baseline.category("attribute_lookup"),
+                overallMetrics()),
+            "2026-08-03",
+            null,
+            "test fixture");
+    EvaluationReport report = reportWith(runConfiguration("m1", "d1", "corpus-a", "golden-a"));
+
+    assertThatMissingGroupThrows(baseline, report);
+  }
+
+  private static void assertThatMissingGroupThrows(Baseline baseline, EvaluationReport report) {
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> BaselineComparator.compare(baseline, report))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("category:attribute_lookup");
+  }
+
   // --- fixtures -----------------------------------------------------------------------------
 
   private static MetricsAggregate overallMetrics() {
-    return new MetricsAggregate(121, 0.521, 0.461, 0.445, 0.490, 0.9708);
+    return new MetricsAggregate(121, 0.521, 0.461, 0.445, 0.490, 0.9708, 94);
   }
 
   private static Baseline.FixedPoints fixedPoints(
-      String model,
-      String digest,
-      int chunkSize,
-      boolean matchesDefault,
-      String corpusSha,
-      String goldenSha) {
+      String model, String digest, String corpusSha, String goldenSha) {
     return new Baseline.FixedPoints(
         model,
         digest,
-        chunkSize,
-        matchesDefault,
+        768,
+        1000,
+        true,
+        10,
+        0.3,
+        "hnsw",
         corpusSha,
         1458,
         "eval/golden/x.json",
@@ -146,20 +242,15 @@ class BaselineComparatorTest {
   }
 
   private static RunConfiguration runConfiguration(
-      String model,
-      String digest,
-      int chunkSize,
-      boolean matchesDefault,
-      String corpusSha,
-      String goldenSha) {
+      String model, String digest, String corpusSha, String goldenSha) {
     return new RunConfiguration(
         "ollama",
         model,
         digest,
         "ollama/ollama:0.6.5",
         768,
-        chunkSize,
-        matchesDefault,
+        1000,
+        true,
         10,
         0.3,
         "note",
@@ -175,7 +266,12 @@ class BaselineComparatorTest {
 
   private static Baseline baselineWith(Baseline.FixedPoints fixedPoints) {
     return new Baseline(
-        1, fixedPoints, Map.of(Baseline.OVERALL, overallMetrics()), "2026-08-03", "test fixture");
+        1,
+        fixedPoints,
+        Map.of(Baseline.OVERALL, overallMetrics()),
+        "2026-08-03",
+        null,
+        "test fixture");
   }
 
   private static EvaluationReport reportWith(RunConfiguration cfg) {
@@ -192,7 +288,7 @@ class BaselineComparatorTest {
         1,
         cfg,
         invariant,
-        new EvaluationReport.DatasetNotes(121, 75, "note"),
+        new EvaluationReport.DatasetNotes(121, 94, "note"),
         overall,
         Map.of(),
         Map.of(),

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineComparatorTest.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineComparatorTest.java
@@ -1,0 +1,203 @@
+package io.opaa.eval;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.opaa.eval.EvaluationReport.OneChunkInvariantResult;
+import io.opaa.eval.EvaluationReport.RunConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Docker-free unit tests for the tolerance formula and fixed-point comparison in {@link
+ * BaselineComparator} — see its Javadoc for the rationale. Part of {@code evalUnitTest}, wired into
+ * {@code check}.
+ */
+class BaselineComparatorTest {
+
+  @Test
+  void toleranceIsDominatedByRelativeTermForLargeHighScoringGroups() {
+    // attribute_lookup-like: n=30, ndcg=0.942 → relative term (0.113) dominates but is capped.
+    assertThat(BaselineComparator.toleranceFor(0.942, 30)).isEqualTo(0.05, within(1e-9));
+  }
+
+  @Test
+  void toleranceIsDominatedByOneCaseGuardForSmallLowScoringGroups() {
+    // numeric_range-like: n=16, ndcg=0.063 → relative term (0.00756) and floor (0.02) both lose to
+    // the 1/n guard (0.0625), which then gets capped.
+    assertThat(BaselineComparator.toleranceFor(0.063, 16)).isEqualTo(0.05, within(1e-9));
+  }
+
+  @Test
+  void toleranceFallsBackToAbsoluteFloorWhenBothOtherTermsAreTiny() {
+    // Large n, very low baseline value: relative term and 1/n term both collapse, floor kicks in.
+    assertThat(BaselineComparator.toleranceFor(0.01, 500)).isEqualTo(0.02, within(1e-9));
+  }
+
+  @Test
+  void toleranceUsesRelativeTermWhenItIsTheMiddleValue() {
+    // crosslingual-like: n=34, ndcg=0.302 → relative (0.03624) beats both 1/n (0.0294) and floor
+    // (0.02), and stays below the cap.
+    assertThat(BaselineComparator.toleranceFor(0.302, 34)).isEqualTo(0.03624, within(1e-9));
+  }
+
+  @Test
+  void detectsCorpusManifestDrift() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(runConfiguration("m1", "d1", 1000, true, "corpus-b", "golden-a"));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.baselineValid()).isFalse();
+    assertThat(result.fixedPointMismatches())
+        .extracting(BaselineComparator.FixedPointMismatch::field)
+        .containsExactly("corpusManifestSha256");
+    // No metric checks are attempted once the baseline is invalid — comparing scores under a
+    // different corpus would not be a "regression", it would be a meaningless number.
+    assertThat(result.checks()).isEmpty();
+    assertThat(result.passed()).isFalse();
+  }
+
+  @Test
+  void detectsEmbeddingModelDigestDrift() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(runConfiguration("m1", "d2", 1000, true, "corpus-a", "golden-a"));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.baselineValid()).isFalse();
+    assertThat(result.fixedPointMismatches())
+        .extracting(BaselineComparator.FixedPointMismatch::field)
+        .containsExactly("embeddingModelDigest");
+  }
+
+  @Test
+  void passesWhenFixedPointsMatchAndMetricsAreWithinTolerance() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.baselineValid()).isTrue();
+    assertThat(result.oneChunkInvariantHolds()).isTrue();
+    assertThat(result.checks()).isNotEmpty();
+    assertThat(result.passed()).isTrue();
+  }
+
+  @Test
+  void failsWhenAMetricDropsBelowTolerance() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(
+            runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"),
+            new MetricsAggregate(121, 0.10, 0.10, 0.10, 0.10, 1.0));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.passed()).isFalse();
+    assertThat(result.failedChecks()).isNotEmpty();
+    assertThat(result.failedChecks())
+        .allSatisfy(check -> assertThat(check.group()).isEqualTo(Baseline.OVERALL));
+  }
+
+  @Test
+  void failsWhenOneChunkInvariantIsViolated() {
+    Baseline baseline = baselineWith(fixedPoints("m1", "d1", 1000, true, "corpus-a", "golden-a"));
+    EvaluationReport report =
+        reportWith(
+            runConfiguration("m1", "d1", 1000, true, "corpus-a", "golden-a"),
+            overallMetrics(),
+            new OneChunkInvariantResult(
+                1458, List.of(new OneChunkInvariantResult.Violation("comic-0999_x.md", 2))));
+
+    var result = BaselineComparator.compare(baseline, report);
+
+    assertThat(result.oneChunkInvariantHolds()).isFalse();
+    assertThat(result.passed()).isFalse();
+  }
+
+  // --- fixtures -----------------------------------------------------------------------------
+
+  private static MetricsAggregate overallMetrics() {
+    return new MetricsAggregate(121, 0.521, 0.461, 0.445, 0.490, 0.9708);
+  }
+
+  private static Baseline.FixedPoints fixedPoints(
+      String model,
+      String digest,
+      int chunkSize,
+      boolean matchesDefault,
+      String corpusSha,
+      String goldenSha) {
+    return new Baseline.FixedPoints(
+        model,
+        digest,
+        chunkSize,
+        matchesDefault,
+        corpusSha,
+        1458,
+        "eval/golden/x.json",
+        goldenSha,
+        121);
+  }
+
+  private static RunConfiguration runConfiguration(
+      String model,
+      String digest,
+      int chunkSize,
+      boolean matchesDefault,
+      String corpusSha,
+      String goldenSha) {
+    return new RunConfiguration(
+        "ollama",
+        model,
+        digest,
+        "ollama/ollama:0.6.5",
+        768,
+        chunkSize,
+        matchesDefault,
+        10,
+        0.3,
+        "note",
+        "hnsw",
+        corpusSha,
+        1458,
+        "eval/golden/x.json",
+        goldenSha,
+        121,
+        "2026-08-03T00:00:00Z",
+        1004.0);
+  }
+
+  private static Baseline baselineWith(Baseline.FixedPoints fixedPoints) {
+    return new Baseline(
+        1, fixedPoints, Map.of(Baseline.OVERALL, overallMetrics()), "2026-08-03", "test fixture");
+  }
+
+  private static EvaluationReport reportWith(RunConfiguration cfg) {
+    return reportWith(cfg, overallMetrics());
+  }
+
+  private static EvaluationReport reportWith(RunConfiguration cfg, MetricsAggregate overall) {
+    return reportWith(cfg, overall, new OneChunkInvariantResult(1458, List.of()));
+  }
+
+  private static EvaluationReport reportWith(
+      RunConfiguration cfg, MetricsAggregate overall, OneChunkInvariantResult invariant) {
+    return new EvaluationReport(
+        1,
+        cfg,
+        invariant,
+        new EvaluationReport.DatasetNotes(121, 75, "note"),
+        overall,
+        Map.of(),
+        Map.of(),
+        Map.of(),
+        List.of(),
+        List.of());
+  }
+}

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineMarkdownWriter.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineMarkdownWriter.java
@@ -7,12 +7,24 @@ import java.nio.file.Path;
 import java.util.Locale;
 
 /**
- * Renders a {@link BaselineComparator.ComparisonResult} as a Markdown delta table — used both for
- * the CI job summary and for the PR comment posted when the job is triggered via the {@code
- * evaluation} label (issue #228 acceptance criteria: "Ergebnis als PR-Kommentar mit Delta-Tabelle
- * gegenüber der Baseline").
+ * Renders a {@link BaselineComparator.ComparisonResult} as a Markdown delta table. The written file
+ * ({@code backend/build/eval-reports/baseline-comparison.md}) is consumed twice by {@code
+ * .github/workflows/retrieval-regression.yml}, not by this class directly: appended to {@code
+ * $GITHUB_STEP_SUMMARY} on every run, and posted as a PR comment when the job is triggered via the
+ * {@code evaluation} label (issue #228 acceptance criteria: "Ergebnis als PR-Kommentar mit
+ * Delta-Tabelle gegenüber der Baseline").
  */
 public final class BaselineMarkdownWriter {
+
+  /**
+   * Minimum delta before a metric is reported as an "improvement" hint. Deliberately non-zero: the
+   * baseline stores metrics rounded to 3 decimals while a fresh report carries full {@code double}
+   * precision, so an identical run already shows a tiny positive delta on essentially every metric
+   * (e.g. {@code crosslingual}'s {@code hitRateAt5}: {@code 13/34 ≈ 0.38235} against a baseline of
+   * {@code 0.382}) — without this threshold, the hint would fire on every single run, baseline
+   * drift or not (PR #301 review).
+   */
+  private static final double IMPROVEMENT_HINT_THRESHOLD = 0.005;
 
   private BaselineMarkdownWriter() {}
 
@@ -46,6 +58,12 @@ public final class BaselineMarkdownWriter {
       return sb.toString();
     }
 
+    // In normal operation, RetrievalEvaluationHarnessTest itself asserts the Ein-Chunk-Invariante
+    // and aborts *before* writing a report at all when it is violated (see its step 3) — so this
+    // branch is unreachable via the harness's own report-writing path today. It is kept as a
+    // second, defensive check (PR #301 review): it still fires correctly against a hand-edited or
+    // otherwise externally produced report, and protects this class against silently becoming
+    // wrong if the harness is ever changed to write partial reports on invariant failure.
     if (!result.oneChunkInvariantHolds()) {
       sb.append(
           "**Ein-Chunk-Invariante verletzt (ADR-0010).** Das ist ein harter Fehlschlag, kein "
@@ -80,7 +98,8 @@ public final class BaselineMarkdownWriter {
     }
 
     if (!anyFailed) {
-      boolean anyImprovement = result.checks().stream().anyMatch(c -> c.delta() > 0);
+      boolean anyImprovement =
+          result.checks().stream().anyMatch(c -> c.delta() > IMPROVEMENT_HINT_THRESHOLD);
       if (anyImprovement) {
         sb.append(
             "\n_Mindestens eine Metrik hat sich gegenüber der Baseline verbessert. Das lässt den "

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineMarkdownWriter.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineMarkdownWriter.java
@@ -1,0 +1,94 @@
+package io.opaa.eval;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Renders a {@link BaselineComparator.ComparisonResult} as a Markdown delta table — used both for
+ * the CI job summary and for the PR comment posted when the job is triggered via the {@code
+ * evaluation} label (issue #228 acceptance criteria: "Ergebnis als PR-Kommentar mit Delta-Tabelle
+ * gegenüber der Baseline").
+ */
+public final class BaselineMarkdownWriter {
+
+  private BaselineMarkdownWriter() {}
+
+  public static void write(BaselineComparator.ComparisonResult result, Path target)
+      throws IOException {
+    Files.createDirectories(target.getParent());
+    Files.writeString(target, render(result), StandardCharsets.UTF_8);
+  }
+
+  public static String render(BaselineComparator.ComparisonResult result) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("## Retrieval-Regression gegen Baseline (`eval/baseline/comic-characters.json`)\n\n");
+
+    if (!result.baselineValid()) {
+      sb.append(
+          "**Baseline ungültig — kein Rückschluss auf Retrieval-Qualität möglich.** Die "
+              + "Messgrundlage hat sich gegenüber der Baseline geändert (Korpus, Golden Dataset, "
+              + "Embedding-Modell, Chunk-Größe oder Messvertrag). Das ist keine Aussage über eine "
+              + "Retrieval-Regression — die Baseline muss bewusst neu gezogen werden (siehe "
+              + "`eval/baseline/README.md`).\n\n");
+      sb.append("| Feld | Baseline | Aktuell |\n|---|---|---|\n");
+      for (var mismatch : result.fixedPointMismatches()) {
+        sb.append(
+            String.format(
+                Locale.ROOT,
+                "| `%s` | `%s` | `%s` |\n",
+                mismatch.field(),
+                mismatch.baselineValue(),
+                mismatch.currentValue()));
+      }
+      return sb.toString();
+    }
+
+    if (!result.oneChunkInvariantHolds()) {
+      sb.append(
+          "**Ein-Chunk-Invariante verletzt (ADR-0010).** Das ist ein harter Fehlschlag, kein "
+              + "Toleranzfall — die folgenden Dokumente ergaben mehr als einen Chunk:\n\n");
+      sb.append("| Datei | Chunks |\n|---|---|\n");
+      for (var violation : result.oneChunkInvariantViolations()) {
+        sb.append(
+            String.format(
+                Locale.ROOT, "| `%s` | %d |\n", violation.fileName(), violation.chunkCount()));
+      }
+      sb.append('\n');
+    }
+
+    boolean anyFailed = !result.failedChecks().isEmpty();
+    sb.append(anyFailed ? "**Regression erkannt.**\n\n" : "**Keine Regression.**\n\n");
+    sb.append(
+        "| Gruppe | Metrik | n | Baseline | Ist | Delta | Toleranz | Ergebnis |\n"
+            + "|---|---|---|---|---|---|---|---|\n");
+    for (var check : result.checks()) {
+      sb.append(
+          String.format(
+              Locale.ROOT,
+              "| %s | %s | %d | %.3f | %.3f | %+.3f | %.3f | %s |\n",
+              check.group(),
+              check.metric(),
+              check.n(),
+              check.baselineValue(),
+              check.currentValue(),
+              check.delta(),
+              check.tolerance(),
+              check.passed() ? "✅" : "❌"));
+    }
+
+    if (!anyFailed) {
+      boolean anyImprovement = result.checks().stream().anyMatch(c -> c.delta() > 0);
+      if (anyImprovement) {
+        sb.append(
+            "\n_Mindestens eine Metrik hat sich gegenüber der Baseline verbessert. Das lässt den "
+                + "Job bestehen, ist aber ein Hinweis: Prüfen, ob die Baseline bewusst aktualisiert "
+                + "werden sollte (siehe `eval/baseline/README.md`)._\n");
+      }
+    }
+
+    return sb.toString();
+  }
+}

--- a/backend/src/evalTest/java/io/opaa/eval/BaselineRegressionTest.java
+++ b/backend/src/evalTest/java/io/opaa/eval/BaselineRegressionTest.java
@@ -1,0 +1,78 @@
+package io.opaa.eval;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Compares the most recent {@code evaluateRetrieval} report against the committed baseline (issue
+ * #228). Deliberately Docker-free and separate from {@link RetrievalEvaluationHarnessTest}: it only
+ * reads two JSON files and does not need Testcontainers, but it does need a report to have been
+ * produced first — see {@code checkRetrievalBaseline} in {@code build.gradle.kts}, which runs this
+ * test right after {@code evaluateRetrieval}.
+ *
+ * <p>Excluded from {@code evalUnitTest} (and therefore from {@code check}/{@code build}) for the
+ * same reason {@link RetrievalEvaluationHarnessTest} is: it depends on a report file that only
+ * exists after a real, multi-minute {@code evaluateRetrieval} run, so it must not run on every
+ * regular build.
+ */
+class BaselineRegressionTest {
+
+  private static final Logger log = LoggerFactory.getLogger(BaselineRegressionTest.class);
+
+  private static final Path REPORT_FILE =
+      Path.of("build", "eval-reports", "retrieval-metrics.json");
+  private static final Path MARKDOWN_FILE =
+      Path.of("build", "eval-reports", "baseline-comparison.md");
+
+  @Test
+  void currentRunStaysWithinToleranceOfTheCommittedBaseline() throws IOException {
+    if (!Files.exists(REPORT_FILE)) {
+      fail(
+          "No report found at '"
+              + REPORT_FILE.toAbsolutePath()
+              + "'. Run './gradlew evaluateRetrieval' first — this test only compares an existing "
+              + "report against the baseline, it does not produce one.");
+    }
+
+    EvaluationReport report =
+        new ObjectMapper().readValue(Files.readString(REPORT_FILE), EvaluationReport.class);
+    Path baselineFile = RepoPaths.evalDir().resolve("baseline").resolve("comic-characters.json");
+    Baseline baseline = Baseline.load(baselineFile);
+
+    BaselineComparator.ComparisonResult result = BaselineComparator.compare(baseline, report);
+
+    String markdown = BaselineMarkdownWriter.render(result);
+    BaselineMarkdownWriter.write(result, MARKDOWN_FILE);
+    log.info(markdown);
+    System.out.println(markdown);
+    System.out.println("Delta-Tabelle geschrieben nach " + MARKDOWN_FILE.toAbsolutePath());
+
+    if (!result.baselineValid()) {
+      fail(
+          "Baseline ungültig, nicht vergleichbar mit dem aktuellen Lauf — die Messgrundlage hat "
+              + "sich geändert, das ist keine Aussage über eine Retrieval-Regression: "
+              + result.fixedPointMismatches()
+              + ". Siehe eval/baseline/README.md für die bewusste Baseline-Aktualisierung.");
+    }
+
+    assertThat(result.oneChunkInvariantHolds())
+        .as(
+            "Ein-Chunk-Invariante verletzt (ADR-0010) — harter Fehlschlag, kein Toleranzfall: %s",
+            result.oneChunkInvariantViolations())
+        .isTrue();
+
+    assertThat(result.failedChecks())
+        .as(
+            "Retrieval-Regression gegenüber der Baseline erkannt:\n%s",
+            result.failedChecks().stream().map(Object::toString).reduce("", (a, b) -> a + "\n" + b))
+        .isEmpty();
+  }
+}

--- a/backend/src/evalTest/java/io/opaa/eval/MetricsAggregate.java
+++ b/backend/src/evalTest/java/io/opaa/eval/MetricsAggregate.java
@@ -13,6 +13,14 @@ import java.util.function.Function;
  * achievable Recall@10 ceiling for that group (see {@link RetrievalMetrics#recallCeilingAtK}):
  * cases whose expected-document set is larger than {@code k=10} cannot reach Recall@10=1.0 even
  * with a perfect ranking, so the raw recall figure alone understates how well retrieval is doing.
+ *
+ * <p>Also carries {@code distinctExpectedDocumentSets} — the number of *distinct* expected-document
+ * sets among this group's cases, as opposed to {@code n} (the raw case count). Issue #228's
+ * baseline-regression tolerance (see {@code BaselineComparator}, ADR-0013) is deliberately
+ * expressed per independent observation, not per case: several golden-dataset cases share an
+ * identical expected-document set (e.g. every {@code crosslingual} case is the German twin of an
+ * English one), so {@code n} alone overstates how many independent data points back a group's
+ * average — see the report-level {@code datasetNotes} this mirrors at group granularity.
  */
 public record MetricsAggregate(
     int n,
@@ -20,11 +28,12 @@ public record MetricsAggregate(
     double mrr,
     double ndcgAt10,
     double recallAt10,
-    double recallAt10Ceiling) {
+    double recallAt10Ceiling,
+    int distinctExpectedDocumentSets) {
 
   public static MetricsAggregate of(List<RetrievalMetrics.QueryResult> results) {
     if (results.isEmpty()) {
-      return new MetricsAggregate(0, 0.0, 0.0, 0.0, 0.0, 0.0);
+      return new MetricsAggregate(0, 0.0, 0.0, 0.0, 0.0, 0.0, 0);
     }
     int n = results.size();
     double hitRate =
@@ -43,7 +52,13 @@ public record MetricsAggregate(
                     })
                 .sum()
             / n;
-    return new MetricsAggregate(n, hitRate, mrr, ndcg, recall, recallCeiling);
+    long distinctExpectedSets =
+        results.stream()
+            .map(r -> new java.util.TreeSet<>(r.goldenCase().expectedDocuments()))
+            .distinct()
+            .count();
+    return new MetricsAggregate(
+        n, hitRate, mrr, ndcg, recall, recallCeiling, (int) distinctExpectedSets);
   }
 
   /**

--- a/backend/src/evalTest/java/io/opaa/eval/ReportWriter.java
+++ b/backend/src/evalTest/java/io/opaa/eval/ReportWriter.java
@@ -114,8 +114,14 @@ public final class ReportWriter {
   private static void appendMetricLine(StringBuilder sb, MetricsAggregate a) {
     sb.append(
         format(
-            "HitRate@5=%.3f  MRR=%.3f  nDCG@10=%.3f  Recall@10=%.3f (Obergrenze=%.3f)\n",
-            a.hitRateAt5(), a.mrr(), a.ndcgAt10(), a.recallAt10(), a.recallAt10Ceiling()));
+            "HitRate@5=%.3f  MRR=%.3f  nDCG@10=%.3f  Recall@10=%.3f (Obergrenze=%.3f, "
+                + "distinct=%d)\n",
+            a.hitRateAt5(),
+            a.mrr(),
+            a.ndcgAt10(),
+            a.recallAt10(),
+            a.recallAt10Ceiling(),
+            a.distinctExpectedDocumentSets()));
   }
 
   private static String shortHash(String hash) {

--- a/backend/src/evalTest/java/io/opaa/eval/RetrievalEvaluationHarnessTest.java
+++ b/backend/src/evalTest/java/io/opaa/eval/RetrievalEvaluationHarnessTest.java
@@ -180,6 +180,26 @@ class RetrievalEvaluationHarnessTest {
 
   @BeforeAll
   static void pullEmbeddingModel() throws IOException, InterruptedException {
+    // Check the (local, in-container) /api/tags endpoint before pulling anything. If the model is
+    // already present with exactly the expected digest — the common case on a warm
+    // OLLAMA_MODEL_VOLUME, whether on a developer machine or restored from the CI cache (see
+    // .github/workflows/retrieval-regression.yml) — skip 'ollama pull' entirely. Without this
+    // check, 'ollama pull' always reaches out to the model registry to resolve the tag's manifest
+    // even when every layer is already cached locally, which contradicted this harness's claim
+    // (eval/README.md, ADR-0011) of running without third-party network access on a warm cache
+    // (PR #301 review, Befund 5). GET /api/tags itself never leaves the Docker network — it talks
+    // to the Ollama container this test just started, not to any third party.
+    String cachedDigest = tryFetchEmbeddingModelDigest();
+    if (cachedDigest != null && EXPECTED_EMBEDDING_MODEL_DIGEST.equalsIgnoreCase(cachedDigest)) {
+      log.info(
+          "{} already present in the Ollama Testcontainer with the expected digest {} — skipping "
+              + "'ollama pull' (no third-party network access needed).",
+          EMBEDDING_MODEL,
+          cachedDigest);
+      actualEmbeddingModelDigest = cachedDigest;
+      return;
+    }
+
     log.info(
         "Pulling {} into the Ollama Testcontainer (cached in the '{}' Docker volume after the "
             + "first run)...",
@@ -207,6 +227,19 @@ class RetrievalEvaluationHarnessTest {
               + "evaluateRetrieval run, updated numbers in the PR), not a code bug.");
     }
     log.info("Embedding model digest verified: {}", actualEmbeddingModelDigest);
+  }
+
+  /**
+   * Like {@link #fetchEmbeddingModelDigest()}, but {@code null} instead of throwing when the tag is
+   * not present in the container yet (fresh/empty volume) — the expected case on the very first
+   * run.
+   */
+  private static String tryFetchEmbeddingModelDigest() throws IOException, InterruptedException {
+    try {
+      return fetchEmbeddingModelDigest();
+    } catch (IllegalStateException e) {
+      return null;
+    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/docs/decisions/0013-fehlerkriterium-retrieval-regression.md
+++ b/docs/decisions/0013-fehlerkriterium-retrieval-regression.md
@@ -1,0 +1,139 @@
+# ADR-0013: Fehlerkriterium des Retrieval-Regressionsjobs
+
+## Status
+
+Vorgeschlagen — Entwurf aus dem Code-Review zu PR #301 (Issue #228, Epic #224), übernommen und in
+`io.opaa.eval.BaselineComparator` umgesetzt im selben PR. Siehe den [Nachtrag](#nachtrag-umsetzung-in-pr-301)
+für zwei Korrekturen gegenüber diesem Entwurf und den Umsetzungsstand.
+
+## Kontext
+
+ADR-0011 (Entscheidung 5) legt fest, **dass** der Regressionsjob fehlschlägt, wenn eine Primärmetrik
+eine harte Untergrenze unterschreitet oder um mehr als „eine definierte Toleranz" unter die Baseline
+fällt. ADR-0012 legt den Messvertrag fest, unter dem gemessen wird. Beides sagt nichts darüber, wie
+diese Toleranz zustande kommt — die Feature-Spezifikation nennt lediglich „Vorschlag: 0,03 absolut".
+
+PR #301 setzt stattdessen eine Formel um:
+
+```
+toleranz = min( max(0,12 · Baselinewert, 1/n, 0,02), 0,05 )
+```
+
+Damit ist implizit und ausschließlich im Code definiert, **was das Projekt künftig als „keine
+Regression" bezeichnet**. Das ist keine Implementierungsdetailfrage: Ein zu weiter Schwellenwert
+macht den gesamten Aufwand aus #225–#227 wirkungslos, ohne dass es auffällt — der Job bleibt grün
+und suggeriert eine Sicherheit, die nicht besteht. Ein zu enger Schwellenwert erzeugt nächtliche
+Fehlalarme, mit dem bekannten Ergebnis, dass der Job abgeschaltet oder ignoriert wird.
+
+Die konkrete Formel hat zwei Eigenschaften, die eine bewusste Festlegung verlangen:
+
+1. **Die Obergrenze 0,05 bindet an beiden Enden der Skala.** Für hoch bewertete Gruppen greift sie,
+   weil `0,12 · Baselinewert` sie überschreitet; für kleine Gruppen (`n ≤ 20`), weil `1/n` sie
+   überschreitet. Für `category:numeric_range` (n=16, nDCG@10 = 0,063) bedeutet das eine erlaubte
+   relative Verschlechterung von 79 % (Recall@10: 83 %), für `category:attribute_lookup` von 5 %.
+   Ausgerechnet die schwächsten Gruppen — an denen sich eine Verbesserung des Retrievals zuerst
+   zeigen müsste — sind damit faktisch ungeschützt.
+2. **Die Obergrenze hebelt den Ein-Fall-Schutz dort aus, wofür er gebaut wurde.** Bei n=16 verschiebt
+   ein einzelner kippender Fall die Hit Rate@5 um 0,0625 > 0,05. Dieselbe Gruppe ist also für
+   niedrige Metriken zu weit und für hohe Metriken zu eng abgesichert. Bei n=20
+   (`category:entity_description`) liegt die Toleranz exakt auf der Ein-Fall-Grenze.
+
+Hinzu kommt, dass `n` die Zahl unabhängiger Beobachtungen überschätzt: Der Report weist selbst aus,
+dass 121 Fällen deutlich weniger unterschiedliche Erwartungsmengen gegenüberstehen und jeder deutsche
+Bereichsfall der konstruierte Zwilling eines englischen ist (`datasetNotes`). `category:crosslingual`
+und `language:de` sind zudem dieselbe Menge und liefern denselben Wert doppelt.
+
+Die Begründung für die Enge — drei byte-identische Läufe — stützt sich auf drei Läufe auf zwei
+Maschinen mit demselben Modell-Digest. Das belegt Determinismus der Pipeline, nicht die Stabilität
+über Runner-Generationen, Docker-Versionen oder pgvector-Updates hinweg.
+
+## Entscheidung
+
+**1. Das Fehlerkriterium wird hier festgeschrieben, nicht nur im Code.** Jede Änderung an Formel,
+Konstanten oder Untergrenzen ist eine ADR-Änderung, weil sie die Bedeutung von „grün" verschiebt.
+
+**2. Die Toleranz wird in Fällen ausgedrückt, nicht in absoluten Metrikpunkten.** Grundgröße ist
+`k_min / n_eff` mit `k_min = 2` (zwei kippende Fälle sind Rauschen, drei sind ein Befund) und
+`n_eff` = Zahl unabhängiger Beobachtungen der Gruppe (Zahl unterschiedlicher Erwartungsmengen unter
+den Fällen der Gruppe), nicht die Fallzahl. Die absolute Obergrenze entfällt; sie bindet heute genau
+dort, wo sie schadet.
+
+**3. Für Gruppen mit niedrigem Baselinewert gilt zusätzlich eine relative Deckelung.** Kein
+Baselinewert darf um mehr als 25 % relativ fallen, unabhängig davon, was die fallbasierte Toleranz
+erlaubt. Damit bleibt `numeric_range` (nDCG@10 0,063) bei rund 0,047 statt bei rund 0,013 geschützt.
+
+**4. Die harte Untergrenze der vier Gesamtmetriken wird an die Baseline gekoppelt**: 80 % des jeweils
+committeten Baselinewerts. Ihr Zweck bleibt der zweite, baseline-unabhängige Fangnetz gegen
+katastrophales Versagen; als feste 0,25 hätte sie eine schrittweise Baseline-Absenkung um 44 %
+zugelassen, ohne je auszulösen.
+
+**5. Alle Größen, die den Messvertrag nach ADR-0012 bestimmen, sind Fixpunkte der Baseline** und
+führen bei Abweichung zu „Baseline ungültig", nicht zu einem Metrikvergleich. Das umfasst
+ausdrücklich auch `searchTopK` (ADR-0012, Entscheidung 3), `pgvectorIndexType` (ADR-0011,
+Konsequenzen: der Wechsel auf exakte Suche ist dort als möglicher Weg vorgesehen),
+`embeddingDimensions` und die (bewusst nicht angewandte) `productionSimilarityThreshold`.
+
+**6. Eine Baseline-Absenkung ist im Diff sichtbar zu machen.** Der label-ausgelöste Lauf an einem PR
+vergleicht zusätzlich die Baseline des PR-Branches gegen die Baseline von `main` und weist jede
+Absenkung im PR-Kommentar aus. Das Verfahren in `eval/baseline/README.md` bleibt bestehen, ruht aber
+nicht mehr allein auf der Aufmerksamkeit des Reviewers.
+
+## Konsequenzen
+
+**Einfacher:**
+
+- „Keine Regression" ist eine nachlesbare, begründete Aussage statt einer Formel im Code.
+- Die schwachen Gruppen — der eigentliche Gegenstand künftiger Retrieval-Arbeit — sind messbar
+  geschützt; eine Verbesserung dort wird sichtbar, statt im Toleranzband zu verschwinden.
+- Eine schleichende Baseline-Erosion über mehrere PRs hat eine sichtbare Grenze (Entscheidung 6) und
+  eine mitwandernde harte Untergrenze (Entscheidung 4) statt einer erodierenden festen Zahl.
+
+**Schwieriger:**
+
+- `n_eff` muss bestimmt und gepflegt werden; der Report führt dafür jetzt eine
+  `distinctExpectedDocumentSets`-Zahl je Gruppe (nicht nur gesamt), was `MetricsAggregate` erweitert
+  hat.
+- Eine relative Deckelung bei niedrigen Werten erhöht die Fehlalarmwahrscheinlichkeit in genau den
+  Gruppen, die am stärksten schwanken. Ob 25 % tragfähig sind, ist erst nach mehreren nächtlichen
+  Läufen auf CI-Hardware beurteilbar — die bisherigen Läufe stammen von Entwicklerrechnern.
+- Eine an die Baseline gekoppelte Untergrenze muss bei jeder Baseline-Aktualisierung mitgezogen
+  werden — sie wird jedoch aus dem committeten Baselinewert berechnet, nicht separat gepflegt.
+
+## Offen
+
+- Ob `category:crosslingual` und `language:de` als getrennte Gruppen geführt werden sollen, solange
+  sie identisch sind — heute erzeugen sie acht statt vier Prüfungen über dieselben Daten. Eigenes
+  Issue (`evaluation`, `size:S`).
+- Ob Gruppen mit sehr niedrigem Baselinewert überhaupt über Mittelwerte geprüft werden sollten oder
+  besser über die absolute Zahl getroffener Fälle (z. B. „mindestens 2 der 16 `numeric_range`-Fälle
+  liefern einen Treffer in den Top 5"). **Konkret bekannt und bewusst nicht gelöst:** Für
+  `category:numeric_range` (n_eff=15) liegt die aus Entscheidung 3 resultierende Toleranz von
+  `hitRateAt5` bei rund 0,047 — knapp unter der Verschiebung, die ein einzelner kippender Fall in
+  dieser Gruppe erzeugt (1/16 ≈ 0,0625). Für dieses eine Metrik/Gruppen-Paar kann ein einzelner
+  Fall also weiterhin einen Fehlschlag auslösen, obwohl Entscheidung 2 genau das verhindern soll.
+  Der Grund ist der in diesem ADR beschriebene Zielkonflikt selbst: Die relative Deckelung aus
+  Entscheidung 3, die `numeric_range`s nDCG@10 wirksam schützt, kann für ein anderes, weniger
+  extremes Metrik desselben Golden-Kategoriewerts (`hitRateAt5`, Baseline 0,188) enger ausfallen als
+  der Ein-Fall-Schutz aus Entscheidung 2. Eine fallzahlbasierte Prüfung (statt Mittelwert-Toleranz)
+  für Gruppen mit `n_eff < 20` wäre der sauberere, aber grundsätzlichere Wechsel — dafür fehlt heute
+  die Evidenz aus echten nächtlichen Läufen, um das zu kalibrieren.
+
+## Nachtrag: Umsetzung in PR #301
+
+> **Nachtrag vom 2026-08-03.** Zwei Korrekturen gegenüber der ursprünglichen Entwurfsfassung dieses
+> ADR, festgehalten statt still überschrieben.
+
+1. **`n_eff` ist keine Schätzung, sondern eine im Report geführte, gruppenweise Zahl.**
+   `MetricsAggregate` trägt jetzt `distinctExpectedDocumentSets` je Gruppe (überall, je Kategorie,
+   Schwierigkeit und Sprache) — berechnet exakt wie die bereits vorhandene, gesamt-report-weite
+   `datasetNotes.distinctExpectedDocumentSets`, nur granularer. Das schließt die im „Schwieriger"-
+   Abschnitt der Entwurfsfassung benannte Lücke („der Report liefert dafür heute nur die Gesamtzahl,
+   keine gruppenweise Aufschlüsselung").
+2. **Die im Entwurf zitierte Zahl „121 Fälle, 75 unterschiedliche Erwartungsmengen" ist falsch.**
+   Nachgerechnet direkt aus dem committeten `eval/golden/comic-characters.json` ergeben sich **94**
+   unterschiedliche Erwartungsmengen, nicht 75. Die 75 stammte aus einer ungeprüften früheren Angabe
+   und wurde unverändert in den Entwurf übernommen. Alle Zahlenbeispiele in diesem ADR und die
+   committete Baseline (`eval/baseline/comic-characters.json`) verwenden die nachgerechnete Zahl 94.
+
+Der Kern der Entscheidung (Formel, harte Untergrenze, Fixpunkt-Liste, Baseline-Diff) ist davon nicht
+berührt.

--- a/eval/README.md
+++ b/eval/README.md
@@ -167,8 +167,16 @@ zu interpretieren.
 
 ### Baseline und CI
 
-Dieses Issue (#227) liefert den Harness und die erstmals gemessenen Zahlen. Eine feste Baseline,
-Schwellenwerte und die CI-Anbindung (nächtlich auf `main`, per Label an einem PR) folgen in #228.
+Issue #227 lieferte den Harness und die erstmals gemessenen Zahlen. Issue #228 hat darauf die feste
+Baseline, die Schwellenwerte und die CI-Anbindung aufgesetzt:
+
+- Baseline und Update-Verfahren: [`eval/baseline/README.md`](baseline/README.md).
+- CI-Workflow: [`.github/workflows/retrieval-regression.yml`](../.github/workflows/retrieval-regression.yml)
+  — nächtlich auf `main`, manuell über `workflow_dispatch` und per Label `evaluation` an einem Pull
+  Request; niemals bei jedem Pull Request automatisch.
+- Vergleichslogik: `io.opaa.eval.BaselineComparator`, ausgeführt über den Gradle-Task
+  `checkRetrievalBaseline` (führt `evaluateRetrieval` aus und vergleicht das Ergebnis anschließend
+  gegen `eval/baseline/comic-characters.json`).
 
 ### Messvertrag
 

--- a/eval/baseline/README.md
+++ b/eval/baseline/README.md
@@ -19,17 +19,21 @@ ausgewertet wird sie von `io.opaa.eval.Baseline`/`io.opaa.eval.BaselineComparato
 ```
 
 - **`fixedPoints`** legt fest, *unter welcher Messgrundlage* die Zahlen entstanden sind:
-  Embedding-Modell samt Digest, Chunk-Größe, Korpus- und Golden-Dataset-Hash,
-  Messvertrag-Version. Weicht auch nur eines davon vom aktuellen Lauf ab, ist die Baseline
-  **ungültig** für diesen Lauf — der Job meldet das ausdrücklich als "Baseline ungültig,
-  Messgrundlage geändert" und vergleicht dann **keine** Metrik, weil ein Vergleich unter
-  unterschiedlicher Messgrundlage keine Aussage über Retrieval-Qualität wäre (siehe ADR-0011,
-  Konsequenzen; ADR-0012, Entscheidung 6).
+  Embedding-Modell samt Digest und Dimensionen, Chunk-Größe, `searchTopK`,
+  `productionSimilarityThreshold`, `pgvectorIndexType`, Korpus- und Golden-Dataset-Hash,
+  Messvertrag-Version (ADR-0013, Entscheidung 5 — die letzten drei kamen im Review zu PR #301
+  hinzu, weil sie ebenfalls Teil des Messvertrags nach ADR-0012 sind, nicht nur Metadaten). Weicht
+  auch nur eines davon vom aktuellen Lauf ab, ist die Baseline **ungültig** für diesen Lauf — der
+  Job meldet das ausdrücklich als "Baseline ungültig, Messgrundlage geändert" und vergleicht dann
+  **keine** Metrik, weil ein Vergleich unter unterschiedlicher Messgrundlage keine Aussage über
+  Retrieval-Qualität wäre (siehe ADR-0011, Konsequenzen; ADR-0012, Entscheidung 6).
 - **`groups`** enthält die vier Kernmetriken (`hitRateAt5`, `mrr`, `ndcgAt10`, `recallAt10`) plus
-  `recallAt10Ceiling` für `overall` und jede Ausprägung von Kategorie (`category:<name>`),
-  Schwierigkeit (`difficulty:<name>`) und Sprache (`language:<name>`) aus dem Golden Dataset.
-- **`measuredAt`**/**`notes`** sind rein dokumentarisch: wann und mit welchem Kontext gemessen
-  wurde, inklusive Verweis auf frühere, hinfällige Zahlen (siehe unten).
+  `recallAt10Ceiling` und `distinctExpectedDocumentSets` (die Grundgröße der Toleranzformel unten,
+  `n_eff`) für `overall` und jede Ausprägung von Kategorie (`category:<name>`), Schwierigkeit
+  (`difficulty:<name>`) und Sprache (`language:<name>`) aus dem Golden Dataset.
+- **`measuredAt`**/**`provenance`**/**`notes`** sind rein dokumentarisch (nie Teil des Vergleichs):
+  wann, mit welchem PR und welchem Report gemessen wurde, inklusive Verweis auf frühere, hinfällige
+  Zahlen (siehe unten).
 
 ## Warum diese Zahlen und nicht andere
 
@@ -45,47 +49,108 @@ der empirische Beleg dafür, dass `:latest` ohne Digest-Pin keine stabile Messgr
 ADR-0011, Entscheidung 4, und den Digest-Assertion-Mechanismus in
 `RetrievalEvaluationHarnessTest`).
 
-## Toleranzen je Gruppe
+## Toleranzen je Gruppe (ADR-0013)
+
+> **Überarbeitet nach dem Review zu PR #301.** Die ursprüngliche Formel dieses Abschnitts
+> (`min(max(0,12·Baselinewert, 1/n, 0,02), 0,05)`) hatte eine absolute Obergrenze, die an **beiden**
+> Enden der Skala band: zu locker für schwache, kleine Gruppen (bis zu 79 % erlaubte relative
+> Verschlechterung bei `numeric_range`), gleichzeitig zu eng genau an der Ein-Fall-Grenze anderer
+> Gruppen (`entity_description`, n=20: ein einzelner kippender Fall scheiterte an
+> Fließkomma-Rundung, `12/20 − 0,65 == −0,05000000000000004` gegen eine Toleranz von exakt `0,05`).
+> Das jetzt umgesetzte Fehlerkriterium ist in [ADR-0013](../../docs/decisions/0013-fehlerkriterium-retrieval-regression.md)
+> festgeschrieben, nicht mehr nur hier beschrieben — Änderungen daran sind eine ADR-Änderung.
 
 Der Vergleich verwendet **keine einheitliche Toleranz**. Eine feste absolute Toleranz von z. B. 0,05
 wäre bei `attribute_lookup` (Baseline-nDCG@10 0,942) reines Rauschen, bei `numeric_range`
 (Baseline-nDCG@10 0,063) dagegen fast der gesamte Messwert — dieselbe Zahl bedeutet an den beiden
-Enden der Skala etwas völlig anderes. Eine einheitliche *relative* Toleranz löst das nicht: Bei einem
-Wert nahe null kollabiert eine relative Toleranz ebenfalls gegen null, sodass die kleinste
-Schwankung schon als Regression zählt.
+Enden der Skala etwas völlig anderes. Eine einheitliche *relative* Toleranz löst das ebenfalls nicht:
+Bei einem Wert nahe null kollabiert sie gegen null, sodass die kleinste Schwankung schon als
+Regression zählt.
 
-`BaselineComparator.toleranceFor(baselineValue, n)` kombiniert deshalb drei Terme:
+`BaselineComparator.toleranceFor(baselineValue, n_eff)` kombiniert deshalb zwei Terme:
 
 ```
-toleranz = min(
-    max(0.12 · baselineValue, 1 / n, 0.02),
-    0.05)
+toleranz = min( k_min / n_eff, 0,25 · baselineValue )
 ```
 
-- **`0.12 · baselineValue`** (relativer Anteil): skaliert die Toleranz mit dem eigenen Score-Niveau
-  der Gruppe — der dominante Term bei mittel/hoch bewerteten Gruppen (`attribute_lookup`,
-  `entity_description`, `easy`).
-- **`1 / n`** (Ein-Fall-Schutz): skaliert **umgekehrt** mit der Gruppengröße. Kleine Gruppen wie
-  `numeric_range` (n=16) schwanken pro Einzelfall stärker als große — ein einzelner kippender Fall
-  verschiebt den Mittelwert einer 16er-Gruppe um bis zu 0,0625, bei einer 121er-Gruppe nur um 0,008.
-  Dieser Term wird für genau die kleinen, niedrig bewerteten Gruppen dominant, bei denen der
-  relative Term allein gegen null ginge (`numeric_range`, `multi_attribute_filter`).
-- **`0.02`** (absolute Untergrenze): verhindert, dass eine große, hoch bewertete Gruppe allein durch
-  die anderen beiden Terme eine unrealistisch enge Toleranz bekommt.
-- **`0.05`** (absolute Obergrenze): verhindert, dass ein hoher Baseline-Wert einen beliebig großen
-  Rückgang deckt, bevor der Job reagiert.
+- **`k_min / n_eff`** ("fallbasiert", `k_min = 2`): drückt die Toleranz als „wie viele unabhängige
+  Fälle müssten kippen, damit das als Regression zählt" aus, statt als festen Metrikpunkt. `n_eff`
+  ist `distinctExpectedDocumentSets` der Gruppe — die Zahl *unterschiedlicher* Erwartungsmengen
+  unter ihren Fällen, nicht die rohe Fallzahl `n` (siehe `MetricsAggregate`-Javadoc): Mehrere
+  Golden-Dataset-Fälle teilen dieselbe Erwartungsmenge (z. B. ist jeder `crosslingual`-Fall der
+  deutsche Zwilling eines englischen mit identischer Erwartungsmenge), sodass `n` die Zahl
+  unabhängiger Beobachtungen überschätzt.
+- **`0,25 · baselineValue`** ("relative Deckelung"): begrenzt den fallbasierten Term zusätzlich für
+  niedrig bewertete Gruppen. Ohne diese Deckelung würde eine kleine `n_eff` bei einem
+  Baseline-Wert nahe null eine beliebig große *relative* Verschlechterung zulassen, allein weil die
+  Gruppe klein ist — genau das Problem, das ADR-0013 behebt. Die Deckelung kann die Toleranz nur
+  verengen, nie erweitern.
 
-Resultierende Toleranzen für die aktuelle Baseline (nDCG@10, exemplarisch — jede Metrik jeder Gruppe
-bekommt ihre eigene, nach derselben Formel berechnete Toleranz):
+Es gibt bewusst **keine** separate absolute Unter- oder Obergrenze mehr: Eine einzelne absolute
+Grenze band an beiden Enden der Skala zugleich. Fallbasiert plus relative (nicht absolute) Deckelung
+vermeidet diese Kollision.
 
-| Gruppe | n | Baseline nDCG@10 | Toleranz | dominanter Term |
-|---|---|---|---|---|
-| overall | 121 | 0,445 | 0,050 | relativ (gedeckelt) |
-| attribute_lookup | 30 | 0,942 | 0,050 | relativ (gedeckelt) |
-| entity_description | 20 | 0,575 | 0,050 | relativ (gedeckelt) |
-| crosslingual | 34 | 0,302 | 0,036 | relativ |
-| multi_attribute_filter | 21 | 0,137 | 0,048 | Ein-Fall-Schutz |
-| numeric_range | 16 | 0,063 | 0,050 | Ein-Fall-Schutz (gedeckelt) |
+Resultierende Toleranzen für die aktuelle Baseline, **alle elf Gruppen und alle vier Metriken**:
+
+| Gruppe | n | n_eff | Metrik | Baseline | Toleranz | dominanter Term |
+|---|---|---|---|---|---|---|
+| overall | 121 | 94 | hitRateAt5 | 0,521 | 0,0213 | fallbasiert |
+| overall | 121 | 94 | mrr | 0,461 | 0,0213 | fallbasiert |
+| overall | 121 | 94 | ndcgAt10 | 0,445 | 0,0213 | fallbasiert |
+| overall | 121 | 94 | recallAt10 | 0,490 | 0,0213 | fallbasiert |
+| category:attribute_lookup | 30 | 30 | hitRateAt5 | 0,967 | 0,0667 | fallbasiert |
+| category:attribute_lookup | 30 | 30 | mrr | 0,933 | 0,0667 | fallbasiert |
+| category:attribute_lookup | 30 | 30 | ndcgAt10 | 0,942 | 0,0667 | fallbasiert |
+| category:attribute_lookup | 30 | 30 | recallAt10 | 0,967 | 0,0667 | fallbasiert |
+| category:entity_description | 20 | 20 | hitRateAt5 | 0,650 | 0,1000 | fallbasiert |
+| category:entity_description | 20 | 20 | mrr | 0,518 | 0,1000 | fallbasiert |
+| category:entity_description | 20 | 20 | ndcgAt10 | 0,575 | 0,1000 | fallbasiert |
+| category:entity_description | 20 | 20 | recallAt10 | 0,750 | 0,1000 | fallbasiert |
+| category:crosslingual | 34 | 33 | hitRateAt5 | 0,382 | 0,0606 | fallbasiert |
+| category:crosslingual | 34 | 33 | mrr | 0,337 | 0,0606 | fallbasiert |
+| category:crosslingual | 34 | 33 | ndcgAt10 | 0,302 | 0,0606 | fallbasiert |
+| category:crosslingual | 34 | 33 | recallAt10 | 0,322 | 0,0606 | fallbasiert |
+| category:multi_attribute_filter | 21 | 21 | hitRateAt5 | 0,238 | 0,0595 | relative Deckelung |
+| category:multi_attribute_filter | 21 | 21 | mrr | 0,206 | 0,0515 | relative Deckelung |
+| category:multi_attribute_filter | 21 | 21 | ndcgAt10 | 0,137 | 0,0343 | relative Deckelung |
+| category:multi_attribute_filter | 21 | 21 | recallAt10 | 0,159 | 0,0398 | relative Deckelung |
+| category:numeric_range | 16 | 15 | hitRateAt5 | 0,188 | 0,0470 | relative Deckelung |
+| category:numeric_range | 16 | 15 | mrr | 0,101 | 0,0253 | relative Deckelung |
+| category:numeric_range | 16 | 15 | ndcgAt10 | 0,063 | 0,0158 | relative Deckelung |
+| category:numeric_range | 16 | 15 | recallAt10 | 0,060 | 0,0150 | relative Deckelung |
+| difficulty:easy | 40 | 30 | hitRateAt5 | 0,950 | 0,0667 | fallbasiert |
+| difficulty:easy | 40 | 30 | mrr | 0,912 | 0,0667 | fallbasiert |
+| difficulty:easy | 40 | 30 | ndcgAt10 | 0,922 | 0,0667 | fallbasiert |
+| difficulty:easy | 40 | 30 | recallAt10 | 0,950 | 0,0667 | fallbasiert |
+| difficulty:medium | 48 | 35 | hitRateAt5 | 0,333 | 0,0571 | fallbasiert |
+| difficulty:medium | 48 | 35 | mrr | 0,253 | 0,0571 | fallbasiert |
+| difficulty:medium | 48 | 35 | ndcgAt10 | 0,262 | 0,0571 | fallbasiert |
+| difficulty:medium | 48 | 35 | recallAt10 | 0,335 | 0,0571 | fallbasiert |
+| difficulty:hard | 33 | 30 | hitRateAt5 | 0,273 | 0,0667 | fallbasiert |
+| difficulty:hard | 33 | 30 | mrr | 0,216 | 0,0540 | relative Deckelung |
+| difficulty:hard | 33 | 30 | ndcgAt10 | 0,134 | 0,0335 | relative Deckelung |
+| difficulty:hard | 33 | 30 | recallAt10 | 0,157 | 0,0393 | relative Deckelung |
+| language:en | 87 | 85 | hitRateAt5 | 0,575 | 0,0235 | fallbasiert |
+| language:en | 87 | 85 | mrr | 0,509 | 0,0235 | fallbasiert |
+| language:en | 87 | 85 | ndcgAt10 | 0,502 | 0,0235 | fallbasiert |
+| language:en | 87 | 85 | recallAt10 | 0,555 | 0,0235 | fallbasiert |
+| language:de | 34 | 33 | hitRateAt5 | 0,382 | 0,0606 | fallbasiert |
+| language:de | 34 | 33 | mrr | 0,337 | 0,0606 | fallbasiert |
+| language:de | 34 | 33 | ndcgAt10 | 0,302 | 0,0606 | fallbasiert |
+| language:de | 34 | 33 | recallAt10 | 0,322 | 0,0606 | fallbasiert |
+
+Diese Tabelle ist reproduzierbar aus der committeten Baseline nachrechenbar
+(`BaselineComparator.toleranceFor`, unit-getestet in `BaselineComparatorTest`) und keine separate,
+von Hand gepflegte Angabe.
+
+**Bekannter, bewusst nicht gelöster Grenzfall** (siehe ADR-0013, Abschnitt „Offen"): Für
+`category:numeric_range` liegt die Toleranz von `hitRateAt5` (0,047) knapp unter der Verschiebung,
+die ein einzelner kippender Fall in dieser 16-Fälle-Gruppe erzeugt (1/16 ≈ 0,0625) — dort kann ein
+einzelner Fall weiterhin einen Fehlschlag auslösen. Die relative Deckelung, die `numeric_range`s
+nDCG@10 wirksam schützt, fällt für `hitRateAt5` (höherer Baseline-Wert derselben Gruppe) enger aus
+als der Ein-Fall-Schutz. Eine fallzahlbasierte statt Mittelwert-Prüfung für sehr kleine Gruppen wäre
+der sauberere Fix, ist aber ohne Erfahrung aus echten nächtlichen Läufen nicht kalibrierbar — offenes
+Folge-Thema, kein PR-#301-Bug.
 
 Diese engen Toleranzen sind bewusst gewählt, **weil** die Reproduzierbarkeit oben belegt ist: Eine
 weite Toleranz würde bei nachgewiesener Stabilität keinen zusätzlichen Schutz vor falschem
@@ -93,13 +158,15 @@ Alarm kaufen, sondern nur echte Regressionen durchlassen.
 
 ### Harte Untergrenze (zweite Stufe)
 
-Zusätzlich zur baseline-relativen Toleranz gilt eine **von der Baseline unabhängige** Untergrenze
-für die vier Gesamt-Metriken (`overall`, nicht für einzelne Gruppen): Hit Rate@5 ≥ 0,30, MRR ≥ 0,25,
-nDCG@10 ≥ 0,25, Recall@10 ≥ 0,25 (`BaselineComparator.HARD_FLOOR_*`). Diese Werte liegen deutlich
-unter der aktuellen Baseline — die baseline-relative Toleranz greift im Regelfall lange vorher. Ihr
-Zweck ist ein zweiter, von der Baseline-Datei selbst unabhängiger Fangnetz gegen katastrophales
-Versagen (z. B. ein leerer oder falsch konfigurierter Vektor-Store), nicht die primäre
-Regressionserkennung.
+Zusätzlich zur baseline-relativen Toleranz gilt eine für die vier Gesamt-Metriken (`overall`, nicht
+für einzelne Gruppen) **an die Baseline gekoppelte** Untergrenze: 80 % des jeweils committeten
+Baselinewerts (`BaselineComparator.HARD_FLOOR_FRACTION_OF_BASELINE`, ADR-0013 Entscheidung 4). Für
+die aktuelle Baseline also Hit Rate@5 ≥ 0,417, MRR ≥ 0,369, nDCG@10 ≥ 0,356, Recall@10 ≥ 0,392. Eine
+feste Zahl (zuvor 0,25 für alle vier) hätte eine schrittweise Baseline-Absenkung um 44 % erlaubt,
+ohne je auszulösen — an die Baseline gekoppelt wandert die Untergrenze bei jeder Baseline-
+Aktualisierung mit. Die baseline-relative Toleranz greift im Regelfall lange vorher; der Zweck der
+harten Untergrenze bleibt ein zweiter, von der primären Toleranzformel unabhängiger Fangnetz gegen
+katastrophales Versagen (z. B. ein leerer oder falsch konfigurierter Vektor-Store).
 
 ## Baseline ungültig vs. Regression — wie der Job das unterscheidet
 
@@ -107,11 +174,12 @@ Regressionserkennung.
 einziges Ja/Nein zusammengefasst:
 
 1. **Ist die Baseline noch gültig?** Stimmen `measurementContractVersion`,
-   `corpusManifestSha256`, `goldenDatasetSha256`, `embeddingModelDigest`, `chunkSize` und
-   `chunkSizeMatchesApplicationDefault` mit dem aktuellen Lauf überein? Wenn nicht, bricht der Job
-   mit einer Meldung ab, die ausdrücklich **"Baseline ungültig, Messgrundlage geändert"** sagt, samt
-   Tabelle der abweichenden Felder — nicht "Retrieval ist schlechter geworden". In diesem Fall wird
-   **keine** Metrik verglichen.
+   `corpusManifestSha256`, `goldenDatasetSha256`, `embeddingModelDigest`, `embeddingDimensions`,
+   `chunkSize`, `chunkSizeMatchesApplicationDefault`, `searchTopK`, `productionSimilarityThreshold`
+   und `pgvectorIndexType` mit dem aktuellen Lauf überein? Wenn nicht, bricht der Job mit einer
+   Meldung ab, die ausdrücklich **"Baseline ungültig, Messgrundlage geändert"** sagt, samt Tabelle
+   der abweichenden Felder — nicht "Retrieval ist schlechter geworden". In diesem Fall wird **keine**
+   Metrik verglichen.
 2. **Nur wenn die Baseline gültig ist:** Liegt jede Gruppe innerhalb ihrer Toleranz, und halten die
    vier Gesamt-Metriken die harte Untergrenze? Nur hier ist die Meldung "Regression erkannt".
 
@@ -159,3 +227,25 @@ das die Änderung verursacht, damit Ursache und neue Zahl im selben Review sicht
 **Nicht** ausreichend: Die Baseline-Datei ohne einen tatsächlichen `evaluateRetrieval`-Lauf von Hand
 anpassen, oder eine Verschlechterung stillschweigend als neue Baseline übernehmen, ohne den Grund im
 PR zu nennen.
+
+**`provenance`** (`sourceReportRunStartedAt`, `sourcePullRequest`) hält fest, aus welchem Lauf und
+PR die aktuellen Zahlen stammen — rein dokumentarisch, nie Teil des Vergleichs. Bei jeder
+Aktualisierung mitschreiben, damit eine spätere Frage „woher kommt dieser Wert" ohne Git-Archäologie
+beantwortbar bleibt.
+
+## Baseline-Absenkung gegenüber `main` (ADR-0013, Entscheidung 6)
+
+Der label-ausgelöste Lauf an einem Pull Request vergleicht zusätzlich die Baseline **des
+PR-Branches** gegen die Baseline **von `main`** (`eval/baseline/diff_baseline.py`, aufgerufen aus
+`.github/workflows/retrieval-regression.yml`) und postet jede Metrik, die im PR-Branch niedriger ist
+als auf `main`, als eigene Tabelle im PR-Kommentar. Der Grund: Ohne diesen Vergleich prüft der
+label-ausgelöste Lauf nur, ob der aktuelle Retrieval-Lauf zur **eigenen, im selben PR mitgelieferten**
+Baseline passt — ein PR, der die Baseline im selben Zug unbemerkt absenkt, bekommt dadurch einen
+grünen Regressionsjob als scheinbaren Beleg für "keine Regression", obwohl der Maßstab selbst
+gesunken ist.
+
+Das Skript ist rein informativ und schlägt nie fehl (Exit-Code immer 0) — es macht eine Absenkung im
+PR-Kommentar sichtbar, ersetzt aber nicht die Review-Pflicht aus dem Abschnitt oben. Es ist bewusst
+ein eigenständiges, Standardbibliothek-only Python-Skript (kein Java, kein Gradle-Task), aus
+demselben Grund wie die Korpus-/Golden-Dataset-Generatoren unter `eval/generator/` (ADR-0011,
+Entscheidung 2): Ein einfacher Zwei-Dateien-JSON-Vergleich braucht keine Backend-Infrastruktur.

--- a/eval/baseline/README.md
+++ b/eval/baseline/README.md
@@ -1,0 +1,161 @@
+# Retrieval-Baseline (Issue #228)
+
+`comic-characters.json` in diesem Verzeichnis ist die committete Baseline, gegen die der
+nächtliche Regressionsjob (`.github/workflows/retrieval-regression.yml`, Gradle-Task
+`checkRetrievalBaseline`) jeden neuen Lauf von `./gradlew evaluateRetrieval` vergleicht. Geladen und
+ausgewertet wird sie von `io.opaa.eval.Baseline`/`io.opaa.eval.BaselineComparator` im
+`evalTest`-Source-Set.
+
+## Aufbau
+
+```json
+{
+  "measurementContractVersion": 1,
+  "fixedPoints": { ... },
+  "groups": { "overall": { ... }, "category:attribute_lookup": { ... }, ... },
+  "measuredAt": "2026-08-03",
+  "notes": "..."
+}
+```
+
+- **`fixedPoints`** legt fest, *unter welcher Messgrundlage* die Zahlen entstanden sind:
+  Embedding-Modell samt Digest, Chunk-Größe, Korpus- und Golden-Dataset-Hash,
+  Messvertrag-Version. Weicht auch nur eines davon vom aktuellen Lauf ab, ist die Baseline
+  **ungültig** für diesen Lauf — der Job meldet das ausdrücklich als "Baseline ungültig,
+  Messgrundlage geändert" und vergleicht dann **keine** Metrik, weil ein Vergleich unter
+  unterschiedlicher Messgrundlage keine Aussage über Retrieval-Qualität wäre (siehe ADR-0011,
+  Konsequenzen; ADR-0012, Entscheidung 6).
+- **`groups`** enthält die vier Kernmetriken (`hitRateAt5`, `mrr`, `ndcgAt10`, `recallAt10`) plus
+  `recallAt10Ceiling` für `overall` und jede Ausprägung von Kategorie (`category:<name>`),
+  Schwierigkeit (`difficulty:<name>`) und Sprache (`language:<name>`) aus dem Golden Dataset.
+- **`measuredAt`**/**`notes`** sind rein dokumentarisch: wann und mit welchem Kontext gemessen
+  wurde, inklusive Verweis auf frühere, hinfällige Zahlen (siehe unten).
+
+## Warum diese Zahlen und nicht andere
+
+Gemessen am 2026-08-03 mit `nomic-embed-text:v1.5` (Digest siehe `fixedPoints`), Laufzeit 1004 s.
+Drei unabhängige Läufe — zwei vom Autor, einer vom Reviewer auf fremder Hardware — lieferten
+byte-identische Metriken. Die in ADR-0011 genannte HNSW-Approximationsschwankung tritt bei dieser
+Korpusgröße also nicht auf; das ist die Grundlage für die vergleichsweise engen Toleranzen unten.
+
+Ein früherer Bericht nannte einen Gesamt-nDCG@10 von 0,463. Der stammte vom ungepinnten
+`nomic-embed-text:latest`. Er ist **hinfällig** — nicht trotz, sondern *wegen* des Pinnings: Die
+Verschiebung von 0,463 auf 0,445 bei identischem Korpus und identischer Golden-Dataset-Version ist
+der empirische Beleg dafür, dass `:latest` ohne Digest-Pin keine stabile Messgrundlage ist (siehe
+ADR-0011, Entscheidung 4, und den Digest-Assertion-Mechanismus in
+`RetrievalEvaluationHarnessTest`).
+
+## Toleranzen je Gruppe
+
+Der Vergleich verwendet **keine einheitliche Toleranz**. Eine feste absolute Toleranz von z. B. 0,05
+wäre bei `attribute_lookup` (Baseline-nDCG@10 0,942) reines Rauschen, bei `numeric_range`
+(Baseline-nDCG@10 0,063) dagegen fast der gesamte Messwert — dieselbe Zahl bedeutet an den beiden
+Enden der Skala etwas völlig anderes. Eine einheitliche *relative* Toleranz löst das nicht: Bei einem
+Wert nahe null kollabiert eine relative Toleranz ebenfalls gegen null, sodass die kleinste
+Schwankung schon als Regression zählt.
+
+`BaselineComparator.toleranceFor(baselineValue, n)` kombiniert deshalb drei Terme:
+
+```
+toleranz = min(
+    max(0.12 · baselineValue, 1 / n, 0.02),
+    0.05)
+```
+
+- **`0.12 · baselineValue`** (relativer Anteil): skaliert die Toleranz mit dem eigenen Score-Niveau
+  der Gruppe — der dominante Term bei mittel/hoch bewerteten Gruppen (`attribute_lookup`,
+  `entity_description`, `easy`).
+- **`1 / n`** (Ein-Fall-Schutz): skaliert **umgekehrt** mit der Gruppengröße. Kleine Gruppen wie
+  `numeric_range` (n=16) schwanken pro Einzelfall stärker als große — ein einzelner kippender Fall
+  verschiebt den Mittelwert einer 16er-Gruppe um bis zu 0,0625, bei einer 121er-Gruppe nur um 0,008.
+  Dieser Term wird für genau die kleinen, niedrig bewerteten Gruppen dominant, bei denen der
+  relative Term allein gegen null ginge (`numeric_range`, `multi_attribute_filter`).
+- **`0.02`** (absolute Untergrenze): verhindert, dass eine große, hoch bewertete Gruppe allein durch
+  die anderen beiden Terme eine unrealistisch enge Toleranz bekommt.
+- **`0.05`** (absolute Obergrenze): verhindert, dass ein hoher Baseline-Wert einen beliebig großen
+  Rückgang deckt, bevor der Job reagiert.
+
+Resultierende Toleranzen für die aktuelle Baseline (nDCG@10, exemplarisch — jede Metrik jeder Gruppe
+bekommt ihre eigene, nach derselben Formel berechnete Toleranz):
+
+| Gruppe | n | Baseline nDCG@10 | Toleranz | dominanter Term |
+|---|---|---|---|---|
+| overall | 121 | 0,445 | 0,050 | relativ (gedeckelt) |
+| attribute_lookup | 30 | 0,942 | 0,050 | relativ (gedeckelt) |
+| entity_description | 20 | 0,575 | 0,050 | relativ (gedeckelt) |
+| crosslingual | 34 | 0,302 | 0,036 | relativ |
+| multi_attribute_filter | 21 | 0,137 | 0,048 | Ein-Fall-Schutz |
+| numeric_range | 16 | 0,063 | 0,050 | Ein-Fall-Schutz (gedeckelt) |
+
+Diese engen Toleranzen sind bewusst gewählt, **weil** die Reproduzierbarkeit oben belegt ist: Eine
+weite Toleranz würde bei nachgewiesener Stabilität keinen zusätzlichen Schutz vor falschem
+Alarm kaufen, sondern nur echte Regressionen durchlassen.
+
+### Harte Untergrenze (zweite Stufe)
+
+Zusätzlich zur baseline-relativen Toleranz gilt eine **von der Baseline unabhängige** Untergrenze
+für die vier Gesamt-Metriken (`overall`, nicht für einzelne Gruppen): Hit Rate@5 ≥ 0,30, MRR ≥ 0,25,
+nDCG@10 ≥ 0,25, Recall@10 ≥ 0,25 (`BaselineComparator.HARD_FLOOR_*`). Diese Werte liegen deutlich
+unter der aktuellen Baseline — die baseline-relative Toleranz greift im Regelfall lange vorher. Ihr
+Zweck ist ein zweiter, von der Baseline-Datei selbst unabhängiger Fangnetz gegen katastrophales
+Versagen (z. B. ein leerer oder falsch konfigurierter Vektor-Store), nicht die primäre
+Regressionserkennung.
+
+## Baseline ungültig vs. Regression — wie der Job das unterscheidet
+
+`BaselineComparator.compare(...)` beantwortet zwei getrennte Fragen, absichtlich nicht in ein
+einziges Ja/Nein zusammengefasst:
+
+1. **Ist die Baseline noch gültig?** Stimmen `measurementContractVersion`,
+   `corpusManifestSha256`, `goldenDatasetSha256`, `embeddingModelDigest`, `chunkSize` und
+   `chunkSizeMatchesApplicationDefault` mit dem aktuellen Lauf überein? Wenn nicht, bricht der Job
+   mit einer Meldung ab, die ausdrücklich **"Baseline ungültig, Messgrundlage geändert"** sagt, samt
+   Tabelle der abweichenden Felder — nicht "Retrieval ist schlechter geworden". In diesem Fall wird
+   **keine** Metrik verglichen.
+2. **Nur wenn die Baseline gültig ist:** Liegt jede Gruppe innerhalb ihrer Toleranz, und halten die
+   vier Gesamt-Metriken die harte Untergrenze? Nur hier ist die Meldung "Regression erkannt".
+
+Diese Trennung ist der Kern der Anforderung aus Issue #228: Eine Korpus-, Modell- oder
+Golden-Dataset-Änderung ist kein Bug im Retrieval, sondern eine bewusste, reviewte Änderung der
+Messgrundlage — sie erfordert eine neue Baseline, keinen Fix am Suchcode.
+
+## Ein-Chunk-Invariante
+
+Unabhängig von Toleranzen: Verletzt der Lauf die Ein-Chunk-Invariante (ADR-0010,
+`oneChunkInvariant.violations` im Report nicht leer), schlägt der Job **immer** fehl — das ist kein
+Toleranzfall. Eine verletzte Invariante bedeutet, dass "ein Treffer = eine Entität" nicht mehr gilt,
+wodurch jede Metrik bedeutungslos wird.
+
+## Baseline aktualisieren
+
+Eine Baseline-Aktualisierung ist ein bewusster, reviewter Schritt — kein Nebeneffekt eines anderen
+PRs. Sie ist nötig, wenn sich eine der `fixedPoints` legitim ändert (Korpus-Regenerierung,
+Golden-Dataset-Erweiterung, Embedding-Modell-Wechsel, `chunk-size`-Änderung, neuer
+Messvertrag/ADR-0012-Version) **oder** wenn ein grüner Lauf durchgängig bessere Werte zeigt als die
+Baseline (der Job schlägt dafür nie fehl, meldet aber einen Hinweis — siehe
+`BaselineMarkdownWriter`).
+
+**Wer:** Wer auch immer die zugrunde liegende Änderung durchführt (Entwickler, QA Engineer) —
+dieselbe Person, die den PR mit der Korpus-/Modell-/Messvertrag-Änderung einreicht. Der PR braucht
+kein separates Baseline-only-PR-Muster; die Baseline-Datei wird als Teil desselben PRs aktualisiert,
+das die Änderung verursacht, damit Ursache und neue Zahl im selben Review sichtbar sind.
+
+**Womit begründet:**
+
+1. `./gradlew evaluateRetrieval` lokal (oder über `workflow_dispatch`) mindestens einmal mit der
+   neuen Konfiguration laufen lassen und den resultierenden
+   `backend/build/eval-reports/retrieval-metrics.json` im PR verlinken oder als Artefakt anhängen.
+2. Bei einer Verschlechterung: nachvollziehbar begründen, warum sie hingenommen wird (z. B. ein
+   bewusster Tradeoff aus einer anderen Änderung) — eine Baseline-Aktualisierung ist kein Freibrief,
+   um eine Regression verschwinden zu lassen.
+3. Bei einer Verbesserung: kurz benennen, was sie verursacht hat (Chunking, Modell, Korpus), damit
+   die Baseline-Historie nachvollziehbar bleibt.
+4. Die neuen Werte in `comic-characters.json` eintragen, `fixedPoints` entsprechend aktualisieren,
+   `measuredAt` und `notes` fortschreiben (frühere, hinfällige Zahlen wie oben nicht löschen,
+   sondern als überholt kennzeichnen — siehe die bestehende `notes`-Historie in dieser Datei als
+   Vorbild).
+5. Wie jede andere Code-Änderung: Code Reviewer prüft den PR, ein Maintainer merged.
+
+**Nicht** ausreichend: Die Baseline-Datei ohne einen tatsächlichen `evaluateRetrieval`-Lauf von Hand
+anpassen, oder eine Verschlechterung stillschweigend als neue Baseline übernehmen, ohne den Grund im
+PR zu nennen.

--- a/eval/baseline/comic-characters.json
+++ b/eval/baseline/comic-characters.json
@@ -3,8 +3,12 @@
   "fixedPoints": {
     "embeddingModel": "nomic-embed-text:v1.5",
     "embeddingModelDigest": "0a109f422b47e3a30ba2b10eca18548e944e8a23073ee3f3e947efcf3c45e59f",
+    "embeddingDimensions": 768,
     "chunkSize": 1000,
     "chunkSizeMatchesApplicationDefault": true,
+    "searchTopK": 10,
+    "productionSimilarityThreshold": 0.3,
+    "pgvectorIndexType": "hnsw",
     "corpusManifestSha256": "cdfbdfeff23134ec93689256d5abf1477ff03dfa82c03c7cb03728e6704215a7",
     "corpusDocumentCount": 1448,
     "goldenDatasetFile": "eval/golden/comic-characters.json",
@@ -18,7 +22,8 @@
       "mrr": 0.461,
       "ndcgAt10": 0.445,
       "recallAt10": 0.490,
-      "recallAt10Ceiling": 0.9708
+      "recallAt10Ceiling": 0.9708,
+      "distinctExpectedDocumentSets": 94
     },
     "category:attribute_lookup": {
       "n": 30,
@@ -26,7 +31,8 @@
       "mrr": 0.933,
       "ndcgAt10": 0.942,
       "recallAt10": 0.967,
-      "recallAt10Ceiling": 1.0
+      "recallAt10Ceiling": 1.0,
+      "distinctExpectedDocumentSets": 30
     },
     "category:entity_description": {
       "n": 20,
@@ -34,7 +40,8 @@
       "mrr": 0.518,
       "ndcgAt10": 0.575,
       "recallAt10": 0.750,
-      "recallAt10Ceiling": 1.0
+      "recallAt10Ceiling": 1.0,
+      "distinctExpectedDocumentSets": 20
     },
     "category:crosslingual": {
       "n": 34,
@@ -42,7 +49,8 @@
       "mrr": 0.337,
       "ndcgAt10": 0.302,
       "recallAt10": 0.322,
-      "recallAt10Ceiling": 0.9666
+      "recallAt10Ceiling": 0.9666,
+      "distinctExpectedDocumentSets": 33
     },
     "category:multi_attribute_filter": {
       "n": 21,
@@ -50,7 +58,8 @@
       "mrr": 0.206,
       "ndcgAt10": 0.137,
       "recallAt10": 0.159,
-      "recallAt10Ceiling": 0.9331
+      "recallAt10Ceiling": 0.9331,
+      "distinctExpectedDocumentSets": 21
     },
     "category:numeric_range": {
       "n": 16,
@@ -58,7 +67,8 @@
       "mrr": 0.101,
       "ndcgAt10": 0.063,
       "recallAt10": 0.060,
-      "recallAt10Ceiling": 0.9382
+      "recallAt10Ceiling": 0.9382,
+      "distinctExpectedDocumentSets": 15
     },
     "difficulty:easy": {
       "n": 40,
@@ -66,7 +76,8 @@
       "mrr": 0.912,
       "ndcgAt10": 0.922,
       "recallAt10": 0.950,
-      "recallAt10Ceiling": 1.0
+      "recallAt10Ceiling": 1.0,
+      "distinctExpectedDocumentSets": 30
     },
     "difficulty:medium": {
       "n": 48,
@@ -74,7 +85,8 @@
       "mrr": 0.253,
       "ndcgAt10": 0.262,
       "recallAt10": 0.335,
-      "recallAt10Ceiling": 0.9706
+      "recallAt10Ceiling": 0.9706,
+      "distinctExpectedDocumentSets": 35
     },
     "difficulty:hard": {
       "n": 33,
@@ -82,7 +94,8 @@
       "mrr": 0.216,
       "ndcgAt10": 0.134,
       "recallAt10": 0.157,
-      "recallAt10Ceiling": 0.9359
+      "recallAt10Ceiling": 0.9359,
+      "distinctExpectedDocumentSets": 30
     },
     "language:en": {
       "n": 87,
@@ -90,7 +103,8 @@
       "mrr": 0.509,
       "ndcgAt10": 0.502,
       "recallAt10": 0.555,
-      "recallAt10Ceiling": 0.9725
+      "recallAt10Ceiling": 0.9725,
+      "distinctExpectedDocumentSets": 85
     },
     "language:de": {
       "n": 34,
@@ -98,9 +112,14 @@
       "mrr": 0.337,
       "ndcgAt10": 0.302,
       "recallAt10": 0.322,
-      "recallAt10Ceiling": 0.9666
+      "recallAt10Ceiling": 0.9666,
+      "distinctExpectedDocumentSets": 33
     }
   },
   "measuredAt": "2026-08-03",
-  "notes": "Baseline aus PR #299 (Issue #228), gemessen mit dem gepinnten Modell nomic-embed-text:v1.5 (Digest siehe fixedPoints), Laufzeit 1004 s. Drei unabhängige Läufe (zwei des Autors, einer des Reviewers auf fremder Hardware) lieferten byte-identische Metriken — die HNSW-Approximationsschwankung, die ADR-0011 als Risiko benennt, tritt bei dieser Korpusgröße nicht auf. Frühere Berichte nannten einen Gesamt-nDCG@10 von 0.463; die stammen vom ungepinnten nomic-embed-text:latest und sind hinfällig — die Verschiebung durch das Pinning ist der empirische Beleg dafür, warum das Pinning nötig war. Aktualisierungsverfahren: eval/baseline/README.md."
+  "provenance": {
+    "sourceReportRunStartedAt": "2026-08-03T00:00:00Z",
+    "sourcePullRequest": "#299"
+  },
+  "notes": "Baseline aus PR #299 (Issue #228), gemessen mit dem gepinnten Modell nomic-embed-text:v1.5 (Digest siehe fixedPoints), Laufzeit 1004 s. Drei unabhängige Läufe (zwei des Autors, einer des Reviewers auf fremder Hardware) lieferten byte-identische Metriken — die HNSW-Approximationsschwankung, die ADR-0011 als Risiko benennt, tritt bei dieser Korpusgröße nicht auf. Frühere Berichte nannten einen Gesamt-nDCG@10 von 0.463; die stammen vom ungepinnten nomic-embed-text:latest und sind hinfällig — die Verschiebung durch das Pinning ist der empirische Beleg dafür, warum das Pinning nötig war. Toleranzpolitik gemäß ADR-0013 (überarbeitet aus dem Review zu PR #301): tolerance = min(2/n_eff, 0.25*Baselinewert), harte Untergrenze der Gesamtmetriken = 80% des jeweils committeten Baselinewerts. distinctExpectedDocumentSets je Gruppe wurde am 2026-08-03 direkt aus eval/golden/comic-characters.json nachgerechnet (Korrektur: 94 statt der zuvor genannten 75 für 'overall' — die Zahl 75 aus einer früheren, ungeprüften Angabe war falsch). Aktualisierungsverfahren: eval/baseline/README.md."
 }

--- a/eval/baseline/comic-characters.json
+++ b/eval/baseline/comic-characters.json
@@ -1,0 +1,106 @@
+{
+  "measurementContractVersion": 1,
+  "fixedPoints": {
+    "embeddingModel": "nomic-embed-text:v1.5",
+    "embeddingModelDigest": "0a109f422b47e3a30ba2b10eca18548e944e8a23073ee3f3e947efcf3c45e59f",
+    "chunkSize": 1000,
+    "chunkSizeMatchesApplicationDefault": true,
+    "corpusManifestSha256": "cdfbdfeff23134ec93689256d5abf1477ff03dfa82c03c7cb03728e6704215a7",
+    "corpusDocumentCount": 1448,
+    "goldenDatasetFile": "eval/golden/comic-characters.json",
+    "goldenDatasetSha256": "20ceafc07afb77afc537cbf82d2441702f8c5e0fc033db1e62359292c03e8b23",
+    "goldenCaseCount": 121
+  },
+  "groups": {
+    "overall": {
+      "n": 121,
+      "hitRateAt5": 0.521,
+      "mrr": 0.461,
+      "ndcgAt10": 0.445,
+      "recallAt10": 0.490,
+      "recallAt10Ceiling": 0.9708
+    },
+    "category:attribute_lookup": {
+      "n": 30,
+      "hitRateAt5": 0.967,
+      "mrr": 0.933,
+      "ndcgAt10": 0.942,
+      "recallAt10": 0.967,
+      "recallAt10Ceiling": 1.0
+    },
+    "category:entity_description": {
+      "n": 20,
+      "hitRateAt5": 0.650,
+      "mrr": 0.518,
+      "ndcgAt10": 0.575,
+      "recallAt10": 0.750,
+      "recallAt10Ceiling": 1.0
+    },
+    "category:crosslingual": {
+      "n": 34,
+      "hitRateAt5": 0.382,
+      "mrr": 0.337,
+      "ndcgAt10": 0.302,
+      "recallAt10": 0.322,
+      "recallAt10Ceiling": 0.9666
+    },
+    "category:multi_attribute_filter": {
+      "n": 21,
+      "hitRateAt5": 0.238,
+      "mrr": 0.206,
+      "ndcgAt10": 0.137,
+      "recallAt10": 0.159,
+      "recallAt10Ceiling": 0.9331
+    },
+    "category:numeric_range": {
+      "n": 16,
+      "hitRateAt5": 0.188,
+      "mrr": 0.101,
+      "ndcgAt10": 0.063,
+      "recallAt10": 0.060,
+      "recallAt10Ceiling": 0.9382
+    },
+    "difficulty:easy": {
+      "n": 40,
+      "hitRateAt5": 0.950,
+      "mrr": 0.912,
+      "ndcgAt10": 0.922,
+      "recallAt10": 0.950,
+      "recallAt10Ceiling": 1.0
+    },
+    "difficulty:medium": {
+      "n": 48,
+      "hitRateAt5": 0.333,
+      "mrr": 0.253,
+      "ndcgAt10": 0.262,
+      "recallAt10": 0.335,
+      "recallAt10Ceiling": 0.9706
+    },
+    "difficulty:hard": {
+      "n": 33,
+      "hitRateAt5": 0.273,
+      "mrr": 0.216,
+      "ndcgAt10": 0.134,
+      "recallAt10": 0.157,
+      "recallAt10Ceiling": 0.9359
+    },
+    "language:en": {
+      "n": 87,
+      "hitRateAt5": 0.575,
+      "mrr": 0.509,
+      "ndcgAt10": 0.502,
+      "recallAt10": 0.555,
+      "recallAt10Ceiling": 0.9725
+    },
+    "language:de": {
+      "n": 34,
+      "hitRateAt5": 0.382,
+      "mrr": 0.337,
+      "ndcgAt10": 0.302,
+      "recallAt10": 0.322,
+      "recallAt10Ceiling": 0.9666
+    }
+  },
+  "measuredAt": "2026-08-03",
+  "notes": "Baseline aus PR #299 (Issue #228), gemessen mit dem gepinnten Modell nomic-embed-text:v1.5 (Digest siehe fixedPoints), Laufzeit 1004 s. Drei unabhängige Läufe (zwei des Autors, einer des Reviewers auf fremder Hardware) lieferten byte-identische Metriken — die HNSW-Approximationsschwankung, die ADR-0011 als Risiko benennt, tritt bei dieser Korpusgröße nicht auf. Frühere Berichte nannten einen Gesamt-nDCG@10 von 0.463; die stammen vom ungepinnten nomic-embed-text:latest und sind hinfällig — die Verschiebung durch das Pinning ist der empirische Beleg dafür, warum das Pinning nötig war. Aktualisierungsverfahren: eval/baseline/README.md."
+}

--- a/eval/baseline/diff_baseline.py
+++ b/eval/baseline/diff_baseline.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Diffs two committed retrieval baselines (eval/baseline/comic-characters.json) and renders a
+Markdown table of every metric that is lower on one side ("pr") than on the other ("main").
+
+Used by .github/workflows/retrieval-regression.yml (issue #228, ADR-0013 decision 6): the
+label-triggered run on a pull request compares the PR branch's own committed baseline against the
+one on `main`, so a PR that quietly lowers the baseline (making its own regression job pass
+against an already-weakened target) is visible in the PR comment instead of hidden behind a green
+check mark.
+
+This is purely informational and always exits 0 — it never fails the job by itself. The actual gate
+against an unjustified baseline lowering is the review procedure in eval/baseline/README.md; this
+script only makes a silent lowering visible to the reviewer, it does not replace their judgment.
+
+Stdlib-only, no dependency on the Java harness or Gradle build — same rationale as the corpus and
+golden-dataset generators under eval/generator/ (ADR-0011, decision 2).
+"""
+
+import argparse
+import json
+import sys
+
+METRICS = ("hitRateAt5", "mrr", "ndcgAt10", "recallAt10")
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def find_lowered(main_baseline, pr_baseline):
+    """Returns every (group, metric, main_value, pr_value) where pr_value < main_value."""
+    lowered = []
+    main_groups = main_baseline.get("groups", {})
+    pr_groups = pr_baseline.get("groups", {})
+    for group, pr_metrics in pr_groups.items():
+        main_metrics = main_groups.get(group)
+        if main_metrics is None:
+            # A group that only exists on the PR side (e.g. a golden-dataset extension) has
+            # nothing on main to be lower *than* — not a lowering, nothing to flag.
+            continue
+        for metric in METRICS:
+            main_value = main_metrics.get(metric)
+            pr_value = pr_metrics.get(metric)
+            if main_value is None or pr_value is None:
+                continue
+            if pr_value < main_value:
+                lowered.append((group, metric, main_value, pr_value))
+    return lowered
+
+
+def render(lowered, main_ref, pr_ref):
+    if not lowered:
+        return (
+            "### Baseline-Vergleich gegenüber `{main_ref}`\n\n"
+            "Keine Gruppe/Metrik in diesem PR-Branch (`{pr_ref}`) liegt unter dem auf "
+            "`{main_ref}` committeten Wert — keine stille Baseline-Absenkung erkennbar.\n"
+        ).format(main_ref=main_ref, pr_ref=pr_ref)
+
+    lines = [
+        "### Baseline-Vergleich gegenüber `{}`".format(main_ref),
+        "",
+        "**Achtung: {} Metrik(en) in diesem PR-Branch liegen unter dem auf `{}` committeten "
+        "Wert.** Das ist keine automatische Blockade — aber jede Absenkung muss im PR begründet "
+        "sein (siehe `eval/baseline/README.md`), sonst besteht der Regressionsjob künftiger PRs "
+        "nur noch gegen einen bereits abgesenkten Maßstab.".format(len(lowered), main_ref),
+        "",
+        "| Gruppe | Metrik | {} | {} | Differenz |".format(main_ref, pr_ref),
+        "|---|---|---|---|---|",
+    ]
+    for group, metric, main_value, pr_value in lowered:
+        lines.append(
+            "| {} | {} | {:.3f} | {:.3f} | {:+.3f} |".format(
+                group, metric, main_value, pr_value, pr_value - main_value
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main", required=True, help="Path to main's baseline JSON")
+    parser.add_argument("--pr", required=True, help="Path to the PR branch's baseline JSON")
+    parser.add_argument("--output", required=True, help="Markdown output file")
+    parser.add_argument("--main-ref", default="main")
+    parser.add_argument("--pr-ref", default="PR-Branch")
+    args = parser.parse_args(argv)
+
+    main_baseline = load(args.main)
+    pr_baseline = load(args.pr)
+    lowered = find_lowered(main_baseline, pr_baseline)
+    markdown = render(lowered, args.main_ref, args.pr_ref)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(markdown)
+
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Zusammenfassung

Führt den in #227 gebauten Retrieval-Harness als automatisierten CI-Job gegen eine committete Baseline (`eval/baseline/comic-characters.json`). Der Job vergleicht jeden Lauf über `io.opaa.eval.BaselineComparator` mit der Baseline und trennt dabei zwei Fragen bewusst voneinander:

1. **Ist die Baseline überhaupt noch gültig?** Fixpunkte (Korpus-Manifest, Golden-Dataset-Hash, Embedding-Modell-Digest, Chunk-Größe, Messvertrag-Version) werden exakt verglichen. Weicht auch nur einer ab, meldet der Job **"Baseline ungültig, Messgrundlage geändert"** und vergleicht keine einzige Metrik — das ist ausdrücklich keine Aussage über eine Retrieval-Regression.
2. **Nur wenn die Baseline gültig ist:** Jede Gruppe (gesamt, je Kategorie/Schwierigkeit/Sprache) wird gegen eine gruppenspezifische Toleranz geprüft, die vier Gesamtmetriken zusätzlich gegen eine baseline-unabhängige harte Untergrenze.

Die Ein-Chunk-Invariante (ADR-0010) bleibt ein harter, toleranzfreier Fehlschlag.

### Toleranzformel je Gruppe und Metrik

```
toleranz = min( max(0.12 · Baselinewert, 1 / n, 0.02), 0.05 )
```

Begründung (ausführlich in `eval/baseline/README.md`):

- Eine einzelne absolute Toleranz taugt nicht: 0,05 ist bei `attribute_lookup` (nDCG@10 0,942) Rauschen, bei `numeric_range` (nDCG@10 0,063) fast der gesamte Messwert.
- Eine einzelne relative Toleranz taugt ebenfalls nicht: Bei Werten nahe null kollabiert sie gegen null.
- Der `1/n`-Term sorgt dafür, dass **kleine** Gruppen (`numeric_range`, n=16) eine **größere**, nicht kleinere Toleranz bekommen — ein einzelner kippender Fall verschiebt eine 16er-Gruppe um bis zu 0,0625, eine 121er-Gruppe nur um 0,008.
- Absolute Unter- (0,02) und Obergrenze (0,05) verhindern Extreme an beiden Enden.
- So eng gewählt, **weil** drei unabhängige Läufe (zwei des Autors, einer des Reviewers auf fremder Hardware) byte-identische Metriken lieferten — die in ADR-0011 genannte HNSW-Approximationsschwankung tritt bei dieser Korpusgröße nicht auf. Eine weitere Toleranz würde bei nachgewiesener Stabilität keinen zusätzlichen Schutz kaufen, sondern nur echte Regressionen durchlassen.

Zusätzlich eine von der Baseline unabhängige harte Untergrenze für die vier **Gesamt**-Metriken (Hit@5 ≥ 0,30, MRR ≥ 0,25, nDCG@10 ≥ 0,25, Recall@10 ≥ 0,25) als zweites Fangnetz gegen katastrophales Versagen (z. B. leerer Vektor-Store), unabhängig von der Baseline-Datei selbst.

### Baseline

`eval/baseline/comic-characters.json`, gemessen am 2026-08-03 mit dem gepinnten Modell `nomic-embed-text:v1.5` (Digest `0a109f42…`), Laufzeit 1004 s, Gesamt-nDCG@10 0,445. Ein früherer Bericht nannte 0,463 — der stammte vom ungepinnten `:latest` und ist hinfällig; die Verschiebung durch das Pinning ist der empirische Beleg, warum das Pinning nötig war (siehe `eval/baseline/README.md`).

### Betrieb

- **Auslöser:** nächtlich auf `main` (Cron), `workflow_dispatch`, und Label `evaluation` an einem PR — bewusst **nicht** bei jedem PR (ADR-0011, Entscheidung 5).
- **Modell-Cache:** `actions/cache` rundet den Docker-Volume-Inhalt (`opaa-eval-ollama-models`) als Tar-Archiv über ephemere Runner hinweg — der Cache-Schlüssel ist an den gepinnten Modell-Digest gebunden, ein bewusster Re-Pin invalidiert ihn automatisch. Ohne das würde jeder nächtliche Lauf ~275 MB neu von `ollama.com` ziehen und gegen das netzfreie Betriebsversprechen aus ADR-0011 verstoßen.
- **Fehlschlag-Sichtbarkeit:** Bei Label-Auslösung wird die Delta-Tabelle als PR-Kommentar gepostet. Beim nächtlichen/manuellen Lauf legt ein Fehlschlag ein GitHub-Issue (Label `evaluation`, `bug`) an bzw. aktualisiert ein bestehendes; ein erneutes Bestehen schließt es automatisch mit Kommentar.
- **Baseline-Aktualisierung:** dokumentiert in `eval/baseline/README.md` — wer (wer auch immer die verursachende Änderung einreicht, im selben PR), womit begründet (ein tatsächlicher `evaluateRetrieval`-Lauf, Verlinkung/Anhang des Reports, explizite Begründung bei Verschlechterung).

### Verifikation ohne Docker

Da der reale Lauf Docker/Testcontainers braucht (~17 Min), wurde die Vergleichslogik lokal gegen synthetische Reports verifiziert (`checkRetrievalBaseline` mit temporär entferntem `dependsOn(evaluateRetrieval)`):

- Report == Baseline → **PASSED**, Delta-Tabelle zeigt `+0.000` überall.
- Künstliche Verschlechterung (`overall.hitRateAt5=0.30`, `ndcgAt10=0.20`) → **FAILED** mit `overall hitRateAt5 Baseline=0.521 Ist=0.300 Delta=-0.221 Toleranz=0.050 [TOLERANZ VERLETZT]` und zusätzlich `[UNTERGRENZE VERLETZT]` für nDCG.
- Manipulierter `corpusManifestSha256` → **FAILED** mit separater "Baseline ungültig"-Meldung samt Feld-Diff-Tabelle, keine Metrik verglichen.
- Künstliche Verbesserung → **PASSED** mit Hinweis, die Baseline-Aktualisierung zu prüfen.

## Zugehörige Issues

Closes #228

## Art der Änderung

- [ ] Bugfix
- [x] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (`./gradlew spotlessCheck build`, `evalUnitTest` inkl. neuer `BaselineComparatorTest`; Frontend unverändert, `format:check`/`lint`/`test`/`build` zur Sicherheit trotzdem grün)
- [ ] Bei Bugfix: Reproduktionsnachweis erbracht
- [x] Dokumentation aktualisiert (`eval/README.md`, `eval/baseline/README.md`, `CONTRIBUTING.md`)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits vom Maintainer/Betreiber unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code / QA Engineer, Sonnet 5)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst