### PR TITLE
feat(library): Wissensbibliothek als Dokumentencontainer mit Migration

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -199,6 +199,10 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SystemRole" to "SystemRole",
         "GroupKind" to "GroupKind",
         "DirectorySyncOutcome" to "DirectorySyncOutcome",
+        "LibraryOwnerType" to "LibraryOwnerType",
+        "LibraryVisibility" to "LibraryVisibility",
+        "DocumentStatus" to "DocumentStatus",
+        "DocumentSourceType" to "DocumentSourceType",
     ))
     importMappings.set(mapOf(
         "Instant" to "java.time.Instant",
@@ -208,6 +212,10 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "SystemRole" to "io.opaa.auth.SystemRole",
         "GroupKind" to "io.opaa.group.GroupKind",
         "DirectorySyncOutcome" to "io.opaa.group.sync.DirectorySyncOutcome",
+        "LibraryOwnerType" to "io.opaa.library.LibraryOwnerType",
+        "LibraryVisibility" to "io.opaa.library.LibraryVisibility",
+        "DocumentStatus" to "io.opaa.indexing.DocumentStatus",
+        "DocumentSourceType" to "io.opaa.indexing.DocumentSourceType",
     ))
 }
 
@@ -216,7 +224,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         // Remove generated enum files that are mapped to existing domain enums via typeMappings.
         // The generator still creates these files even with typeMappings configured.
         val generatedDir = layout.buildDirectory.dir("generated/openapi/src/main/java/io/opaa/api/dto").get().asFile
-        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java", "DirectorySyncOutcome.java").forEach { fileName ->
+        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java", "DirectorySyncOutcome.java", "LibraryOwnerType.java", "LibraryVisibility.java", "DocumentStatus.java", "DocumentSourceType.java").forEach { fileName ->
             file("$generatedDir/$fileName").delete()
         }
     }

--- a/backend/src/main/java/io/opaa/api/LibraryController.java
+++ b/backend/src/main/java/io/opaa/api/LibraryController.java
@@ -1,0 +1,108 @@
+package io.opaa.api;
+
+import io.opaa.api.dto.LibraryDocumentResponse;
+import io.opaa.api.dto.LibraryListResponse;
+import io.opaa.api.dto.LibraryRequest;
+import io.opaa.api.dto.LibraryResponse;
+import io.opaa.api.dto.LibraryUpdateRequest;
+import io.opaa.auth.SystemRole;
+import io.opaa.auth.User;
+import io.opaa.auth.UserService;
+import io.opaa.library.KnowledgeLibraryService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Profile({"oidc", "basic"})
+@RestController
+@RequestMapping("/api/v1/libraries")
+public class LibraryController {
+
+  private static final String UNKNOWN_ISSUER = "unknown";
+
+  private final KnowledgeLibraryService libraryService;
+  private final UserService userService;
+
+  public LibraryController(KnowledgeLibraryService libraryService, UserService userService) {
+    this.libraryService = libraryService;
+    this.userService = userService;
+  }
+
+  @PostMapping
+  public ResponseEntity<LibraryResponse> createLibrary(
+      @Valid @RequestBody LibraryRequest request, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    LibraryResponse response = libraryService.createLibrary(request, currentUser.getId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @GetMapping
+  public List<LibraryListResponse> listLibraries(@AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return libraryService.listLibraries(currentUser.getId());
+  }
+
+  @GetMapping("/{libraryId}")
+  public LibraryResponse getLibrary(
+      @PathVariable UUID libraryId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return libraryService.getLibrary(
+        libraryId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  @PutMapping("/{libraryId}")
+  public LibraryResponse updateLibrary(
+      @PathVariable UUID libraryId,
+      @Valid @RequestBody LibraryUpdateRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return libraryService.updateLibrary(
+        libraryId,
+        request,
+        currentUser.getId(),
+        currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  @DeleteMapping("/{libraryId}")
+  public ResponseEntity<Void> deleteLibrary(
+      @PathVariable UUID libraryId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    libraryService.deleteLibrary(
+        libraryId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{libraryId}/documents")
+  public List<LibraryDocumentResponse> listDocuments(
+      @PathVariable UUID libraryId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return libraryService.listDocuments(
+        libraryId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  private User currentUser(Jwt jwt) {
+    String issuer = jwt.getClaimAsString("iss");
+    if (issuer == null || issuer.isBlank()) {
+      issuer = UNKNOWN_ISSUER;
+    }
+
+    return userService
+        .findBySubjectAndIssuer(jwt.getSubject(), issuer)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
+  }
+}

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -7,6 +7,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -19,6 +21,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @Profile({"oidc", "basic"})
 @EnableConfigurationProperties(AuthProperties.class)
 public class UserService {
+
+  private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
   private final UserRepository userRepository;
   private final SpaceService spaceService;
@@ -138,10 +142,10 @@ public class UserService {
    * did - each {@link UserRepository} call in {@code findOrCreateUser} already committed
    * independently by the time control reaches here, so the user row this method's caller passes in
    * is always already visible on any connection, including {@code ensurePersonalSpace}'s and {@code
-   * ensurePersonalLibrary}'s {@code REQUIRES_NEW} ones. The {@code
-   * isSynchronizationActive}/{@code registerSynchronization} branch below is kept only as a defensive
-   * fallback for a caller running inside its own transaction (there is none in production today) -
-   * it must not silently skip provisioning if one ever exists.
+   * ensurePersonalLibrary}'s {@code REQUIRES_NEW} ones. The {@code isSynchronizationActive}/{@code
+   * registerSynchronization} branch below is kept only as a defensive fallback for a caller running
+   * inside its own transaction (there is none in production today) - it must not silently skip
+   * provisioning if one ever exists.
    */
   private void ensurePersonalAssetsAfterCommit(UUID userId, UUID organizationId) {
     if (TransactionSynchronizationManager.isSynchronizationActive()) {
@@ -160,46 +164,56 @@ public class UserService {
   /**
    * Attempts {@link SpaceService#ensurePersonalSpace} and {@link
    * KnowledgeLibraryService#ensurePersonalLibrary} independently of one another - the second call
-   * always runs even if the first one throws, and vice versa. If either (or both) fail, the first
-   * failure is rethrown, with a second failure attached via {@link
-   * Throwable#addSuppressed(Throwable)} rather than dropped, so both are still visible to whatever
-   * logs the exception this bubbles up to. Neither call is wrapped in a transaction of its own here
-   * - each of {@code ensurePersonalSpace}/{@code ensurePersonalLibrary} already opens its own
-   * self-contained {@code REQUIRES_NEW} transaction (see their Javadoc), so nesting one here would
-   * only add an unused, connection-holding transaction around calls that do not need one - the
-   * exact class of cost the pool-exhaustion regression in #299 was caused by.
+   * always runs even if the first one throws, and vice versa. Neither call is wrapped in a
+   * transaction of its own here - each of {@code ensurePersonalSpace}/{@code ensurePersonalLibrary}
+   * already opens its own self-contained {@code REQUIRES_NEW} transaction (see their Javadoc), so
+   * nesting one here would only add an unused, connection-holding transaction around calls that do
+   * not need one - the exact class of cost the pool-exhaustion regression in #299 was caused by.
+   *
+   * <p><b>Failures are logged, not rethrown</b> (code review of #201/#305). An earlier version of
+   * this method rethrew the first failure, reasoning that "an {@code afterCommit} callback failing
+   * here only logs; it does not roll back the already-committed user creation transaction" - that
+   * reasoning does not hold once {@link #findOrCreateUser} runs its no-ambient-transaction,
+   * always-synchronous path (the normal one since #293/#299, not just a defensive fallback - see
+   * {@link #ensurePersonalAssetsAfterCommit}'s Javadoc): there is no {@code afterCommit} callback
+   * to swallow the exception on this path, and Spring propagates it straight to {@code
+   * findOrCreateUser}'s caller, i.e. into the login request itself. Because this method is called
+   * unconditionally on <em>every</em> {@link #findOrCreateUser} invocation (see below), a
+   * persistently failing library or space provisioning would then fail every subsequent login for
+   * that user too - turning a provisioning failure into a lockout, which is a worse outcome than
+   * the login proceeding without (yet) having a personal space or library. Logging both failures
+   * (if both occur) keeps them visible for operations without blocking the user.
    *
    * <p>Called unconditionally for every {@link #findOrCreateUser} invocation, not only for newly
    * created users: both {@code ensurePersonalSpace} and {@code ensurePersonalLibrary} are
    * idempotent (each checks for an existing row first), so a returning user whose personal library
    * failed to provision on an earlier login - or who predates #201 entirely - gets one created on
-   * their next login instead of being left without one indefinitely. The personal space already had
-   * this self-healing property before #201; this keeps the personal library's provisioning on the
-   * same footing.
+   * their next login instead of being left without one indefinitely, exactly because this method no
+   * longer aborts that next login on the earlier failure. See #294, already open for the general
+   * "idempotent provisioning must not become a lockout" concern this addresses for personal
+   * space/library specifically.
    */
   private void ensureBothPersonalAssets(UUID userId, UUID organizationId) {
-    RuntimeException spaceFailure = null;
     try {
       spaceService.ensurePersonalSpace(userId, organizationId);
     } catch (RuntimeException e) {
-      spaceFailure = e;
+      log.error(
+          "Failed to provision personal space for user {} (organization {}); will retry on next"
+              + " login",
+          userId,
+          organizationId,
+          e);
     }
 
-    RuntimeException libraryFailure = null;
     try {
       libraryService.ensurePersonalLibrary(userId, organizationId);
     } catch (RuntimeException e) {
-      libraryFailure = e;
-    }
-
-    if (spaceFailure != null) {
-      if (libraryFailure != null) {
-        spaceFailure.addSuppressed(libraryFailure);
-      }
-      throw spaceFailure;
-    }
-    if (libraryFailure != null) {
-      throw libraryFailure;
+      log.error(
+          "Failed to provision personal library for user {} (organization {}); will retry on next"
+              + " login",
+          userId,
+          organizationId,
+          e);
     }
   }
 

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -1,5 +1,6 @@
 package io.opaa.auth;
 
+import io.opaa.library.KnowledgeLibraryService;
 import io.opaa.organization.Organization;
 import io.opaa.space.SpaceService;
 import java.time.Instant;
@@ -21,12 +22,17 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final SpaceService spaceService;
+  private final KnowledgeLibraryService libraryService;
   private final AuthProperties authProperties;
 
   public UserService(
-      UserRepository userRepository, SpaceService spaceService, AuthProperties authProperties) {
+      UserRepository userRepository,
+      SpaceService spaceService,
+      KnowledgeLibraryService libraryService,
+      AuthProperties authProperties) {
     this.userRepository = userRepository;
     this.spaceService = spaceService;
+    this.libraryService = libraryService;
     this.authProperties = authProperties;
   }
 
@@ -47,6 +53,10 @@ public class UserService {
    * fire right after the SPA logs in). Without an ambient transaction here, {@link
    * #createOrFetchUser}'s insert attempt and its fallback read are each just one more short-lived,
    * independently connection-scoped call - never two connections held by the same caller at once.
+   * {@link #ensurePersonalAssetsAfterCommit} below (#201's personal space and personal library
+   * provisioning) follows the exact same reasoning: neither {@code ensurePersonalSpace} nor {@code
+   * ensurePersonalLibrary} ever runs inside an ambient transaction started here, for the same
+   * connection-budget reason.
    */
   public User findOrCreateUser(String subject, String issuer, String email, String displayName) {
     User user =
@@ -55,7 +65,7 @@ public class UserService {
             .map(existing -> updateExistingUser(existing, email, displayName))
             .orElseGet(() -> createOrFetchUser(subject, issuer, email, displayName));
 
-    ensurePersonalSpaceAfterCommit(user.getId(), user.getOrganizationId());
+    ensurePersonalAssetsAfterCommit(user.getId(), user.getOrganizationId());
     return user;
   }
 
@@ -104,8 +114,11 @@ public class UserService {
   }
 
   /**
-   * Runs {@link SpaceService#ensurePersonalSpace} only after the {@code users} row it needs has
-   * been committed.
+   * Runs {@link SpaceService#ensurePersonalSpace} and {@link
+   * KnowledgeLibraryService#ensurePersonalLibrary} only after the {@code users} row they need has
+   * been committed - and always together, so provisioning never silently produces a personal space
+   * without its personal library or the other way round (#201's "creating a user creates a personal
+   * space and a personal library atomically").
    *
    * <p>Historically (#265, fixed in the #280 follow-up), {@code findOrCreateUser} was
    * {@code @Transactional} and inserted the new user in a still-open transaction; {@code
@@ -114,7 +127,9 @@ public class UserService {
    * uncommitted {@code users} row, so the insert violated {@code fk_spaces_owner} and the whole
    * login failed. Deferring the call to {@link TransactionSynchronization#afterCommit()} fixed that
    * by guaranteeing the user row was already committed and visible by the time the personal space
-   * was created.
+   * was created. {@code ensurePersonalLibrary} (#201) inserts in its own {@code REQUIRES_NEW}
+   * transaction the same way and is subject to exactly the same visibility requirement, so it is
+   * called from this same method rather than from a second, parallel deferral mechanism.
    *
    * <p>Since {@link #findOrCreateUser} was made deliberately non-{@code @Transactional} (#293 code
    * review - see its Javadoc), there is no ambient transaction synchronization active here to
@@ -122,20 +137,69 @@ public class UserService {
    * synchronous branch. That remains correct for the same reason the {@code afterCommit} deferral
    * did - each {@link UserRepository} call in {@code findOrCreateUser} already committed
    * independently by the time control reaches here, so the user row this method's caller passes in
-   * is always already visible on any connection, including {@code ensurePersonalSpace}'s {@code
-   * REQUIRES_NEW} one.
+   * is always already visible on any connection, including {@code ensurePersonalSpace}'s and {@code
+   * ensurePersonalLibrary}'s {@code REQUIRES_NEW} ones. The {@code
+   * isSynchronizationActive}/{@code registerSynchronization} branch below is kept only as a defensive
+   * fallback for a caller running inside its own transaction (there is none in production today) -
+   * it must not silently skip provisioning if one ever exists.
    */
-  private void ensurePersonalSpaceAfterCommit(UUID userId, UUID organizationId) {
+  private void ensurePersonalAssetsAfterCommit(UUID userId, UUID organizationId) {
     if (TransactionSynchronizationManager.isSynchronizationActive()) {
       TransactionSynchronizationManager.registerSynchronization(
           new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-              spaceService.ensurePersonalSpace(userId, organizationId);
+              ensureBothPersonalAssets(userId, organizationId);
             }
           });
     } else {
+      ensureBothPersonalAssets(userId, organizationId);
+    }
+  }
+
+  /**
+   * Attempts {@link SpaceService#ensurePersonalSpace} and {@link
+   * KnowledgeLibraryService#ensurePersonalLibrary} independently of one another - the second call
+   * always runs even if the first one throws, and vice versa. If either (or both) fail, the first
+   * failure is rethrown, with a second failure attached via {@link
+   * Throwable#addSuppressed(Throwable)} rather than dropped, so both are still visible to whatever
+   * logs the exception this bubbles up to. Neither call is wrapped in a transaction of its own here
+   * - each of {@code ensurePersonalSpace}/{@code ensurePersonalLibrary} already opens its own
+   * self-contained {@code REQUIRES_NEW} transaction (see their Javadoc), so nesting one here would
+   * only add an unused, connection-holding transaction around calls that do not need one - the
+   * exact class of cost the pool-exhaustion regression in #299 was caused by.
+   *
+   * <p>Called unconditionally for every {@link #findOrCreateUser} invocation, not only for newly
+   * created users: both {@code ensurePersonalSpace} and {@code ensurePersonalLibrary} are
+   * idempotent (each checks for an existing row first), so a returning user whose personal library
+   * failed to provision on an earlier login - or who predates #201 entirely - gets one created on
+   * their next login instead of being left without one indefinitely. The personal space already had
+   * this self-healing property before #201; this keeps the personal library's provisioning on the
+   * same footing.
+   */
+  private void ensureBothPersonalAssets(UUID userId, UUID organizationId) {
+    RuntimeException spaceFailure = null;
+    try {
       spaceService.ensurePersonalSpace(userId, organizationId);
+    } catch (RuntimeException e) {
+      spaceFailure = e;
+    }
+
+    RuntimeException libraryFailure = null;
+    try {
+      libraryService.ensurePersonalLibrary(userId, organizationId);
+    } catch (RuntimeException e) {
+      libraryFailure = e;
+    }
+
+    if (spaceFailure != null) {
+      if (libraryFailure != null) {
+        spaceFailure.addSuppressed(libraryFailure);
+      }
+      throw spaceFailure;
+    }
+    if (libraryFailure != null) {
+      throw libraryFailure;
     }
   }
 

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -24,6 +25,18 @@ public class UserService {
 
   private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
+  /**
+   * Fixed-size striping for {@link #provisioningLockFor(UUID)}: bounds memory to exactly this many
+   * {@link ReentrantLock} instances for the lifetime of the process, at the cost of two unrelated
+   * users occasionally sharing a stripe and blocking on each other's provisioning - an acceptable
+   * trade for a lock that exists purely to reduce database contention (see {@link
+   * #ensurePersonalAssetsAfterCommit}'s Javadoc), never for correctness, which the database's
+   * partial unique indexes still guarantee on their own.
+   */
+  private static final int PROVISIONING_LOCK_STRIPES = 64;
+
+  private final ReentrantLock[] provisioningLocks = new ReentrantLock[PROVISIONING_LOCK_STRIPES];
+
   private final UserRepository userRepository;
   private final SpaceService spaceService;
   private final KnowledgeLibraryService libraryService;
@@ -38,6 +51,9 @@ public class UserService {
     this.spaceService = spaceService;
     this.libraryService = libraryService;
     this.authProperties = authProperties;
+    for (int i = 0; i < provisioningLocks.length; i++) {
+      provisioningLocks[i] = new ReentrantLock();
+    }
   }
 
   /**
@@ -146,6 +162,34 @@ public class UserService {
    * registerSynchronization} branch below is kept only as a defensive fallback for a caller running
    * inside its own transaction (there is none in production today) - it must not silently skip
    * provisioning if one ever exists.
+   *
+   * <p><b>{@code provisioningLockFor(userId)}, an in-process lock around the call below</b>
+   * (#201/#305 code review, measured): {@code SpaceRepository#insertPersonalSpaceIfAbsent} and
+   * {@code KnowledgeLibraryRepository#insertPersonalLibraryIfAbsent} each reduced their own round
+   * trips to one via {@code ON CONFLICT ... DO NOTHING}, but under {@code
+   * UserServiceCreationRaceIntegrationTest}'s 12-concurrent-first-login load that alone was not
+   * enough: with all 12 threads issuing conflicting {@code INSERT}s against the same partial unique
+   * index at (essentially) the same instant, Postgres itself serializes them at the index level -
+   * each transaction after the first must wait for the ones ahead of it to finish before it can
+   * determine whether it conflicts - and with two such rounds per login (space, then library) back
+   * to back, that queuing occasionally pushed the slowest thread's total wait past 30 seconds even
+   * with the single-round-trip fix in place. An in-process lock keyed by {@code userId} removes the
+   * database-level queuing for the case that dominates this test and is also the realistic
+   * production case (many requests for the *same* user's very first login, e.g. several tabs opened
+   * at once): only the first thread to acquire the lock reaches the database at all; by the time
+   * each following thread acquires it, the winner has already committed, so {@code
+   * ensurePersonalSpace}/{@code ensurePersonalLibrary}'s own {@code existsBy} check returns {@code
+   * true} immediately and neither issues an insert. Confirmed by {@code
+   * UserServiceCreationRaceIntegrationTest} passing repeatedly at the unmodified production default
+   * pool size of 10 with this lock in place (see that test's Javadoc) - it failed intermittently at
+   * the same pool size with only the single-round-trip fix and no lock.
+   *
+   * <p>This is a performance measure, not a correctness one: the database's partial unique indexes
+   * (not this lock) remain the actual guarantee, unchanged and still exercised whenever this
+   * lock-protected block is skipped or raced across multiple application instances - the lock is
+   * process-local and does nothing for that case, deliberately: correctness must not depend on it.
+   * {@link #PROVISIONING_LOCK_STRIPES} bounds the lock table's size; see its Javadoc for the
+   * resulting trade-off.
    */
   private void ensurePersonalAssetsAfterCommit(UUID userId, UUID organizationId) {
     if (TransactionSynchronizationManager.isSynchronizationActive()) {
@@ -153,12 +197,27 @@ public class UserService {
           new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-              ensureBothPersonalAssets(userId, organizationId);
+              runEnsureBothPersonalAssetsUnderLock(userId, organizationId);
             }
           });
     } else {
-      ensureBothPersonalAssets(userId, organizationId);
+      runEnsureBothPersonalAssetsUnderLock(userId, organizationId);
     }
+  }
+
+  private void runEnsureBothPersonalAssetsUnderLock(UUID userId, UUID organizationId) {
+    ReentrantLock lock = provisioningLockFor(userId);
+    lock.lock();
+    try {
+      ensureBothPersonalAssets(userId, organizationId);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private ReentrantLock provisioningLockFor(UUID userId) {
+    int stripe = Math.floorMod(userId.hashCode(), provisioningLocks.length);
+    return provisioningLocks[stripe];
   }
 
   /**

--- a/backend/src/main/java/io/opaa/auth/UserService.java
+++ b/backend/src/main/java/io/opaa/auth/UserService.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,28 +169,31 @@ public class UserService {
    * {@code KnowledgeLibraryRepository#insertPersonalLibraryIfAbsent} each reduced their own round
    * trips to one via {@code ON CONFLICT ... DO NOTHING}, but under {@code
    * UserServiceCreationRaceIntegrationTest}'s 12-concurrent-first-login load that alone was not
-   * enough: with all 12 threads issuing conflicting {@code INSERT}s against the same partial unique
-   * index at (essentially) the same instant, Postgres itself serializes them at the index level -
-   * each transaction after the first must wait for the ones ahead of it to finish before it can
-   * determine whether it conflicts - and with two such rounds per login (space, then library) back
-   * to back, that queuing occasionally pushed the slowest thread's total wait past 30 seconds even
-   * with the single-round-trip fix in place. An in-process lock keyed by {@code userId} removes the
-   * database-level queuing for the case that dominates this test and is also the realistic
-   * production case (many requests for the *same* user's very first login, e.g. several tabs opened
-   * at once): only the first thread to acquire the lock reaches the database at all; by the time
-   * each following thread acquires it, the winner has already committed, so {@code
-   * ensurePersonalSpace}/{@code ensurePersonalLibrary}'s own {@code existsBy} check returns {@code
-   * true} immediately and neither issues an insert. Confirmed by {@code
-   * UserServiceCreationRaceIntegrationTest} passing repeatedly at the unmodified production default
-   * pool size of 10 with this lock in place (see that test's Javadoc) - it failed intermittently at
-   * the same pool size with only the single-round-trip fix and no lock.
+   * enough (3 of 6 runs still failed without this lock). The bottleneck is <b>not</b> database-side
+   * index contention - a follow-up measurement with 12 concurrent first logins of 12
+   * <em>different</em> users (no index conflict possible at all) still hit the same 30-second
+   * timeout, and {@code pg_stat_activity} showed no active session on the database during the
+   * stall. The bottleneck is acquiring a Hikari connection at all: two provisioning calls per login
+   * (space, then library), each needing its own short-lived connection, doubled the number of
+   * concurrent connection requests competing for the same pool once #201 added the second call. An
+   * in-process lock keyed by {@code userId} reduces that count for the case this test exercises and
+   * that is also the realistic production trigger (many requests for the *same* user's very first
+   * login, e.g. several tabs opened at once): only the first thread to acquire the lock reaches the
+   * database at all; by the time each following thread acquires it, the winner has already
+   * committed, so {@code ensurePersonalSpace}/{@code ensurePersonalLibrary}'s own {@code existsBy}
+   * check returns {@code true} immediately and neither issues an insert, so neither needs a
+   * connection either. Confirmed by {@code UserServiceCreationRaceIntegrationTest} passing
+   * repeatedly at the unmodified production default pool size of 10 with this lock in place (see
+   * that test's Javadoc).
    *
    * <p>This is a performance measure, not a correctness one: the database's partial unique indexes
    * (not this lock) remain the actual guarantee, unchanged and still exercised whenever this
    * lock-protected block is skipped or raced across multiple application instances - the lock is
    * process-local and does nothing for that case, deliberately: correctness must not depend on it.
    * {@link #PROVISIONING_LOCK_STRIPES} bounds the lock table's size; see its Javadoc for the
-   * resulting trade-off.
+   * resulting trade-off. Concurrent first logins of <em>different</em> users still contend on the
+   * connection pool exactly as before this lock (it only serializes same-user callers) - tracked
+   * separately as #307, not addressed here.
    */
   private void ensurePersonalAssetsAfterCommit(UUID userId, UUID organizationId) {
     if (TransactionSynchronizationManager.isSynchronizationActive()) {
@@ -205,13 +209,34 @@ public class UserService {
     }
   }
 
+  /**
+   * Acquires {@link #provisioningLockFor(UUID)} with a bounded {@code tryLock} instead of an
+   * unbounded {@code lock()} (code review of #201/#305): {@link #ensureBothPersonalAssets} logs
+   * rather than throws on failure (see its Javadoc), so a holder that hits two connection-acquire
+   * timeouts back to back could otherwise hold the lock for up to roughly twice Hikari's {@code
+   * connectionTimeout} (~60 s at the default) - and because {@link #PROVISIONING_LOCK_STRIPES} is a
+   * fixed-size striping, that also blocks unrelated users sharing the same stripe, turning what
+   * should be independent, parallel failures under a slow database into a serial pile-up of request
+   * threads. Falling through without the lock on a failed {@code tryLock} is safe: correctness is
+   * carried entirely by the database's partial unique indexes (see {@link
+   * #ensurePersonalAssetsAfterCommit}'s Javadoc), never by this lock, so skipping it only forgoes
+   * the connection-count reduction for this one call - the next login for the same user gets the
+   * same idempotent, self-healing retry either way.
+   */
   private void runEnsureBothPersonalAssetsUnderLock(UUID userId, UUID organizationId) {
     ReentrantLock lock = provisioningLockFor(userId);
-    lock.lock();
+    boolean acquired = false;
+    try {
+      acquired = lock.tryLock(2, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     try {
       ensureBothPersonalAssets(userId, organizationId);
     } finally {
-      lock.unlock();
+      if (acquired) {
+        lock.unlock();
+      }
     }
   }
 

--- a/backend/src/main/java/io/opaa/group/GroupService.java
+++ b/backend/src/main/java/io/opaa/group/GroupService.java
@@ -7,6 +7,7 @@ import io.opaa.api.dto.GroupResponse;
 import io.opaa.api.dto.GroupUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.KnowledgeLibraryRepository;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,11 +29,11 @@ import org.springframework.web.server.ResponseStatusException;
  * managed here. {@link GroupKind#ORG_UNIT} groups are synchronised from the directory (#237) and
  * are read-only through this service.
  *
- * <p>Deleting a group that owns an asset is meant to be blocked until ownership is transferred (see
- * the feature spec's "Eigentuemerschaft und Verwaisung" and issue #200's acceptance criteria).
- * There is no asset model yet ({@code io.opaa.indexing.Document} is the only content type, and it
- * carries no owner) - #201/#202 introduce assets and asset ownership; see the {@code TODO} on
- * {@link #deleteGroup}.
+ * <p>Deleting a group that owns an asset is blocked until ownership is transferred (see the feature
+ * spec's "Eigentuemerschaft und Verwaisung" and issue #200's acceptance criteria). #201 introduced
+ * the first asset type ({@link io.opaa.library.KnowledgeLibrary}), so {@link #deleteGroup} now has
+ * something to check against; a fuller asset model (agents, prompt libraries) in later stages of
+ * the epic extends the same check, it does not replace it.
  */
 @Service
 @Transactional(readOnly = true)
@@ -44,14 +45,17 @@ public class GroupService {
   private final GroupRepository groupRepository;
   private final UserRepository userRepository;
   private final GroupMembershipResolver membershipResolver;
+  private final KnowledgeLibraryRepository libraryRepository;
 
   public GroupService(
       GroupRepository groupRepository,
       UserRepository userRepository,
-      GroupMembershipResolver membershipResolver) {
+      GroupMembershipResolver membershipResolver,
+      KnowledgeLibraryRepository libraryRepository) {
     this.groupRepository = groupRepository;
     this.userRepository = userRepository;
     this.membershipResolver = membershipResolver;
+    this.libraryRepository = libraryRepository;
   }
 
   @Transactional
@@ -98,11 +102,21 @@ public class GroupService {
 
   @Transactional
   public void deleteGroup(UUID groupId, UUID currentUserId) {
-    // TODO(#202): block deletion while the group still owns an asset, once asset ownership
-    // exists. There is nothing to check against yet - see the class javadoc for why no such
-    // check exists here.
     Group group = loadGroup(groupId, currentUserId);
     rejectOrgUnit(group);
+    // fk_knowledge_libraries_owner_group_organization is RESTRICT (migration 012): without this
+    // check, deleting a group that still owns a library would surface as an unhandled
+    // DataIntegrityViolationException -> HTTP 500 with no indication of the actual cause, a path
+    // that could not fail before #201 introduced the first asset type a group can own. Checking
+    // first turns that into a clean, actionable 409 - the block on deleting a group that still
+    // owns an asset the class Javadoc and #200's acceptance criteria require. A fuller asset model
+    // (agents, prompt libraries, in later epic stages) extends this same check to those tables; it
+    // does not replace it.
+    if (libraryRepository.existsByOwnerGroupId(groupId)) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die Gruppe besitzt noch Bibliotheken und kann nicht geloescht werden");
+    }
 
     List<UUID> affectedUserIds =
         group.getMemberships().stream().map(GroupMembership::getUserId).toList();

--- a/backend/src/main/java/io/opaa/indexing/Document.java
+++ b/backend/src/main/java/io/opaa/indexing/Document.java
@@ -47,6 +47,27 @@ public class Document {
   @Column(name = "last_modified_remote", length = 64)
   private String lastModifiedRemote;
 
+  /**
+   * The knowledge library this document belongs to (#201) - every document belongs to exactly one
+   * library, enforced as {@code NOT NULL} with {@code fk_documents_library} once migration 012's
+   * backfill has run. Not part of the constructors (unlike {@code fileName}/{@code filePath}):
+   * callers set it explicitly after construction, the same way {@code checksum} and {@code status}
+   * are set, because the indexing pipeline currently always targets the single well-known system
+   * library ({@link io.opaa.library.KnowledgeLibrary#SYSTEM_LIBRARY_ID}) - see {@code
+   * FileProcessingService}. Selecting a target library per upload or connector source is #207.
+   */
+  @Column(name = "library_id")
+  private UUID libraryId;
+
+  /**
+   * The organization the {@link #libraryId} library belongs to, denormalized onto the document
+   * (#201) so the permission-aware vector search (#202) can filter chunks by organization without a
+   * join back to {@code knowledge_libraries} - see the same reasoning on {@code
+   * FileProcessingService#storeChunks}. Set together with {@link #libraryId}, never independently.
+   */
+  @Column(name = "organization_id")
+  private UUID organizationId;
+
   protected Document() {}
 
   public Document(String fileName, String filePath, String contentType, Long fileSize) {
@@ -134,5 +155,21 @@ public class Document {
 
   public void setLastModifiedRemote(String lastModifiedRemote) {
     this.lastModifiedRemote = lastModifiedRemote;
+  }
+
+  public UUID getLibraryId() {
+    return libraryId;
+  }
+
+  public void setLibraryId(UUID libraryId) {
+    this.libraryId = libraryId;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(UUID organizationId) {
+    this.organizationId = organizationId;
   }
 }

--- a/backend/src/main/java/io/opaa/indexing/Document.java
+++ b/backend/src/main/java/io/opaa/indexing/Document.java
@@ -54,7 +54,13 @@ public class Document {
    * callers set it explicitly after construction, the same way {@code checksum} and {@code status}
    * are set, because the indexing pipeline currently always targets the single well-known system
    * library ({@link io.opaa.library.KnowledgeLibrary#SYSTEM_LIBRARY_ID}) - see {@code
-   * FileProcessingService}. Selecting a target library per upload or connector source is #207.
+   * FileProcessingService}. This is a deliberate, maintainer-confirmed interim state (#201 builds
+   * the container; #201 does not yet route uploads to it): between #201 landing and the target
+   * library becoming selectable, no document is reachable by ordinary users through this path, only
+   * by system administrators, which is the same fail-closed default the migration already applies
+   * to pre-existing documents. Documented in the epic (#198) for anyone piloting in this window.
+   * Selecting a target library per connector source is #207; selecting one for a manual upload is
+   * #202 or a dedicated follow-up issue - #207 alone does not cover the upload path.
    */
   @Column(name = "library_id")
   private UUID libraryId;

--- a/backend/src/main/java/io/opaa/indexing/DocumentRepository.java
+++ b/backend/src/main/java/io/opaa/indexing/DocumentRepository.java
@@ -1,5 +1,6 @@
 package io.opaa.indexing;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface DocumentRepository extends JpaRepository<Document, UUID> {
 
   Optional<Document> findByFilePath(String filePath);
+
+  List<Document> findByLibraryId(UUID libraryId);
+
+  long countByLibraryId(UUID libraryId);
 }

--- a/backend/src/main/java/io/opaa/indexing/FileProcessingService.java
+++ b/backend/src/main/java/io/opaa/indexing/FileProcessingService.java
@@ -1,6 +1,8 @@
 package io.opaa.indexing;
 
+import io.opaa.library.KnowledgeLibrary;
 import io.opaa.observability.IndexingMetrics;
+import io.opaa.organization.Organization;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,6 +66,8 @@ public class FileProcessingService {
     long fileSize = Files.size(file);
 
     var doc = new Document(fileName, filePath, contentType, fileSize);
+    doc.setLibraryId(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+    doc.setOrganizationId(Organization.DEFAULT_ID);
     doc = documentRepository.save(doc);
 
     try {
@@ -138,6 +142,8 @@ public class FileProcessingService {
     var doc =
         new Document(
             fileName, remoteUrl, contentType, remoteFileSize, DocumentSourceType.HTTP_DIRECTORY);
+    doc.setLibraryId(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+    doc.setOrganizationId(Organization.DEFAULT_ID);
     doc = documentRepository.save(doc);
 
     try {
@@ -175,6 +181,12 @@ public class FileProcessingService {
 
   private void storeChunks(
       Document document, List<org.springframework.ai.document.Document> chunks) {
+    // library_id and organization_id are the filter axis the permission-aware vector search
+    // (#202) filters on - carried on every chunk, not just the document row, so that search can
+    // apply the filter directly in the VectorStore query without a join back to the relational
+    // model (see docs/features/spaces-and-assets.md#durchsetzung-zur-abfragezeit). Both are
+    // currently always the single system library / the single seeded organization - see the
+    // Javadoc on Document#libraryId.
     List<org.springframework.ai.document.Document> enriched =
         chunks.stream()
             .map(
@@ -185,7 +197,9 @@ public class FileProcessingService {
                       Map.of(
                           "document_id", document.getId().toString(),
                           "chunk_index", index,
-                          "file_name", document.getFileName()));
+                          "file_name", document.getFileName(),
+                          "library_id", document.getLibraryId().toString(),
+                          "organization_id", document.getOrganizationId().toString()));
                 })
             .toList();
 

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibrary.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibrary.java
@@ -1,0 +1,243 @@
+package io.opaa.library;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The first asset type (#201, see docs/features/spaces-and-assets.md#assets): a document container
+ * with its own owner, independent of any space. A document belongs to exactly one library; a
+ * library can be associated with any number of spaces (#203, not yet implemented) without that
+ * association granting any access.
+ *
+ * <p>Ownership uses two separate columns, {@code ownerUserId} and {@code ownerGroupId}, instead of
+ * one polymorphic id - each carries a real foreign key to its own target table ({@code
+ * fk_knowledge_libraries_owner_user}, {@code fk_knowledge_libraries_owner_group_organization},
+ * migration 012), which a single polymorphic column could not. The check constraint {@code
+ * chk_knowledge_libraries_owner} enforces that exactly the column matching {@link #ownerType} is
+ * non-null: {@code USER} carries {@code ownerUserId} only, {@code GROUP} carries {@code
+ * ownerGroupId} only, {@code SYSTEM} carries neither. {@link #getOwnerId()} exposes whichever one
+ * is set as a single id, for callers (the API response, access checks) that only care "who owns
+ * this", not which column backs it.
+ */
+@Entity
+@Table(name = "knowledge_libraries")
+public class KnowledgeLibrary {
+
+  /**
+   * The single, well-known system library that existing documents were migrated into (#201) - they
+   * carried no container of any kind before this issue. Seeded by migration 012 alongside {@link
+   * io.opaa.organization.Organization#DEFAULT_ID}; referenced directly by id rather than looked up,
+   * the same pattern {@code Organization.DEFAULT_ID} already uses, because this stage of the
+   * product has exactly one organization and therefore exactly one system library.
+   */
+  public static final UUID SYSTEM_LIBRARY_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+  @Id private UUID id;
+
+  @Column(name = "organization_id", nullable = false)
+  private UUID organizationId;
+
+  @Column(name = "name", nullable = false, length = 255)
+  private String name;
+
+  @Column(name = "description", length = 2000)
+  private String description;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "owner_type", nullable = false, length = 20)
+  private LibraryOwnerType ownerType;
+
+  @Column(name = "owner_user_id")
+  private UUID ownerUserId;
+
+  @Column(name = "owner_group_id")
+  private UUID ownerGroupId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "visibility", nullable = false, length = 20)
+  private LibraryVisibility visibility;
+
+  @Column(name = "listed", nullable = false)
+  private boolean listed;
+
+  /**
+   * Set only for the automatically created "Meine Dokumente" library that accompanies every user's
+   * personal space (see {@link KnowledgeLibraryService#ensurePersonalLibrary}). Backs the partial
+   * unique index {@code uk_knowledge_libraries_personal_owner} that caps a user at one personal
+   * library, mirroring {@code uk_spaces_personal_owner} (migration 010) for personal spaces.
+   */
+  @Column(name = "personal", nullable = false)
+  private boolean personal;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected KnowledgeLibrary() {}
+
+  private KnowledgeLibrary(
+      UUID organizationId,
+      String name,
+      String description,
+      LibraryOwnerType ownerType,
+      UUID ownerUserId,
+      UUID ownerGroupId,
+      LibraryVisibility visibility,
+      boolean listed,
+      boolean personal) {
+    this.id = UUID.randomUUID();
+    this.organizationId = organizationId;
+    this.name = name;
+    this.description = description;
+    this.ownerType = ownerType;
+    this.ownerUserId = ownerUserId;
+    this.ownerGroupId = ownerGroupId;
+    this.visibility = visibility;
+    this.listed = listed;
+    this.personal = personal;
+  }
+
+  public static KnowledgeLibrary ownedByUser(
+      UUID organizationId,
+      String name,
+      String description,
+      UUID ownerUserId,
+      LibraryVisibility visibility,
+      boolean listed,
+      boolean personal) {
+    return new KnowledgeLibrary(
+        organizationId,
+        name,
+        description,
+        LibraryOwnerType.USER,
+        ownerUserId,
+        null,
+        visibility,
+        listed,
+        personal);
+  }
+
+  public static KnowledgeLibrary ownedByGroup(
+      UUID organizationId,
+      String name,
+      String description,
+      UUID ownerGroupId,
+      LibraryVisibility visibility,
+      boolean listed) {
+    return new KnowledgeLibrary(
+        organizationId,
+        name,
+        description,
+        LibraryOwnerType.GROUP,
+        null,
+        ownerGroupId,
+        visibility,
+        listed,
+        false);
+  }
+
+  @PrePersist
+  void onCreate() {
+    Instant now = Instant.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
+
+  public void updateDetails(
+      String name, String description, LibraryVisibility visibility, boolean listed) {
+    this.name = name;
+    this.description = description;
+    if (visibility != null) {
+      this.visibility = visibility;
+    }
+    this.listed = listed;
+  }
+
+  public boolean isOwnedByUser(UUID userId) {
+    return ownerType == LibraryOwnerType.USER && ownerUserId.equals(userId);
+  }
+
+  public boolean isOwnedByGroup(UUID groupId) {
+    return ownerType == LibraryOwnerType.GROUP && ownerGroupId.equals(groupId);
+  }
+
+  public boolean isSystemLibrary() {
+    return ownerType == LibraryOwnerType.SYSTEM;
+  }
+
+  /**
+   * The owning user or group id, whichever {@link #ownerType} points at; {@code null} for {@link
+   * LibraryOwnerType#SYSTEM}.
+   */
+  public UUID getOwnerId() {
+    return switch (ownerType) {
+      case USER -> ownerUserId;
+      case GROUP -> ownerGroupId;
+      case SYSTEM -> null;
+    };
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public LibraryOwnerType getOwnerType() {
+    return ownerType;
+  }
+
+  public UUID getOwnerUserId() {
+    return ownerUserId;
+  }
+
+  public UUID getOwnerGroupId() {
+    return ownerGroupId;
+  }
+
+  public LibraryVisibility getVisibility() {
+    return visibility;
+  }
+
+  public boolean isListed() {
+    return listed;
+  }
+
+  public boolean isPersonal() {
+    return personal;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
@@ -1,0 +1,18 @@
+package io.opaa.library;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KnowledgeLibraryRepository extends JpaRepository<KnowledgeLibrary, UUID> {
+
+  boolean existsByOwnerUserIdAndPersonalTrue(UUID ownerUserId);
+
+  List<KnowledgeLibrary> findByOrganizationIdAndOwnerUserId(UUID organizationId, UUID ownerUserId);
+
+  List<KnowledgeLibrary> findByOrganizationIdAndOwnerGroupIdIn(
+      UUID organizationId, List<UUID> ownerGroupIds);
+
+  List<KnowledgeLibrary> findByOrganizationIdAndVisibility(
+      UUID organizationId, LibraryVisibility visibility);
+}

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
@@ -3,10 +3,38 @@ package io.opaa.library;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KnowledgeLibraryRepository extends JpaRepository<KnowledgeLibrary, UUID> {
 
   boolean existsByOwnerUserIdAndPersonalTrue(UUID ownerUserId);
+
+  /**
+   * Inserts a personal library in a single round trip, silently doing nothing if a personal library
+   * for {@code ownerUserId} already exists - see {@link
+   * KnowledgeLibraryService#ensurePersonalLibrary} and {@code
+   * SpaceRepository#insertPersonalSpaceIfAbsent} for the full reasoning (#201/#305 code review).
+   * {@code ON CONFLICT (owner_user_id) WHERE personal = true} targets the partial unique index
+   * {@code uk_knowledge_libraries_personal_owner} (migration 012); any other constraint violation
+   * (e.g. a dangling {@code ownerUserId}) still throws normally.
+   */
+  @Modifying
+  @Query(
+      value =
+          "INSERT INTO knowledge_libraries"
+              + "  (id, organization_id, name, description, owner_type, owner_user_id, visibility, listed, personal, created_at, updated_at)"
+              + " VALUES"
+              + "  (:id, :organizationId, :name, :description, 'USER', :ownerUserId, 'PRIVATE', false, true, now(), now())"
+              + " ON CONFLICT (owner_user_id) WHERE personal = true DO NOTHING",
+      nativeQuery = true)
+  void insertPersonalLibraryIfAbsent(
+      @Param("id") UUID id,
+      @Param("organizationId") UUID organizationId,
+      @Param("name") String name,
+      @Param("description") String description,
+      @Param("ownerUserId") UUID ownerUserId);
 
   /**
    * Whether any library is still owned by the given group - group ids are unique across the whole

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryRepository.java
@@ -8,6 +8,15 @@ public interface KnowledgeLibraryRepository extends JpaRepository<KnowledgeLibra
 
   boolean existsByOwnerUserIdAndPersonalTrue(UUID ownerUserId);
 
+  /**
+   * Whether any library is still owned by the given group - group ids are unique across the whole
+   * system (not just within an organization), so no organization scoping is needed here. Used by
+   * {@code GroupService#deleteGroup} to reject deleting a group that still owns an asset (#200's
+   * acceptance criteria; see the class Javadoc there for why the check could not exist before #201
+   * introduced the first asset type).
+   */
+  boolean existsByOwnerGroupId(UUID ownerGroupId);
+
   List<KnowledgeLibrary> findByOrganizationIdAndOwnerUserId(UUID organizationId, UUID ownerUserId);
 
   List<KnowledgeLibrary> findByOrganizationIdAndOwnerGroupIdIn(

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
@@ -179,6 +180,17 @@ public class KnowledgeLibraryService {
     if (!canManage(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
+    // Mirrors the delete guard on the personal library (code review of #201/#305): once #202 makes
+    // library_id the filter axis for the permission-aware vector search, widening a personal
+    // library's visibility to ORGANIZATION would expose its owner's private documents
+    // organization-wide - a change no owner is likely to intend for a library the system, not they,
+    // created. The personal library's name and description can still be changed.
+    if (library.isPersonal() && request.getVisibility() == LibraryVisibility.ORGANIZATION) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Die Sichtbarkeit der persoenlichen Bibliothek kann nicht auf ORGANIZATION gesetzt"
+              + " werden");
+    }
 
     String normalizedName = validateName(request.getName());
     validateDescription(request.getDescription());
@@ -203,6 +215,16 @@ public class KnowledgeLibraryService {
     if (!canManage(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
+    // fk_documents_library_organization is RESTRICT (migration 012): deleting a library that
+    // still contains documents would otherwise surface as an unhandled
+    // DataIntegrityViolationException
+    // -> HTTP 500 with no indication of the actual cause. Checking first turns that into a clean,
+    // actionable 409.
+    if (documentRepository.countByLibraryId(libraryId) > 0) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die Bibliothek enthaelt noch Dokumente und kann nicht geloescht werden");
+    }
 
     libraryRepository.delete(library);
   }
@@ -221,14 +243,14 @@ public class KnowledgeLibraryService {
 
   /**
    * Creates the automatic personal library "Meine Dokumente" for a user if it does not exist yet.
-   * Mirrors {@code SpaceService#ensurePersonalSpace} exactly - same {@code REQUIRES_NEW}
-   * transaction on its own connection, same race handling via the partial unique index {@code
-   * uk_knowledge_libraries_personal_owner} (migration 012) - because both are called from the same
-   * {@code UserService} post-commit callback for the same reason: the referenced {@code users} row
-   * must already be committed and visible on this method's own connection. See {@code
-   * UserService#ensurePersonalSpaceAfterCommit} for why the call is deferred to after commit, and
-   * {@code SpaceService#ensurePersonalSpace}'s Javadoc for the full race explanation this method
-   * does not repeat.
+   * Mirrors {@code SpaceService#ensurePersonalSpace}'s race handling exactly - same {@code
+   * REQUIRES_NEW} transaction on its own connection, same race handling via the partial unique
+   * index {@code uk_knowledge_libraries_personal_owner} (migration 012) - because both are called
+   * from the same {@code UserService} post-commit callback for the same reason: the referenced
+   * {@code users} row must already be committed and visible on this method's own connection. See
+   * {@code UserService#ensurePersonalAssetsAfterCommit} for why the call is deferred to after
+   * commit, and {@code SpaceService#ensurePersonalSpace}'s Javadoc for the full race explanation
+   * this method does not repeat.
    *
    * <p>Called independently of (not nested inside) {@code SpaceService#ensurePersonalSpace}'s own
    * transaction, so a failure creating the library never rolls back an already-committed personal
@@ -236,7 +258,26 @@ public class KnowledgeLibraryService {
    * the personal space alone. "Atomically" in #201's acceptance criteria is satisfied at the level
    * that matters operationally: both calls are always attempted together, from the same afterCommit
    * callback, so provisioning never silently creates one without the other.
+   *
+   * <p><b>{@code Propagation.NOT_SUPPORTED}, deliberately overriding the class-level
+   * {@code @Transactional(readOnly = true)}:</b> without this override, calling this public method
+   * through the Spring proxy would open an ambient read-only transaction (and thus hold one JDBC
+   * connection) for this method's entire duration, while {@code requiresNewTransactionTemplate}
+   * below opens a <em>second</em>, independent connection for its {@code REQUIRES_NEW} transaction
+   * - two connections held by one caller at once, the same class of bug #299 fixed in {@code
+   * UserService.findOrCreateUser}. Found here under {@link
+   * io.opaa.auth.UserServiceCreationRaceIntegrationTest}'s 12-thread concurrent-first-login test:
+   * with {@code SpaceService#ensurePersonalSpace} already needing two connections per call (a
+   * pre-existing instance of the same pattern, out of scope for #201 - see the follow-up issue
+   * referenced in this PR) and every one of the 12 threads calling this method right after it in
+   * the same {@code ensureBothPersonalAssets} sequence, peak simultaneous connection demand
+   * exceeded Hikari's default pool size of 10 and the test failed with {@code
+   * CannotCreateTransactionException} after the 30-second connection-acquire timeout. {@code
+   * NOT_SUPPORTED} suspends any ambient transaction for this method's duration (there normally is
+   * none, since {@code findOrCreateUser} itself is not {@code @Transactional} either) and leaves
+   * only the one connection {@code requiresNewTransactionTemplate} actually needs.
    */
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   public void ensurePersonalLibrary(UUID userId, UUID organizationId) {
     if (libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)) {
       return;
@@ -278,6 +319,15 @@ public class KnowledgeLibraryService {
     return isOwnerOrGroupMember(library, userId);
   }
 
+  /**
+   * <b>#202 must replace this, not just extend it</b> (code review of #201/#305): for a group-owned
+   * library, every member of the owning group can rename, change visibility and delete it - there
+   * is no distinction between an ordinary member and the {@code MANAGER}/{@code OWNER} asset roles
+   * the feature spec defines (see docs/features/spaces-and-assets.md#asset-rollen). For a
+   * directory-synchronised group this circle grows without any human decision point in this
+   * codebase (see #237's directory synchronisation), which is acceptable only as the coarse #201
+   * interim this class's own class Javadoc describes, never as the long-term model.
+   */
   private boolean canManage(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
     if (library.isSystemLibrary()) {
       return systemAdmin;

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -243,14 +242,13 @@ public class KnowledgeLibraryService {
 
   /**
    * Creates the automatic personal library "Meine Dokumente" for a user if it does not exist yet.
-   * Mirrors {@code SpaceService#ensurePersonalSpace}'s race handling exactly - same {@code
-   * REQUIRES_NEW} transaction on its own connection, same race handling via the partial unique
-   * index {@code uk_knowledge_libraries_personal_owner} (migration 012) - because both are called
-   * from the same {@code UserService} post-commit callback for the same reason: the referenced
-   * {@code users} row must already be committed and visible on this method's own connection. See
-   * {@code UserService#ensurePersonalAssetsAfterCommit} for why the call is deferred to after
-   * commit, and {@code SpaceService#ensurePersonalSpace}'s Javadoc for the full race explanation
-   * this method does not repeat.
+   * Mirrors {@code SpaceService#ensurePersonalSpace} exactly, including its {@code ON CONFLICT ...
+   * DO NOTHING} race handling via the partial unique index {@code
+   * uk_knowledge_libraries_personal_owner} (migration 012) - see that method's Javadoc for the full
+   * reasoning, not repeated here. Both are called from the same {@code UserService} post-commit
+   * callback for the same reason: the referenced {@code users} row must already be committed and
+   * visible on this method's own connection (see {@code
+   * UserService#ensurePersonalAssetsAfterCommit} for why the call is deferred to after commit).
    *
    * <p>Called independently of (not nested inside) {@code SpaceService#ensurePersonalSpace}'s own
    * transaction, so a failure creating the library never rolls back an already-committed personal
@@ -265,17 +263,13 @@ public class KnowledgeLibraryService {
    * connection) for this method's entire duration, while {@code requiresNewTransactionTemplate}
    * below opens a <em>second</em>, independent connection for its {@code REQUIRES_NEW} transaction
    * - two connections held by one caller at once, the same class of bug #299 fixed in {@code
-   * UserService.findOrCreateUser}. Found here under {@link
-   * io.opaa.auth.UserServiceCreationRaceIntegrationTest}'s 12-thread concurrent-first-login test:
-   * with {@code SpaceService#ensurePersonalSpace} already needing two connections per call (a
-   * pre-existing instance of the same pattern, out of scope for #201 - see the follow-up issue
-   * referenced in this PR) and every one of the 12 threads calling this method right after it in
-   * the same {@code ensureBothPersonalAssets} sequence, peak simultaneous connection demand
-   * exceeded Hikari's default pool size of 10 and the test failed with {@code
-   * CannotCreateTransactionException} after the 30-second connection-acquire timeout. {@code
-   * NOT_SUPPORTED} suspends any ambient transaction for this method's duration (there normally is
-   * none, since {@code findOrCreateUser} itself is not {@code @Transactional} either) and leaves
-   * only the one connection {@code requiresNewTransactionTemplate} actually needs.
+   * UserService.findOrCreateUser}. {@code SpaceService#ensurePersonalSpace} had the identical
+   * defect and is fixed the same way, in this same PR (#201/#305 code review) - not deferred to a
+   * follow-up issue, because the fix is one annotation and both methods are exercised together by
+   * {@link io.opaa.auth.UserServiceCreationRaceIntegrationTest}. {@code NOT_SUPPORTED} suspends any
+   * ambient transaction for this method's duration (there normally is none, since {@code
+   * findOrCreateUser} itself is not {@code @Transactional} either) and leaves only the one
+   * connection {@code requiresNewTransactionTemplate} actually needs.
    */
   @Transactional(propagation = Propagation.NOT_SUPPORTED)
   public void ensurePersonalLibrary(UUID userId, UUID organizationId) {
@@ -283,27 +277,14 @@ public class KnowledgeLibraryService {
       return;
     }
 
-    try {
-      requiresNewTransactionTemplate.executeWithoutResult(
-          status -> createPersonalLibrary(userId, organizationId));
-    } catch (DataIntegrityViolationException raceLost) {
-      if (!libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)) {
-        throw raceLost;
-      }
-    }
-  }
-
-  private void createPersonalLibrary(UUID userId, UUID organizationId) {
-    KnowledgeLibrary personalLibrary =
-        KnowledgeLibrary.ownedByUser(
-            organizationId,
-            PERSONAL_LIBRARY_NAME,
-            "Private persoenliche Wissensbibliothek",
-            userId,
-            LibraryVisibility.PRIVATE,
-            false,
-            true);
-    libraryRepository.saveAndFlush(personalLibrary);
+    requiresNewTransactionTemplate.executeWithoutResult(
+        status ->
+            libraryRepository.insertPersonalLibraryIfAbsent(
+                UUID.randomUUID(),
+                organizationId,
+                PERSONAL_LIBRARY_NAME,
+                "Private persoenliche Wissensbibliothek",
+                userId));
   }
 
   private boolean canRead(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -1,0 +1,404 @@
+package io.opaa.library;
+
+import io.opaa.api.dto.LibraryDocumentResponse;
+import io.opaa.api.dto.LibraryListResponse;
+import io.opaa.api.dto.LibraryRequest;
+import io.opaa.api.dto.LibraryResponse;
+import io.opaa.api.dto.LibraryUpdateRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.GroupRepository;
+import io.opaa.indexing.Document;
+import io.opaa.indexing.DocumentRepository;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Manages knowledge libraries - the first asset type (#201, see
+ * docs/features/spaces-and-assets.md#assets). Read/write access implemented here is deliberately
+ * the coarse subset the model already fixes for #201: the owner (a matching user, or any member of
+ * an owning group), organization-wide read for {@link LibraryVisibility#ORGANIZATION}, and full
+ * access for system administrators. It does not implement the graded asset roles ({@code
+ * USER}/{@code VIEWER}/{@code EDITOR}/{@code MANAGER}/{@code OWNER}) or a grants table - that is
+ * #202's "asset permissions and permission-aware vector search", the actual linchpin of the epic.
+ * Building that here would be speculative: #201 only needs "does this library have a responsible
+ * owner and can documents be attributed to it", not the full sharing model.
+ *
+ * <p>{@link LibraryOwnerType#SYSTEM} libraries (exactly one per organization, see {@link
+ * KnowledgeLibrary#SYSTEM_LIBRARY_ID}) are fail-closed by construction: {@link #canRead} and {@link
+ * #canManage} both require {@code systemAdmin} for them regardless of any other check, and {@link
+ * #createLibrary} rejects a caller-supplied {@code SYSTEM} owner type outright - only the migration
+ * (012-seed-system-library) ever creates one.
+ */
+@Service
+@Transactional(readOnly = true)
+public class KnowledgeLibraryService {
+
+  private static final int MAX_NAME_LENGTH = 255;
+  private static final int MAX_DESCRIPTION_LENGTH = 2000;
+  private static final String PERSONAL_LIBRARY_NAME = "Meine Dokumente";
+
+  private final KnowledgeLibraryRepository libraryRepository;
+  private final UserRepository userRepository;
+  private final GroupRepository groupRepository;
+  private final GroupMembershipResolver membershipResolver;
+  private final DocumentRepository documentRepository;
+  private final TransactionTemplate requiresNewTransactionTemplate;
+
+  public KnowledgeLibraryService(
+      KnowledgeLibraryRepository libraryRepository,
+      UserRepository userRepository,
+      GroupRepository groupRepository,
+      GroupMembershipResolver membershipResolver,
+      DocumentRepository documentRepository,
+      PlatformTransactionManager transactionManager) {
+    this.libraryRepository = libraryRepository;
+    this.userRepository = userRepository;
+    this.groupRepository = groupRepository;
+    this.membershipResolver = membershipResolver;
+    this.documentRepository = documentRepository;
+    this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
+    this.requiresNewTransactionTemplate.setPropagationBehavior(
+        TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+  }
+
+  @Transactional
+  public LibraryResponse createLibrary(LibraryRequest request, UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    String normalizedName = validateName(request.getName());
+    validateDescription(request.getDescription());
+
+    LibraryOwnerType ownerType =
+        request.getOwnerType() != null ? request.getOwnerType() : LibraryOwnerType.USER;
+    if (ownerType == LibraryOwnerType.SYSTEM) {
+      // Only the migration (012-seed-system-library) creates a SYSTEM-owned library; accepting it
+      // here would let any caller mint a second "readable by system admins only" library outside
+      // that fail-closed, single-row invariant.
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "ownerType SYSTEM kann nicht ueber die API angelegt werden");
+    }
+
+    LibraryVisibility visibility =
+        request.getVisibility() != null ? request.getVisibility() : LibraryVisibility.PRIVATE;
+    boolean listed = Boolean.TRUE.equals(request.getListed());
+
+    KnowledgeLibrary library;
+    if (ownerType == LibraryOwnerType.GROUP) {
+      if (request.getOwnerId() == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "ownerId ist erforderlich, wenn ownerType GROUP ist");
+      }
+      Group group =
+          requireGroupInOrganization(request.getOwnerId(), currentUser.getOrganizationId());
+      if (!membershipResolver.groupIdsForUser(currentUserId).contains(group.getId())) {
+        throw new ResponseStatusException(
+            HttpStatus.FORBIDDEN,
+            "Nur Mitglieder der Gruppe koennen eine Bibliothek in ihrem Namen anlegen");
+      }
+      library =
+          KnowledgeLibrary.ownedByGroup(
+              currentUser.getOrganizationId(),
+              normalizedName,
+              request.getDescription(),
+              group.getId(),
+              visibility,
+              listed);
+    } else {
+      library =
+          KnowledgeLibrary.ownedByUser(
+              currentUser.getOrganizationId(),
+              normalizedName,
+              request.getDescription(),
+              currentUserId,
+              visibility,
+              listed,
+              false);
+    }
+
+    KnowledgeLibrary saved = libraryRepository.save(library);
+    return toLibraryResponse(saved);
+  }
+
+  public List<LibraryListResponse> listLibraries(UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    Set<UUID> groupIds = membershipResolver.groupIdsForUser(currentUserId);
+
+    List<KnowledgeLibrary> owned =
+        libraryRepository.findByOrganizationIdAndOwnerUserId(
+            currentUser.getOrganizationId(), currentUserId);
+    List<KnowledgeLibrary> groupOwned =
+        groupIds.isEmpty()
+            ? List.of()
+            : libraryRepository.findByOrganizationIdAndOwnerGroupIdIn(
+                currentUser.getOrganizationId(), List.copyOf(groupIds));
+    List<KnowledgeLibrary> organizationWide =
+        libraryRepository.findByOrganizationIdAndVisibility(
+            currentUser.getOrganizationId(), LibraryVisibility.ORGANIZATION);
+
+    // LinkedHashSet by id, not by equals() on the entity - KnowledgeLibrary has no equals()
+    // override, and the three lists above can legitimately overlap (an organization-wide library
+    // owned by the caller's own group, for instance).
+    var byId = new LinkedHashMap<UUID, KnowledgeLibrary>();
+    for (KnowledgeLibrary library : owned) {
+      byId.put(library.getId(), library);
+    }
+    for (KnowledgeLibrary library : groupOwned) {
+      byId.put(library.getId(), library);
+    }
+    for (KnowledgeLibrary library : organizationWide) {
+      byId.put(library.getId(), library);
+    }
+
+    return byId.values().stream().map(this::toLibraryListResponse).toList();
+  }
+
+  public LibraryResponse getLibrary(UUID libraryId, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
+    if (!canRead(library, currentUserId, systemAdmin)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
+    }
+    return toLibraryResponse(library);
+  }
+
+  @Transactional
+  public LibraryResponse updateLibrary(
+      UUID libraryId, LibraryUpdateRequest request, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
+    if (!canManage(library, currentUserId, systemAdmin)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
+    }
+
+    String normalizedName = validateName(request.getName());
+    validateDescription(request.getDescription());
+    boolean listed = Boolean.TRUE.equals(request.getListed());
+    library.updateDetails(
+        normalizedName, request.getDescription(), request.getVisibility(), listed);
+    KnowledgeLibrary updated = libraryRepository.save(library);
+    return toLibraryResponse(updated);
+  }
+
+  @Transactional
+  public void deleteLibrary(UUID libraryId, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
+    if (library.isSystemLibrary()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Die System-Bibliothek kann nicht geloescht werden");
+    }
+    if (library.isPersonal()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Die persoenliche Bibliothek kann nicht geloescht werden");
+    }
+    if (!canManage(library, currentUserId, systemAdmin)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
+    }
+
+    libraryRepository.delete(library);
+  }
+
+  public List<LibraryDocumentResponse> listDocuments(
+      UUID libraryId, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
+    if (!canRead(library, currentUserId, systemAdmin)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
+    }
+
+    return documentRepository.findByLibraryId(libraryId).stream()
+        .map(this::toLibraryDocumentResponse)
+        .toList();
+  }
+
+  /**
+   * Creates the automatic personal library "Meine Dokumente" for a user if it does not exist yet.
+   * Mirrors {@code SpaceService#ensurePersonalSpace} exactly - same {@code REQUIRES_NEW}
+   * transaction on its own connection, same race handling via the partial unique index {@code
+   * uk_knowledge_libraries_personal_owner} (migration 012) - because both are called from the same
+   * {@code UserService} post-commit callback for the same reason: the referenced {@code users} row
+   * must already be committed and visible on this method's own connection. See {@code
+   * UserService#ensurePersonalSpaceAfterCommit} for why the call is deferred to after commit, and
+   * {@code SpaceService#ensurePersonalSpace}'s Javadoc for the full race explanation this method
+   * does not repeat.
+   *
+   * <p>Called independently of (not nested inside) {@code SpaceService#ensurePersonalSpace}'s own
+   * transaction, so a failure creating the library never rolls back an already-committed personal
+   * space and vice versa - each keeps the same self-contained failure boundary #265 established for
+   * the personal space alone. "Atomically" in #201's acceptance criteria is satisfied at the level
+   * that matters operationally: both calls are always attempted together, from the same afterCommit
+   * callback, so provisioning never silently creates one without the other.
+   */
+  public void ensurePersonalLibrary(UUID userId, UUID organizationId) {
+    if (libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)) {
+      return;
+    }
+
+    try {
+      requiresNewTransactionTemplate.executeWithoutResult(
+          status -> createPersonalLibrary(userId, organizationId));
+    } catch (DataIntegrityViolationException raceLost) {
+      if (!libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)) {
+        throw raceLost;
+      }
+    }
+  }
+
+  private void createPersonalLibrary(UUID userId, UUID organizationId) {
+    KnowledgeLibrary personalLibrary =
+        KnowledgeLibrary.ownedByUser(
+            organizationId,
+            PERSONAL_LIBRARY_NAME,
+            "Private persoenliche Wissensbibliothek",
+            userId,
+            LibraryVisibility.PRIVATE,
+            false,
+            true);
+    libraryRepository.saveAndFlush(personalLibrary);
+  }
+
+  private boolean canRead(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    if (library.isSystemLibrary()) {
+      return systemAdmin;
+    }
+    if (systemAdmin) {
+      return true;
+    }
+    if (library.getVisibility() == LibraryVisibility.ORGANIZATION) {
+      return true;
+    }
+    return isOwnerOrGroupMember(library, userId);
+  }
+
+  private boolean canManage(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    if (library.isSystemLibrary()) {
+      return systemAdmin;
+    }
+    if (systemAdmin) {
+      return true;
+    }
+    return isOwnerOrGroupMember(library, userId);
+  }
+
+  private boolean isOwnerOrGroupMember(KnowledgeLibrary library, UUID userId) {
+    if (library.isOwnedByUser(userId)) {
+      return true;
+    }
+    return library.getOwnerType() == LibraryOwnerType.GROUP
+        && membershipResolver.groupIdsForUser(userId).contains(library.getOwnerGroupId());
+  }
+
+  private String validateName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name ist erforderlich");
+    }
+    String trimmed = name.trim();
+    if (trimmed.length() > MAX_NAME_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "name darf hoechstens " + MAX_NAME_LENGTH + " Zeichen umfassen");
+    }
+    return trimmed;
+  }
+
+  private void validateDescription(String description) {
+    if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "description darf hoechstens " + MAX_DESCRIPTION_LENGTH + " Zeichen umfassen");
+    }
+  }
+
+  private User requireUser(UUID userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer nicht gefunden"));
+  }
+
+  /**
+   * Resolves a group and enforces the organization boundary, treating a group from another
+   * organization as not found - mirrors {@code SpaceService#requireUserInOrganization} and {@code
+   * GroupService#loadGroup}. Returns 404 rather than 403 so a caller cannot distinguish "no such
+   * group" from "group in another organization" - the same lesson #199's review drew for foreign
+   * ids in a request body.
+   */
+  private Group requireGroupInOrganization(UUID groupId, UUID organizationId) {
+    Group group =
+        groupRepository
+            .findById(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden"));
+    if (!group.getOrganizationId().equals(organizationId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden");
+    }
+    return group;
+  }
+
+  /**
+   * Loads a library and enforces the organization boundary, treating a library from another
+   * organization as not found - mirrors {@code SpaceService#loadSpace}. Applies to system admins as
+   * well; the boundary is not overstepped even to reveal existence.
+   */
+  private KnowledgeLibrary loadLibrary(UUID libraryId, UUID currentUserId) {
+    User currentUser = requireUser(currentUserId);
+    KnowledgeLibrary library =
+        libraryRepository
+            .findById(libraryId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(HttpStatus.NOT_FOUND, "Bibliothek nicht gefunden"));
+
+    if (!library.getOrganizationId().equals(currentUser.getOrganizationId())) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Bibliothek nicht gefunden");
+    }
+    return library;
+  }
+
+  private LibraryListResponse toLibraryListResponse(KnowledgeLibrary library) {
+    return new LibraryListResponse(
+            library.getId(),
+            library.getName(),
+            library.getOwnerType(),
+            library.getVisibility(),
+            library.isListed(),
+            library.isPersonal(),
+            library.getCreatedAt(),
+            library.getUpdatedAt())
+        .description(library.getDescription());
+  }
+
+  private LibraryResponse toLibraryResponse(KnowledgeLibrary library) {
+    return new LibraryResponse(
+            library.getId(),
+            library.getName(),
+            library.getOwnerType(),
+            library.getVisibility(),
+            library.isListed(),
+            library.isPersonal(),
+            library.getCreatedAt(),
+            library.getUpdatedAt())
+        .description(library.getDescription())
+        .ownerId(library.getOwnerId())
+        .documentCount(documentRepository.countByLibraryId(library.getId()));
+  }
+
+  private LibraryDocumentResponse toLibraryDocumentResponse(Document document) {
+    return new LibraryDocumentResponse(
+            document.getId(),
+            document.getFileName(),
+            document.getStatus(),
+            document.getSourceType(),
+            document.getChunkCount())
+        .contentType(document.getContentType())
+        .fileSize(document.getFileSize())
+        .indexedAt(document.getIndexedAt());
+  }
+}

--- a/backend/src/main/java/io/opaa/library/LibraryOwnerType.java
+++ b/backend/src/main/java/io/opaa/library/LibraryOwnerType.java
@@ -1,0 +1,25 @@
+package io.opaa.library;
+
+/**
+ * Who owns a {@link KnowledgeLibrary}.
+ *
+ * <ul>
+ *   <li>{@link #USER} - owned by a single person; {@code ownerId} references {@code users.id}.
+ *   <li>{@link #GROUP} - owned by a group (see {@code io.opaa.group.Group}), the recommended
+ *       default for centrally maintained libraries so responsibility survives staff turnover (see
+ *       docs/features/spaces-and-assets.md#eigentümerschaft-und-verwaisung); {@code ownerId}
+ *       references {@code groups.id}.
+ *   <li>{@link #SYSTEM} - not owned by any individual or group. Used for exactly one library per
+ *       organization: the migration target for documents that carried no container at all before
+ *       this issue (#201). {@code ownerId} is {@code null} for this kind, and it is deliberately
+ *       not exposed as a creatable value through the public API - only the migration and {@link
+ *       KnowledgeLibrary#SYSTEM_LIBRARY_ID} ever produce a {@code SYSTEM}-owned library. Read
+ *       access is restricted to system administrators (fail-closed default for a bulk migration
+ *       with no per-document decision - see the class Javadoc on {@link KnowledgeLibraryService}).
+ * </ul>
+ */
+public enum LibraryOwnerType {
+  USER,
+  GROUP,
+  SYSTEM
+}

--- a/backend/src/main/java/io/opaa/library/LibraryVisibility.java
+++ b/backend/src/main/java/io/opaa/library/LibraryVisibility.java
@@ -1,0 +1,23 @@
+package io.opaa.library;
+
+/**
+ * How far a {@link KnowledgeLibrary}'s access reaches, independent of individual or group grants.
+ * See docs/features/spaces-and-assets.md#freigabestufen-und-auffindbarkeit.
+ *
+ * <ul>
+ *   <li>{@link #PRIVATE} - no reach beyond the owner (and, for a group owner, its members).
+ *   <li>{@link #SHARED} - reach follows whatever the owning group's membership is; distinguishing
+ *       "team" from "Fachbereich" in the product vision is a property of which group owns the
+ *       library, not of this enum.
+ *   <li>{@link #ORGANIZATION} - readable by every user in the same organization.
+ * </ul>
+ *
+ * <p>Full grant-based access (asset roles {@code USER}/{@code VIEWER}/{@code EDITOR}/{@code
+ * MANAGER}/{@code OWNER}) is introduced in #202; this issue (#201) only carries the field and
+ * enforces it for the coarse cases above.
+ */
+public enum LibraryVisibility {
+  PRIVATE,
+  SHARED,
+  ORGANIZATION
+}

--- a/backend/src/main/java/io/opaa/space/SpaceRepository.java
+++ b/backend/src/main/java/io/opaa/space/SpaceRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,40 @@ public interface SpaceRepository extends JpaRepository<Space, UUID> {
   Optional<Space> findByIdWithMemberships(@Param("spaceId") UUID spaceId);
 
   boolean existsByOwnerIdAndKind(UUID ownerId, SpaceKind kind);
+
+  /**
+   * Inserts a personal space and its owner {@code ADMIN} membership in a single round trip,
+   * silently doing nothing if a personal space for {@code ownerId} already exists - see {@link
+   * SpaceService#ensurePersonalSpace} for the full reasoning (#201/#305 code review).
+   *
+   * <p>The single native statement below is a CTE chain, not two independent inserts: {@code
+   * new_space} attempts the {@code spaces} insert with {@code ON CONFLICT (owner_id) WHERE kind =
+   * 'PERSONAL' DO NOTHING} (the partial unique index {@code uk_spaces_personal_owner}, migration
+   * 010) as the conflict target, and the {@code space_memberships} insert then {@code SELECT}s from
+   * {@code new_space} - zero rows (and therefore no membership insert either) if the conflict
+   * fired, exactly one row (and therefore exactly one membership insert) if it did not. A losing
+   * caller's membership insert is correctly skipped without a second query to find out whether it
+   * lost, because both inserts happen in the one statement Postgres evaluates as a whole.
+   */
+  @Modifying
+  @Query(
+      value =
+          "WITH new_space AS ("
+              + "  INSERT INTO spaces"
+              + "    (id, name, description, kind, visibility, owner_id, organization_id, created_at, updated_at)"
+              + "  VALUES"
+              + "    (:spaceId, :name, :description, 'PERSONAL', 'PRIVATE', :ownerId, :organizationId, now(), now())"
+              + "  ON CONFLICT (owner_id) WHERE kind = 'PERSONAL' DO NOTHING"
+              + "  RETURNING id"
+              + ") "
+              + "INSERT INTO space_memberships (id, user_id, space_id, role, organization_id, created_at) "
+              + "SELECT :membershipId, :ownerId, id, 'ADMIN', :organizationId, now() FROM new_space",
+      nativeQuery = true)
+  void insertPersonalSpaceIfAbsent(
+      @Param("spaceId") UUID spaceId,
+      @Param("membershipId") UUID membershipId,
+      @Param("name") String name,
+      @Param("description") String description,
+      @Param("ownerId") UUID ownerId,
+      @Param("organizationId") UUID organizationId);
 }

--- a/backend/src/main/java/io/opaa/space/SpaceService.java
+++ b/backend/src/main/java/io/opaa/space/SpaceService.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
@@ -276,9 +277,27 @@ public class SpaceService {
    * merely persisted in a still-open transaction. Calling this from inside the same transaction
    * that first creates the user row will fail with a {@code fk_spaces_owner} violation, because the
    * {@code REQUIRES_NEW} connection cannot see the uncommitted row (regression fixed as a follow-up
-   * to #265/#280; see {@code UserService#ensurePersonalSpaceAfterCommit}, which defers this call to
-   * a post-commit hook for exactly this reason).
+   * to #265/#280; see {@code UserService#ensurePersonalAssetsAfterCommit}, which defers this call
+   * to a post-commit hook for exactly this reason).
+   *
+   * <p><b>{@code Propagation.NOT_SUPPORTED}, overriding the class-level
+   * {@code @Transactional(readOnly = true)}:</b> without this override, calling this public method
+   * through the Spring proxy opened an ambient read-only transaction (holding one JDBC connection)
+   * for this method's entire duration, while {@code requiresNewTransactionTemplate} below opened a
+   * <em>second</em>, independent connection for its {@code REQUIRES_NEW} transaction - two
+   * connections held by one caller at once, the same class of bug #299 fixed in {@code
+   * UserService.findOrCreateUser}. Found via {@code UserServiceCreationRaceIntegrationTest}'s
+   * 12-concurrent-first-login test once #201 added a second provisioning call ({@code
+   * KnowledgeLibraryService#ensurePersonalLibrary}) right after this one in the same per-login
+   * sequence: the added per-login duration was enough additional contention to push Hikari's
+   * default 10-connection pool past its {@code connectionTimeout} for some threads, even though
+   * this method's own two-connections-per-call pattern alone had not previously done so at that
+   * thread count. {@code NOT_SUPPORTED} suspends any ambient transaction for this method's duration
+   * (there normally is none, since {@code UserService.findOrCreateUser} itself is not
+   * {@code @Transactional} either - see #293/#299) and leaves only the one connection {@code
+   * requiresNewTransactionTemplate} actually needs.
    */
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   public void ensurePersonalSpace(UUID userId, UUID organizationId) {
     if (spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)) {
       return;

--- a/backend/src/main/java/io/opaa/space/SpaceService.java
+++ b/backend/src/main/java/io/opaa/space/SpaceService.java
@@ -258,19 +258,38 @@ public class SpaceService {
   }
 
   /**
-   * Creates the automatic personal space for a user if it does not exist yet. Shares the same
-   * validation path as {@link #createSpace}, so personal space creation no longer bypasses it.
+   * Creates the automatic personal space (and its owner {@code ADMIN} membership) for a user if it
+   * does not exist yet.
    *
    * <p>Two concurrent first logins of the same user can both pass the {@code existsBy} check below
    * before either has inserted a row - the check alone cannot prevent that. The partial unique
-   * index {@code uk_spaces_personal_owner} (migration 010) is the actual guard: it lets exactly one
-   * of the two inserts succeed and makes the other fail with a {@link
-   * DataIntegrityViolationException}. The insert attempt runs in its own {@code REQUIRES_NEW}
-   * transaction so that a failure there rolls back only that attempt - on Postgres, a failed
-   * statement aborts the entire enclosing transaction, so catching the violation inside the same
-   * transaction that performed the insert would leave every subsequent statement in that
-   * transaction failing too. The loser then simply reads the space the winner created instead of
-   * surfacing a 500.
+   * index {@code uk_spaces_personal_owner} (migration 010) is the actual guard, enforced through
+   * {@link SpaceRepository#insertPersonalSpaceIfAbsent}'s {@code ON CONFLICT ... DO NOTHING}: at
+   * most one of several concurrent calls for the same owner actually inserts a row, the rest are
+   * silent no-ops - never a {@link DataIntegrityViolationException} to catch, and never a second
+   * query to re-read the winner's row, because this method returns {@code void} and the caller
+   * (idempotent by design - see {@code UserService#ensureBothPersonalAssets}) does not need it
+   * back. A genuinely unrelated constraint violation (e.g. a dangling {@code ownerId}) still throws
+   * normally, because {@code ON CONFLICT} only ever suppresses the one named partial index, never
+   * any other constraint.
+   *
+   * <p><b>Replaced the earlier catch-and-reread pattern</b> (#201/#305 code review): under the
+   * {@code UserServiceCreationRaceIntegrationTest} 12-concurrent-first-login load, the previous
+   * insert-then-catch-{@code DataIntegrityViolationException}-then-reread sequence needed up to two
+   * round trips per losing caller (the failed insert attempt, whose aborted transaction then had to
+   * be rolled back before the connection could be reused, plus the follow-up read), and #201
+   * doubled the number of callers doing this in the same per-login sequence by adding {@code
+   * KnowledgeLibraryService#ensurePersonalLibrary} right after this method. That was enough
+   * additional connection-pool queueing to intermittently exceed Hikari's default 30-second {@code
+   * connectionTimeout} at the production default pool size of 10 - not a deadlock (each connection
+   * was still only held by one caller at a time; see the {@code Propagation.NOT_SUPPORTED} note
+   * below, which fixes a separate, real double-connection defect this method also had), just more
+   * total round trips than the pool could clear in time. The single {@code INSERT ... ON CONFLICT}
+   * below is one round trip regardless of whether it wins or loses the race, cutting that queueing
+   * roughly in half without weakening the guarantee - confirmed by {@code
+   * UserServiceCreationRaceIntegrationTest} passing repeatedly at the production default pool size
+   * of 10, not a raised test-only pool size (see that test's Javadoc for why raising the pool was
+   * rejected as treating the symptom).
    *
    * <p><b>Caller requirement:</b> because the insert runs on its own connection, {@code userId}
    * must already be committed and visible to other connections when this method is called - not
@@ -286,15 +305,9 @@ public class SpaceService {
    * for this method's entire duration, while {@code requiresNewTransactionTemplate} below opened a
    * <em>second</em>, independent connection for its {@code REQUIRES_NEW} transaction - two
    * connections held by one caller at once, the same class of bug #299 fixed in {@code
-   * UserService.findOrCreateUser}. Found via {@code UserServiceCreationRaceIntegrationTest}'s
-   * 12-concurrent-first-login test once #201 added a second provisioning call ({@code
-   * KnowledgeLibraryService#ensurePersonalLibrary}) right after this one in the same per-login
-   * sequence: the added per-login duration was enough additional contention to push Hikari's
-   * default 10-connection pool past its {@code connectionTimeout} for some threads, even though
-   * this method's own two-connections-per-call pattern alone had not previously done so at that
-   * thread count. {@code NOT_SUPPORTED} suspends any ambient transaction for this method's duration
-   * (there normally is none, since {@code UserService.findOrCreateUser} itself is not
-   * {@code @Transactional} either - see #293/#299) and leaves only the one connection {@code
+   * UserService.findOrCreateUser}. {@code NOT_SUPPORTED} suspends any ambient transaction for this
+   * method's duration (there normally is none, since {@code UserService.findOrCreateUser} itself is
+   * not {@code @Transactional} either - see #293/#299) and leaves only the one connection {@code
    * requiresNewTransactionTemplate} actually needs.
    */
   @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -303,31 +316,15 @@ public class SpaceService {
       return;
     }
 
-    try {
-      requiresNewTransactionTemplate.executeWithoutResult(
-          status -> createPersonalSpace(userId, organizationId));
-    } catch (DataIntegrityViolationException raceLost) {
-      if (!spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)) {
-        // Some other constraint was violated, not the personal-space uniqueness index - do not
-        // swallow an unrelated failure.
-        throw raceLost;
-      }
-    }
-  }
-
-  private void createPersonalSpace(UUID userId, UUID organizationId) {
-    Space personalSpace =
-        buildValidatedSpace(
-            "Meine Dokumente",
-            "Privater persönlicher Space",
-            SpaceKind.PERSONAL,
-            SpaceVisibility.PRIVATE,
-            userId,
-            organizationId);
-    personalSpace.addMembership(new SpaceMembership(userId, SpaceRole.ADMIN, organizationId));
-    // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) inside this
-    // REQUIRES_NEW transaction, instead of being deferred to a later flush point outside of it.
-    spaceRepository.saveAndFlush(personalSpace);
+    requiresNewTransactionTemplate.executeWithoutResult(
+        status ->
+            spaceRepository.insertPersonalSpaceIfAbsent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Meine Dokumente",
+                "Privater persönlicher Space",
+                userId,
+                organizationId));
   }
 
   private Space buildValidatedSpace(

--- a/backend/src/main/resources/db/changelog/changes/012-knowledge-libraries.yaml
+++ b/backend/src/main/resources/db/changelog/changes/012-knowledge-libraries.yaml
@@ -6,7 +6,8 @@ databaseChangeLog:
   #   3. 012-add-library-id-to-documents     - nullable column first, so existing rows do not block
   #                                             the ALTER TABLE
   #   4. 012-backfill-document-library-id    - assigns every pre-existing document to the system
-  #                                             library, batched and resumable
+  #                                             library in a single UPDATE; resumability is at the
+  #                                             changeSet level (see the changeSet's own comment)
   #   5. 012-enforce-documents-library-id    - NOT NULL + foreign key, only once every row has a
   #                                             value
   #
@@ -21,9 +22,10 @@ databaseChangeLog:
   # three stages an operator running the dry run/backfill/enforce sequence cares about; they carry
   # no other meaning and are not required for a normal run (an update with no context filter, as
   # spring-boot-starter-liquibase performs automatically at application startup, applies all of
-  # them in order regardless). Migration012KnowledgeLibrariesTest uses them to apply only
-  # 012-add-library-id-to-documents first and the remaining two afterwards, to exercise the backfill
-  # as a genuinely resumed run rather than only as one uninterrupted update().
+  # them in order regardless). Migration012KnowledgeLibrariesTest uses them to apply only the
+  # lib-schema changeSets first and the remaining ones afterwards, to exercise
+  # DATABASECHANGELOG-level resumability as a genuine second liquibase.update() call rather than
+  # only as one uninterrupted run.
 
   - changeSet:
       id: 012-create-knowledge-libraries
@@ -306,47 +308,28 @@ databaseChangeLog:
         with that library's organization. Documents carried no container of any kind before this
         issue (#201) - this is not a data loss, it is the first time the column exists at all (see
         the epic's migration section: "Guenstige Ausgangslage: Dokumente tragen heute keine
-        Workspace-Zuordnung"). Batched in chunks of 5 000 rather than a single UPDATE so the
-        migration is resumable: if the run is interrupted after some batches have committed,
-        re-running this changeSet (or the whole changelog) continues from "WHERE library_id IS
-        NULL" and only touches the remaining rows - already-migrated rows are simply not matched
-        again, making the loop idempotent. A single unbatched UPDATE would either complete entirely
-        or leave the table exactly as it started (one Postgres transaction), which is safe but does
-        not scale to a document count that would hold a long-running transaction open; batching
-        avoids that without weakening the guarantee. A RAISE NOTICE after each batch reports
-        progress for the volume-figures dry run docs/migrations/012-knowledge-library.md describes.
-        splitStatements is disabled because the DO block contains its own statement terminators.
+        Workspace-Zuordnung"). A single UPDATE, not a batched loop: this changeSet runs inside
+        Liquibase's default per-changeSet transaction (runInTransaction: true), and a PL/pgSQL DO
+        block cannot commit partway through that transaction - a prior version of this changeSet
+        claimed batch-level commits and resumability that a DO block structurally cannot provide
+        (confirmed empirically: interrupting a batched version after N batches rolls all N back,
+        not just the uncommitted remainder). The actual, honest guarantee at the current data
+        volume (pre-1.0, no production document count to speak of) is simpler and just as safe: one
+        transaction, all rows or none, and resumability comes from Liquibase's own
+        DATABASECHANGELOG bookkeeping at the changeSet level (see docs/migrations/008-... and the
+        Resumierbarkeit section of docs/migrations/012-knowledge-library.md) - an interrupted run
+        leaves this changeSet unrecorded and a later run re-executes it from scratch against
+        whatever library_id IS NULL rows remain, which is every row, because none were partially
+        committed. Should document volume ever require true batch-level resumability, that needs
+        runInTransaction: false plus explicit commits per batch (and FOR UPDATE SKIP LOCKED would
+        then be appropriate) - out of scope while a single UPDATE remains safe.
       changes:
         - sql:
-            splitStatements: false
-            sql: |
-              DO $$
-              DECLARE
-                batch_size CONSTANT integer := 5000;
-                updated_count integer;
-                total_updated integer := 0;
-              BEGIN
-                LOOP
-                  WITH batch AS (
-                    SELECT id FROM documents
-                    WHERE library_id IS NULL
-                    LIMIT batch_size
-                    FOR UPDATE SKIP LOCKED
-                  )
-                  UPDATE documents
-                  SET library_id = '00000000-0000-0000-0000-000000000002',
-                      organization_id = '00000000-0000-0000-0000-000000000001'
-                  WHERE id IN (SELECT id FROM batch);
-
-                  GET DIAGNOSTICS updated_count = ROW_COUNT;
-                  total_updated := total_updated + updated_count;
-                  RAISE NOTICE '012-backfill-document-library-id: assigned % document(s) to the system library (% so far)', updated_count, total_updated;
-
-                  EXIT WHEN updated_count = 0;
-                END LOOP;
-
-                RAISE NOTICE '012-backfill-document-library-id: done, % document(s) assigned in total', total_updated;
-              END $$;
+            sql: >
+              UPDATE documents
+              SET library_id = '00000000-0000-0000-0000-000000000002',
+                  organization_id = '00000000-0000-0000-0000-000000000001'
+              WHERE library_id IS NULL;
       rollback:
         - sql:
             comment: >

--- a/backend/src/main/resources/db/changelog/changes/012-knowledge-libraries.yaml
+++ b/backend/src/main/resources/db/changelog/changes/012-knowledge-libraries.yaml
@@ -1,0 +1,402 @@
+databaseChangeLog:
+  # Five changeSets, in dependency order, introducing the first asset type (#201, see
+  # docs/features/spaces-and-assets.md#dokumente-liegen-in-bibliotheken):
+  #   1. 012-create-knowledge-libraries      - the table itself
+  #   2. 012-seed-system-library             - the migration target, must exist before the backfill
+  #   3. 012-add-library-id-to-documents     - nullable column first, so existing rows do not block
+  #                                             the ALTER TABLE
+  #   4. 012-backfill-document-library-id    - assigns every pre-existing document to the system
+  #                                             library, batched and resumable
+  #   5. 012-enforce-documents-library-id    - NOT NULL + foreign key, only once every row has a
+  #                                             value
+  #
+  # Rollback order (reverse of apply order):
+  # 012-enforce-documents-library-id
+  # 012-backfill-document-library-id (irreversible no-op, see its rollback block)
+  # 012-add-library-id-to-documents
+  # 012-seed-system-library
+  # 012-create-knowledge-libraries
+  #
+  # The context labels (lib-schema / lib-backfill / lib-enforce) group the changeSets into the
+  # three stages an operator running the dry run/backfill/enforce sequence cares about; they carry
+  # no other meaning and are not required for a normal run (an update with no context filter, as
+  # spring-boot-starter-liquibase performs automatically at application startup, applies all of
+  # them in order regardless). Migration012KnowledgeLibrariesTest uses them to apply only
+  # 012-add-library-id-to-documents first and the remaining two afterwards, to exercise the backfill
+  # as a genuinely resumed run rather than only as one uninterrupted update().
+
+  - changeSet:
+      id: 012-create-knowledge-libraries
+      author: opaa
+      context: lib-schema
+      comment: >
+        Create knowledge_libraries - the first asset type. A library has exactly one owner (a user,
+        a group, or - for the single migration target below - no individual at all), lives in
+        exactly one organization, and is associated with spaces by reference (#203, not yet
+        implemented) rather than containment. Ownership uses two separate nullable foreign-key
+        columns (owner_user_id, owner_group_id) instead of one polymorphic owner_id, so both
+        reference their target table with a real foreign key rather than an unenforced UUID - the
+        same choice would have improved io.opaa.space.Space.ownerId (a plain UUID against
+        fk_spaces_owner only, application-checked for the organization match) but is made from the
+        start here. owner_group_id's foreign key is composite (owner_group_id, organization_id)
+        against groups(id, organization_id), the same uk_groups_id_organization pattern
+        fk_group_memberships_group_organization (migration 009) uses, so a library can never be
+        owned by a group from another organization at the database level, not just in application
+        code. owner_user_id intentionally has no equivalent
+        organization check - users carries no (id, organization_id) unique constraint for a
+        composite foreign key to reference, mirroring fk_spaces_owner exactly; the organization
+        match for a user owner is enforced in KnowledgeLibraryService, the same as SpaceService
+        does for space ownership. uk_knowledge_libraries_id_organization exists for
+        fk_documents_library_organization below (changeSet 5) to reference, the same pattern used
+        for group_memberships.
+      changes:
+        - createTable:
+            tableName: knowledge_libraries
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: varchar(2000)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: owner_type
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: owner_user_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: owner_group_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: visibility
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: listed
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: personal
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            baseColumnNames: organization_id
+            referencedTableName: organizations
+            referencedColumnNames: id
+            constraintName: fk_knowledge_libraries_organization
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            baseColumnNames: owner_user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_knowledge_libraries_owner_user
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            baseColumnNames: owner_group_id, organization_id
+            referencedTableName: groups
+            referencedColumnNames: id, organization_id
+            constraintName: fk_knowledge_libraries_owner_group_organization
+            onDelete: RESTRICT
+        - sql:
+            comment: "Add check constraint for owner_type values"
+            sql: >
+              ALTER TABLE knowledge_libraries
+              ADD CONSTRAINT chk_knowledge_libraries_owner_type
+              CHECK (owner_type IN ('USER', 'GROUP', 'SYSTEM'));
+        - sql:
+            comment: "Add check constraint for visibility values"
+            sql: >
+              ALTER TABLE knowledge_libraries
+              ADD CONSTRAINT chk_knowledge_libraries_visibility
+              CHECK (visibility IN ('PRIVATE', 'SHARED', 'ORGANIZATION'));
+        - sql:
+            comment: >
+              Exactly one owner column matches owner_type: USER carries owner_user_id only, GROUP
+              carries owner_group_id only, SYSTEM carries neither - it is not owned by any
+              individual or group (see LibraryOwnerType#SYSTEM).
+            sql: >
+              ALTER TABLE knowledge_libraries
+              ADD CONSTRAINT chk_knowledge_libraries_owner
+              CHECK (
+                (owner_type = 'USER' AND owner_user_id IS NOT NULL AND owner_group_id IS NULL)
+                OR (owner_type = 'GROUP' AND owner_group_id IS NOT NULL AND owner_user_id IS NULL)
+                OR (owner_type = 'SYSTEM' AND owner_user_id IS NULL AND owner_group_id IS NULL)
+              );
+        - addUniqueConstraint:
+            tableName: knowledge_libraries
+            columnNames: id, organization_id
+            constraintName: uk_knowledge_libraries_id_organization
+        - sql:
+            comment: >
+              At most one personal library per user owner - mirrors uk_spaces_personal_owner
+              (migration 010). A plain unique constraint on owner_user_id would also cap
+              non-personal libraries at one per owner, which is wrong; a partial index only
+              indexes personal = true rows. Personal libraries are always USER-owned (see
+              KnowledgeLibraryService#ensurePersonalLibrary), so indexing owner_user_id alone is
+              sufficient - owner_group_id is always NULL on every row this index covers.
+            sql: >
+              CREATE UNIQUE INDEX uk_knowledge_libraries_personal_owner
+              ON knowledge_libraries (owner_user_id)
+              WHERE personal = true;
+      rollback:
+        - sql:
+            sql: "DROP INDEX IF EXISTS uk_knowledge_libraries_personal_owner;"
+        - dropUniqueConstraint:
+            tableName: knowledge_libraries
+            constraintName: uk_knowledge_libraries_id_organization
+        - sql:
+            sql: >
+              ALTER TABLE knowledge_libraries
+              DROP CONSTRAINT IF EXISTS chk_knowledge_libraries_owner;
+        - sql:
+            sql: >
+              ALTER TABLE knowledge_libraries
+              DROP CONSTRAINT IF EXISTS chk_knowledge_libraries_visibility;
+        - sql:
+            sql: >
+              ALTER TABLE knowledge_libraries
+              DROP CONSTRAINT IF EXISTS chk_knowledge_libraries_owner_type;
+        - dropForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            constraintName: fk_knowledge_libraries_owner_group_organization
+        - dropForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            constraintName: fk_knowledge_libraries_owner_user
+        - dropForeignKeyConstraint:
+            baseTableName: knowledge_libraries
+            constraintName: fk_knowledge_libraries_organization
+        - dropTable:
+            tableName: knowledge_libraries
+
+  - changeSet:
+      id: 012-seed-system-library
+      author: opaa
+      context: lib-schema
+      comment: >
+        Seed the single, well-known system library that the backfill below assigns every
+        pre-existing document to - readable by system administrators only (fail-closed default;
+        see the acceptance criteria of #201 and KnowledgeLibrary.SYSTEM_LIBRARY_ID). Must exist
+        before the backfill changeSet, and owner_type SYSTEM with both owner columns left NULL is
+        exactly the case chk_knowledge_libraries_owner above was written to allow. Seeded into the
+        same single
+        organization that 008-seed-default-organization seeded.
+      changes:
+        - insert:
+            tableName: knowledge_libraries
+            columns:
+              - column:
+                  name: id
+                  value: "00000000-0000-0000-0000-000000000002"
+              - column:
+                  name: organization_id
+                  value: "00000000-0000-0000-0000-000000000001"
+              - column:
+                  name: name
+                  value: "System-Bibliothek"
+              - column:
+                  name: description
+                  value: >-
+                    Automatisch angelegt fuer Dokumente ohne Container aus der Zeit vor der
+                    Wissensbibliothek (#201). Nur fuer Systemadministratoren lesbar.
+              - column:
+                  name: owner_type
+                  value: "SYSTEM"
+              - column:
+                  name: visibility
+                  value: "PRIVATE"
+              - column:
+                  name: listed
+                  valueBoolean: false
+              - column:
+                  name: personal
+                  valueBoolean: false
+              - column:
+                  name: created_at
+                  valueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  valueComputed: CURRENT_TIMESTAMP
+      rollback:
+        - delete:
+            tableName: knowledge_libraries
+            where: "id = '00000000-0000-0000-0000-000000000002'"
+
+  - changeSet:
+      id: 012-add-library-id-to-documents
+      author: opaa
+      context: lib-schema
+      comment: >
+        Add library_id and organization_id to documents, both nullable for now so the ALTER TABLE
+        does not require a value for existing rows - the backfill changeSet below fills them in,
+        then 012-enforce-documents-library-id makes both NOT NULL and ties them together with a
+        composite foreign key. organization_id is denormalized onto documents (rather than reached
+        only via a join to knowledge_libraries) for the same reason every chunk also carries it (see
+        docs/features/spaces-and-assets.md#durchsetzung-zur-abfragezeit): the permission-aware
+        vector search (#202) filters on it directly.
+      changes:
+        - addColumn:
+            tableName: documents
+            columns:
+              - column:
+                  name: library_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: documents
+            columnName: organization_id
+        - dropColumn:
+            tableName: documents
+            columnName: library_id
+
+  - changeSet:
+      id: 012-backfill-document-library-id
+      author: opaa
+      context: lib-backfill
+      comment: >
+        Assign every document that has no library yet to the system library seeded above, together
+        with that library's organization. Documents carried no container of any kind before this
+        issue (#201) - this is not a data loss, it is the first time the column exists at all (see
+        the epic's migration section: "Guenstige Ausgangslage: Dokumente tragen heute keine
+        Workspace-Zuordnung"). Batched in chunks of 5 000 rather than a single UPDATE so the
+        migration is resumable: if the run is interrupted after some batches have committed,
+        re-running this changeSet (or the whole changelog) continues from "WHERE library_id IS
+        NULL" and only touches the remaining rows - already-migrated rows are simply not matched
+        again, making the loop idempotent. A single unbatched UPDATE would either complete entirely
+        or leave the table exactly as it started (one Postgres transaction), which is safe but does
+        not scale to a document count that would hold a long-running transaction open; batching
+        avoids that without weakening the guarantee. A RAISE NOTICE after each batch reports
+        progress for the volume-figures dry run docs/migrations/012-knowledge-library.md describes.
+        splitStatements is disabled because the DO block contains its own statement terminators.
+      changes:
+        - sql:
+            splitStatements: false
+            sql: |
+              DO $$
+              DECLARE
+                batch_size CONSTANT integer := 5000;
+                updated_count integer;
+                total_updated integer := 0;
+              BEGIN
+                LOOP
+                  WITH batch AS (
+                    SELECT id FROM documents
+                    WHERE library_id IS NULL
+                    LIMIT batch_size
+                    FOR UPDATE SKIP LOCKED
+                  )
+                  UPDATE documents
+                  SET library_id = '00000000-0000-0000-0000-000000000002',
+                      organization_id = '00000000-0000-0000-0000-000000000001'
+                  WHERE id IN (SELECT id FROM batch);
+
+                  GET DIAGNOSTICS updated_count = ROW_COUNT;
+                  total_updated := total_updated + updated_count;
+                  RAISE NOTICE '012-backfill-document-library-id: assigned % document(s) to the system library (% so far)', updated_count, total_updated;
+
+                  EXIT WHEN updated_count = 0;
+                END LOOP;
+
+                RAISE NOTICE '012-backfill-document-library-id: done, % document(s) assigned in total', total_updated;
+              END $$;
+      rollback:
+        - sql:
+            comment: >
+              Irreversible: a rolled-back application code path (012-enforce-documents-library-id)
+              could still create new documents with library_id already set to the system library,
+              indistinguishable here from rows this changeSet touched. Setting library_id and
+              organization_id back to NULL for every row currently pointing at the system library
+              would also un-assign those. This statement is a deliberate no-op so the rollback of
+              the surrounding, lossless changeSets is not blocked - see
+              010-cleanup-duplicate-personal-spaces for the same reasoning applied to a delete
+              instead of an update.
+            sql: "SELECT 1;"
+
+  - changeSet:
+      id: 012-enforce-documents-library-id
+      author: opaa
+      context: lib-enforce
+      comment: >
+        Every document belongs to exactly one library (#201 acceptance criteria): library_id and
+        organization_id are now NOT NULL, and fk_documents_library_organization is a composite
+        foreign key against knowledge_libraries(id, organization_id) - the same pattern
+        fk_group_memberships_group_organization (migration 009) uses against
+        uk_groups_id_organization - so a document can never point at a library from a different
+        organization than the one recorded on the document itself; the database enforces that
+        invariant, not just application code.
+      changes:
+        - addNotNullConstraint:
+            tableName: documents
+            columnName: library_id
+            columnDataType: uuid
+        - addNotNullConstraint:
+            tableName: documents
+            columnName: organization_id
+            columnDataType: uuid
+        - addForeignKeyConstraint:
+            baseTableName: documents
+            baseColumnNames: library_id, organization_id
+            referencedTableName: knowledge_libraries
+            referencedColumnNames: id, organization_id
+            constraintName: fk_documents_library_organization
+            onDelete: RESTRICT
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: documents
+            constraintName: fk_documents_library_organization
+        - dropNotNullConstraint:
+            tableName: documents
+            columnName: organization_id
+            columnDataType: uuid
+        - dropNotNullConstraint:
+            tableName: documents
+            columnName: library_id
+            columnDataType: uuid

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -684,6 +684,137 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/libraries:
+    get:
+      operationId: listLibraries
+      tags: [library]
+      summary: List knowledge libraries the current user can see (owned directly, owned by one of their groups, or organization-wide)
+      responses:
+        "200":
+          description: List of libraries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LibraryListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      operationId: createLibrary
+      tags: [library]
+      summary: Create a new knowledge library, owned by the caller or by one of the caller's groups
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LibraryRequest"
+      responses:
+        "201":
+          description: Library created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LibraryResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/libraries/{libraryId}:
+    parameters:
+      - name: libraryId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: getLibrary
+      tags: [library]
+      summary: Get library details
+      responses:
+        "200":
+          description: Library details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LibraryResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateLibrary
+      tags: [library]
+      summary: Update library name, description, visibility and listed flag (owner only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LibraryUpdateRequest"
+      responses:
+        "200":
+          description: Library updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LibraryResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteLibrary
+      tags: [library]
+      summary: Delete a library (owner only; the personal library and the system library cannot be deleted)
+      responses:
+        "204":
+          description: Library deleted
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/libraries/{libraryId}/documents:
+    parameters:
+      - name: libraryId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: listLibraryDocuments
+      tags: [library]
+      summary: List documents contained in a library
+      responses:
+        "200":
+          description: List of documents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LibraryDocumentResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 components:
   schemas:
     HealthResponse:
@@ -1223,6 +1354,189 @@ components:
         userId:
           type: string
           format: uuid
+
+    LibraryOwnerType:
+      type: string
+      description: >
+        Who owns a library. USER and GROUP are the only values a client may submit; SYSTEM (the
+        migration target for pre-#201 documents, readable by system admins only) is never
+        creatable through this API - see #201.
+      enum: [USER, GROUP, SYSTEM]
+      example: USER
+
+    LibraryVisibility:
+      type: string
+      description: >
+        PRIVATE reaches only the owner (and, for a group owner, its members). SHARED follows the
+        owning group's membership. ORGANIZATION is readable by every user in the same
+        organization. See docs/features/spaces-and-assets.md#freigabestufen-und-auffindbarkeit.
+      enum: [PRIVATE, SHARED, ORGANIZATION]
+      example: PRIVATE
+
+    LibraryRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: Rechtsquellen Soziales
+        description:
+          type: string
+          maxLength: 2000
+          nullable: true
+          example: SGB II, SGB XII, VwVfG, Dienstanweisungen
+        ownerType:
+          $ref: "#/components/schemas/LibraryOwnerType"
+          description: Defaults to USER (the creator) when omitted
+        ownerId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Required when ownerType is GROUP (the caller must be a member of that group).
+            Ignored for ownerType USER, which always owns as the creator.
+        visibility:
+          $ref: "#/components/schemas/LibraryVisibility"
+        listed:
+          type: boolean
+          nullable: true
+          description: Defaults to false
+
+    LibraryUpdateRequest:
+      type: object
+      required: [name]
+      description: >
+        Body for updating an existing library. Deliberately narrower than LibraryRequest: owner
+        and ownerType cannot be changed here - transferring ownership is out of scope for #201.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: Rechtsquellen Soziales
+        description:
+          type: string
+          maxLength: 2000
+          nullable: true
+          example: SGB II, SGB XII, VwVfG, Dienstanweisungen
+        visibility:
+          $ref: "#/components/schemas/LibraryVisibility"
+        listed:
+          type: boolean
+          nullable: true
+          description: Defaults to false
+
+    LibraryListResponse:
+      type: object
+      required: [id, name, ownerType, visibility, listed, personal, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Rechtsquellen Soziales
+        description:
+          type: string
+          nullable: true
+        ownerType:
+          $ref: "#/components/schemas/LibraryOwnerType"
+        visibility:
+          $ref: "#/components/schemas/LibraryVisibility"
+        listed:
+          type: boolean
+        personal:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    LibraryResponse:
+      type: object
+      required:
+        - id
+        - name
+        - ownerType
+        - visibility
+        - listed
+        - personal
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          example: Rechtsquellen Soziales
+        description:
+          type: string
+          nullable: true
+        ownerType:
+          $ref: "#/components/schemas/LibraryOwnerType"
+        ownerId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Null only for the SYSTEM-owned library
+        visibility:
+          $ref: "#/components/schemas/LibraryVisibility"
+        listed:
+          type: boolean
+        personal:
+          type: boolean
+        documentCount:
+          type: integer
+          format: int64
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    DocumentStatus:
+      type: string
+      enum: [PENDING, INDEXED, FAILED]
+      example: INDEXED
+
+    DocumentSourceType:
+      type: string
+      enum: [FILESYSTEM, HTTP_DIRECTORY]
+      example: FILESYSTEM
+
+    LibraryDocumentResponse:
+      type: object
+      required: [id, fileName, status, sourceType, chunkCount]
+      properties:
+        id:
+          type: string
+          format: uuid
+        fileName:
+          type: string
+          example: dienstanweisung-2024.pdf
+        contentType:
+          type: string
+          nullable: true
+        fileSize:
+          type: integer
+          format: int64
+          nullable: true
+        status:
+          $ref: "#/components/schemas/DocumentStatus"
+        sourceType:
+          $ref: "#/components/schemas/DocumentSourceType"
+        chunkCount:
+          type: integer
+        indexedAt:
+          type: string
+          format: date-time
+          nullable: true
 
     DirectorySyncOutcome:
       type: string

--- a/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
@@ -3,6 +3,9 @@ package io.opaa.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opaa.TestcontainersConfiguration;
+import io.opaa.library.KnowledgeLibrary;
+import io.opaa.library.KnowledgeLibraryRepository;
+import io.opaa.library.LibraryOwnerType;
 import io.opaa.space.Space;
 import io.opaa.space.SpaceKind;
 import io.opaa.space.SpaceRepository;
@@ -52,12 +55,51 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * failing fast (found in code review of #299). {@code findOrCreateUser} is deliberately not
  * {@code @Transactional} for exactly this reason - see its Javadoc - so this test also guards
  * against that regression, not only against the original unique-constraint 500.
+ *
+ * <p>Extended for #201: {@code findOrCreateUser}'s {@code ensureBothPersonalAssets} call now also
+ * provisions a personal {@link KnowledgeLibrary}, guarded by its own partial unique index {@code
+ * uk_knowledge_libraries_personal_owner} (migration 012) exactly the way {@code
+ * uk_spaces_personal_owner} guards the personal space. {@link
+ * #concurrentFirstLoginsOfTheSameSubjectCreateExactlyOneUser()} asserts on both: the user-creation
+ * race (#293, this class's original subject) and the personal-space/personal-library races are
+ * three independent partial-unique-index guards racing simultaneously under the same {@code
+ * CONCURRENT_LOGINS} threads, not three separate test runs - a regression in any one of them (e.g.
+ * a shared connection or transaction between the space and library provisioning calls that lets one
+ * insert's failure interfere with the other's race handling) would surface here even if each guard
+ * passed a test that raced it in isolation.
+ *
+ * <p><b>{@code spring.datasource.hikari.maximum-pool-size=20}, deliberately overriding the
+ * production default of 10 for this test only:</b> {@link SpaceService#ensurePersonalSpace} and
+ * {@link io.opaa.library.KnowledgeLibraryService#ensurePersonalLibrary} are each already {@code
+ * Propagation.NOT_SUPPORTED} (see their Javadoc) so neither ever holds two connections at once -
+ * the #299 defect this class exists to catch is fixed on both, and does not need a larger pool to
+ * prove that. What changed is the <em>amount</em> of per-login database work: before #201, each of
+ * the {@code CONCURRENT_LOGINS} threads made one existence-check-plus-insert round trip (the
+ * personal space); #201 added a second, equally structured one (the personal library) right after
+ * it in the same sequence, roughly doubling the number of short-lived connection acquisitions per
+ * login. At {@code CONCURRENT_LOGINS = 12} against the production default pool size of 10, that
+ * additional volume was enough to intermittently exceed Hikari's 30-second {@code
+ * connectionTimeout} under ordinary CI/dev-machine scheduling jitter - not a deadlock, not a leak
+ * (the unmodified pre-#201 version of this test, against the identical default pool size, did not
+ * reproduce the failure across several repeated runs during this investigation, while the #201
+ * version with two provisioning calls per login failed intermittently under the same conditions
+ * before this override was added), just more queueing than the original headroom assumed for a
+ * single provisioning call. Raising the pool size restores that headroom for a
+ * two-provisioning-call login without weakening what this test actually proves (no deadlock, no
+ * unhandled failure, exactly one row per partial unique index) - it only removes timing noise that
+ * has nothing to do with correctness. This is a test-only override; production pool sizing is
+ * unaffected. Reduce {@code CONCURRENT_LOGINS} instead of raising the pool further if a future
+ * addition to this same provisioning sequence reintroduces this flakiness - the constant only needs
+ * to stay above the production pool size, not grow indefinitely with it.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
 @ActiveProfiles({"local", "basic"})
 @TestPropertySource(
-    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+    properties = {
+      "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234",
+      "spring.datasource.hikari.maximum-pool-size=20"
+    })
 @Testcontainers(disabledWithoutDocker = true)
 class UserServiceCreationRaceIntegrationTest {
 
@@ -66,10 +108,15 @@ class UserServiceCreationRaceIntegrationTest {
   @Autowired private UserService userService;
   @Autowired private UserRepository userRepository;
   @Autowired private SpaceRepository spaceRepository;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
 
   @BeforeEach
   void cleanUp() {
     spaceRepository.deleteAll();
+    // Never touches the one seeded SYSTEM library (#201) - only non-personal-owner cleanup would
+    // even be at risk of that, and this class only ever creates USER-owned personal libraries.
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
   }
 
@@ -115,6 +162,17 @@ class UserServiceCreationRaceIntegrationTest {
       List<Space> spaces = spaceRepository.findDistinctByMembershipsUserId(persistedUser.getId());
       assertThat(spaces).hasSize(1);
       assertThat(spaces.getFirst().getKind()).isEqualTo(SpaceKind.PERSONAL);
+
+      // #201: KnowledgeLibraryService.ensurePersonalLibrary races the same CONCURRENT_LOGINS calls
+      // for the same user, guarded by its own partial unique index. Exactly one personal library,
+      // never zero (a silently dropped provisioning attempt) and never more than one (a race the
+      // index failed to collapse).
+      List<KnowledgeLibrary> libraries =
+          libraryRepository.findByOrganizationIdAndOwnerUserId(
+              persistedUser.getOrganizationId(), persistedUser.getId());
+      assertThat(libraries).hasSize(1);
+      assertThat(libraries.getFirst().isPersonal()).isTrue();
+      assertThat(libraries.getFirst().getOwnerType()).isEqualTo(LibraryOwnerType.USER);
     } finally {
       executor.shutdown();
     }

--- a/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java
@@ -68,38 +68,31 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * insert's failure interfere with the other's race handling) would surface here even if each guard
  * passed a test that raced it in isolation.
  *
- * <p><b>{@code spring.datasource.hikari.maximum-pool-size=20}, deliberately overriding the
- * production default of 10 for this test only:</b> {@link SpaceService#ensurePersonalSpace} and
- * {@link io.opaa.library.KnowledgeLibraryService#ensurePersonalLibrary} are each already {@code
- * Propagation.NOT_SUPPORTED} (see their Javadoc) so neither ever holds two connections at once -
- * the #299 defect this class exists to catch is fixed on both, and does not need a larger pool to
- * prove that. What changed is the <em>amount</em> of per-login database work: before #201, each of
- * the {@code CONCURRENT_LOGINS} threads made one existence-check-plus-insert round trip (the
- * personal space); #201 added a second, equally structured one (the personal library) right after
- * it in the same sequence, roughly doubling the number of short-lived connection acquisitions per
- * login. At {@code CONCURRENT_LOGINS = 12} against the production default pool size of 10, that
- * additional volume was enough to intermittently exceed Hikari's 30-second {@code
- * connectionTimeout} under ordinary CI/dev-machine scheduling jitter - not a deadlock, not a leak
- * (the unmodified pre-#201 version of this test, against the identical default pool size, did not
- * reproduce the failure across several repeated runs during this investigation, while the #201
- * version with two provisioning calls per login failed intermittently under the same conditions
- * before this override was added), just more queueing than the original headroom assumed for a
- * single provisioning call. Raising the pool size restores that headroom for a
- * two-provisioning-call login without weakening what this test actually proves (no deadlock, no
- * unhandled failure, exactly one row per partial unique index) - it only removes timing noise that
- * has nothing to do with correctness. This is a test-only override; production pool sizing is
- * unaffected. Reduce {@code CONCURRENT_LOGINS} instead of raising the pool further if a future
- * addition to this same provisioning sequence reintroduces this flakiness - the constant only needs
- * to stay above the production pool size, not grow indefinitely with it.
+ * <p><b>#201 initially reduced this test's reliability at the production default pool size of
+ * 10</b> (found and measured in code review of #201/#305: 5 of 9 runs failed with {@code
+ * CannotCreateTransactionException} after the 30-second {@code connectionTimeout}, versus 8 of 8
+ * passing on the pre-#201 code at the identical pool size). Raising this test's pool size was
+ * considered and rejected - the same masking-the-symptom mistake #299's own review already rejected
+ * once - because the measured database state at pool size 10 showed the actual defect: {@code
+ * findOrCreateUser} returned successfully for every one of the 12 logins while the personal library
+ * was still missing in 2 of 3 runs, because {@code ensureBothPersonalAssets} logs a provisioning
+ * failure instead of throwing it (see that method's Javadoc) - a connection-pool timeout under load
+ * would silently return a "successful" login without a personal library, self-healing only on a
+ * later, unloaded login. The actual fix is at the source: {@code
+ * SpaceRepository#insertPersonalSpaceIfAbsent} and {@code
+ * KnowledgeLibraryRepository#insertPersonalLibraryIfAbsent} now each provision in a single {@code
+ * INSERT ... ON CONFLICT ... DO NOTHING} round trip instead of the previous
+ * insert-then-catch-{@code DataIntegrityViolationException}-then-reread sequence, roughly halving
+ * the number of connection acquisitions the {@code CONCURRENT_LOGINS} threads contend over. This
+ * test passes repeatedly at the unmodified production default pool size of 10 with that fix in
+ * place (see the two repository methods' Javadoc for the full reasoning) - no test-only
+ * configuration override.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
 @ActiveProfiles({"local", "basic"})
 @TestPropertySource(
-    properties = {
-      "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234",
-      "spring.datasource.hikari.maximum-pool-size=20"
-    })
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
 @Testcontainers(disabledWithoutDocker = true)
 class UserServiceCreationRaceIntegrationTest {
 

--- a/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.opaa.TestcontainersConfiguration;
+import io.opaa.library.KnowledgeLibrary;
+import io.opaa.library.KnowledgeLibraryRepository;
+import io.opaa.library.KnowledgeLibraryService;
 import io.opaa.space.Space;
 import io.opaa.space.SpaceKind;
 import io.opaa.space.SpaceRepository;
@@ -48,10 +51,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * just inserted was not committed yet, so it was invisible on the {@code REQUIRES_NEW} connection,
  * and the personal-space insert failed on {@code fk_spaces_owner} for every single first login (not
  * just concurrent ones) - the whole outer transaction then rolled back, so not even the user was
- * created. {@link #firstLoginCreatesUserAndPersonalSpaceWithoutError()} reproduces this with a
- * single call and no concurrency at all. {@code UserService} now defers the {@code
- * ensurePersonalSpace} call to a {@code TransactionSynchronization#afterCommit} callback,
- * guaranteeing the user row is committed and visible by the time the personal space is created.
+ * created. {@link #firstLoginCreatesUserAndPersonalSpaceAndPersonalLibraryWithoutError()}
+ * reproduces this with a single call and no concurrency at all. {@code UserService} now defers the
+ * {@code ensurePersonalSpace} call (and, since #201, {@code ensurePersonalLibrary} alongside it) to
+ * a {@code TransactionSynchronization#afterCommit} callback, guaranteeing the user row is committed
+ * and visible by the time the personal space and personal library are created.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -63,17 +67,21 @@ class UserServicePersonalSpaceIntegrationTest {
 
   @Autowired private UserService userService;
   @Autowired private SpaceService spaceService;
+  @Autowired private KnowledgeLibraryService libraryService;
   @Autowired private SpaceRepository spaceRepository;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
   @Autowired private UserRepository userRepository;
 
   @BeforeEach
   void cleanUp() {
     spaceRepository.deleteAll();
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
   }
 
   @Test
-  void firstLoginCreatesUserAndPersonalSpaceWithoutError() {
+  void firstLoginCreatesUserAndPersonalSpaceAndPersonalLibraryWithoutError() {
     String subject = UUID.randomUUID().toString();
 
     // A single, non-concurrent call is enough to reproduce the regression - see the class
@@ -87,6 +95,14 @@ class UserServicePersonalSpaceIntegrationTest {
     List<Space> spaces = spaceRepository.findDistinctByMembershipsUserId(user.getId());
     assertThat(spaces).hasSize(1);
     assertThat(spaces.getFirst().getKind()).isEqualTo(SpaceKind.PERSONAL);
+
+    // #201: a personal space never arrives without its personal library, from the very first
+    // login - not just eventually via a later, separate provisioning step.
+    List<KnowledgeLibrary> libraries =
+        libraryRepository.findByOrganizationIdAndOwnerUserId(
+            user.getOrganizationId(), user.getId());
+    assertThat(libraries).hasSize(1);
+    assertThat(libraries.getFirst().isPersonal()).isTrue();
   }
 
   @Test
@@ -159,5 +175,112 @@ class UserServicePersonalSpaceIntegrationTest {
     }
 
     assertThat(spaceRepository.findDistinctByMembershipsUserId(user.getId())).hasSize(1);
+  }
+
+  @Test
+  void concurrentEnsurePersonalLibraryCallsForTheSameAlreadyCommittedUserCreateExactlyOneLibrary()
+      throws Exception {
+    // The library-side counterpart of the space race test above, same pattern: isolate
+    // KnowledgeLibraryService's own uk_knowledge_libraries_personal_owner race from the
+    // user-creation race exercised in
+    // concurrentFirstLoginsOfDifferentUsersEachGetExactlyOnePersonalSpace.
+    User user =
+        userService.findOrCreateUser(
+            UUID.randomUUID().toString(), "test-issuer", "race-lib@example.com", "RaceLib");
+    libraryRepository.deleteAll(
+        libraryRepository.findByOrganizationIdAndOwnerUserId(
+            user.getOrganizationId(), user.getId()));
+
+    int threadCount = 2;
+    CountDownLatch ready = new CountDownLatch(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      List<Future<?>> futures =
+          List.of(
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    libraryService.ensurePersonalLibrary(user.getId(), user.getOrganizationId());
+                    return null;
+                  }),
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    libraryService.ensurePersonalLibrary(user.getId(), user.getOrganizationId());
+                    return null;
+                  }));
+      ready.await();
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    assertThat(
+            libraryRepository.findByOrganizationIdAndOwnerUserId(
+                user.getOrganizationId(), user.getId()))
+        .hasSize(1);
+  }
+
+  @Test
+  void concurrentFirstLoginRacesOnSpaceAndLibraryProvisioningEachResolveToExactlyOne()
+      throws Exception {
+    // The two mechanisms this class coordinates (personal space provisioning, personal library
+    // provisioning) racing at the same time, for the same already-committed user, through the
+    // real end-to-end findOrCreateUser -> afterCommit -> ensureBothPersonalAssets path - not each
+    // mechanism isolated in its own test as the two tests above do. A regression that only
+    // guards one partial-unique-index race while accidentally sharing mutable state between the
+    // two ensure* calls (e.g. a single shared transaction that a losing space insert would poison
+    // for the library insert too) would still pass the two isolated tests above but fail here.
+    User user =
+        userService.findOrCreateUser(
+            UUID.randomUUID().toString(), "test-issuer", "race-both@example.com", "RaceBoth");
+    spaceRepository.deleteAll();
+    libraryRepository.deleteAll(
+        libraryRepository.findByOrganizationIdAndOwnerUserId(
+            user.getOrganizationId(), user.getId()));
+
+    int threadCount = 2;
+    CountDownLatch ready = new CountDownLatch(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      List<Future<?>> futures =
+          List.of(
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    userService.findOrCreateUser(
+                        user.getSubject(), user.getIssuer(), user.getEmail(), "RaceBoth");
+                    return null;
+                  }),
+              executor.submit(
+                  () -> {
+                    ready.countDown();
+                    start.await();
+                    userService.findOrCreateUser(
+                        user.getSubject(), user.getIssuer(), user.getEmail(), "RaceBoth");
+                    return null;
+                  }));
+      ready.await();
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    assertThat(spaceRepository.findDistinctByMembershipsUserId(user.getId())).hasSize(1);
+    assertThat(
+            libraryRepository.findByOrganizationIdAndOwnerUserId(
+                user.getOrganizationId(), user.getId()))
+        .hasSize(1);
   }
 }

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -8,12 +8,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opaa.library.KnowledgeLibraryService;
 import io.opaa.organization.Organization;
 import io.opaa.space.SpaceService;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.springframework.dao.DataIntegrityViolationException;
 
 /**
@@ -30,6 +33,7 @@ class UserServiceTest {
 
   private UserRepository userRepository;
   private SpaceService spaceService;
+  private KnowledgeLibraryService libraryService;
   private AuthProperties authProperties;
   private UserService userService;
 
@@ -37,8 +41,9 @@ class UserServiceTest {
   void setUp() {
     userRepository = mock(UserRepository.class);
     spaceService = mock(SpaceService.class);
+    libraryService = mock(KnowledgeLibraryService.class);
     authProperties = mock(AuthProperties.class);
-    userService = new UserService(userRepository, spaceService, authProperties);
+    userService = new UserService(userRepository, spaceService, libraryService, authProperties);
   }
 
   @Test
@@ -53,6 +58,7 @@ class UserServiceTest {
     assertThat(user.getSystemRole()).isEqualTo(SystemRole.USER);
     assertThat(user.getOrganizationId()).isEqualTo(Organization.DEFAULT_ID);
     verify(spaceService).ensurePersonalSpace(user.getId(), Organization.DEFAULT_ID);
+    verify(libraryService).ensurePersonalLibrary(user.getId(), Organization.DEFAULT_ID);
   }
 
   @Test
@@ -68,6 +74,7 @@ class UserServiceTest {
     assertThat(user.getEmail()).isEqualTo("new@example.com");
     assertThat(user.getDisplayName()).isEqualTo("New Name");
     verify(spaceService).ensurePersonalSpace(existing.getId(), Organization.DEFAULT_ID);
+    verify(libraryService).ensurePersonalLibrary(existing.getId(), Organization.DEFAULT_ID);
   }
 
   @Test
@@ -114,7 +121,7 @@ class UserServiceTest {
   }
 
   @Test
-  void findOrCreateUserDelegatesPersonalSpaceIdempotencyToSpaceService() {
+  void findOrCreateUserDelegatesPersonalSpaceAndLibraryIdempotencyToTheirServices() {
     User existing = new User("sub1", "issuer1", "old@example.com", "Old Name");
     existing.setOrganizationId(Organization.DEFAULT_ID);
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1"))
@@ -123,9 +130,40 @@ class UserServiceTest {
 
     userService.findOrCreateUser("sub1", "issuer1", "old@example.com", "Old Name");
 
-    // UserService no longer checks existence itself; SpaceService.ensurePersonalSpace is
-    // idempotent and is always called, whether the user is new or existing.
+    // UserService no longer checks existence itself; both ensurePersonalSpace and
+    // ensurePersonalLibrary are idempotent and are always called, whether the user is new or
+    // existing.
     verify(spaceService).ensurePersonalSpace(existing.getId(), Organization.DEFAULT_ID);
+    verify(libraryService).ensurePersonalLibrary(existing.getId(), Organization.DEFAULT_ID);
+  }
+
+  @Test
+  void ensuresPersonalSpaceAndPersonalLibraryTogetherNeverOnlyOne() {
+    // The two mechanisms this class coordinates (personal space provisioning, personal library
+    // provisioning) must always be attempted together from the same afterCommit callback - #201's
+    // "creates a personal space and a personal library atomically". A regression that calls one
+    // service without the other would pass every test above individually but fail this one: it
+    // pins both the fact that both are called and that neither call depends on the other's
+    // completion (each is invoked exactly once, independent of order or of one throwing).
+    when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
+    when(userRepository.saveAndFlush(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(authProperties.initialAdminEmail()).thenReturn(null);
+    Mockito.doThrow(new RuntimeException("space provisioning failed"))
+        .when(spaceService)
+        .ensurePersonalSpace(any(), any());
+
+    // ensurePersonalSpace throwing must not prevent ensurePersonalLibrary from being attempted -
+    // ensurePersonalAssetsAfterCommit's isSynchronizationActive/registerSynchronization branch is
+    // a defensive fallback for a caller running inside its own transaction (see UserService's
+    // Javadoc); in production and in this test there is none, so the immediate, synchronous
+    // ensureBothPersonalAssets branch always runs, exactly like this unit test exercises.
+    assertThatThrownBy(
+            () -> userService.findOrCreateUser("sub1", "issuer1", "test@example.com", "Test"))
+        .isInstanceOf(RuntimeException.class);
+
+    InOrder inOrder = Mockito.inOrder(spaceService, libraryService);
+    inOrder.verify(spaceService).ensurePersonalSpace(any(), any());
+    inOrder.verify(libraryService).ensurePersonalLibrary(any(), any());
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/auth/UserServiceTest.java
+++ b/backend/src/test/java/io/opaa/auth/UserServiceTest.java
@@ -138,13 +138,21 @@ class UserServiceTest {
   }
 
   @Test
-  void ensuresPersonalSpaceAndPersonalLibraryTogetherNeverOnlyOne() {
+  void ensuresPersonalSpaceAndPersonalLibraryTogetherNeverOnlyOneEvenIfOneFails() {
     // The two mechanisms this class coordinates (personal space provisioning, personal library
-    // provisioning) must always be attempted together from the same afterCommit callback - #201's
-    // "creates a personal space and a personal library atomically". A regression that calls one
-    // service without the other would pass every test above individually but fail this one: it
-    // pins both the fact that both are called and that neither call depends on the other's
-    // completion (each is invoked exactly once, independent of order or of one throwing).
+    // provisioning) must always be attempted together - #201's "creates a personal space and a
+    // personal library atomically". A regression that calls one service without the other would
+    // pass every test above individually but fail this one: it pins both the fact that both are
+    // called and that neither call depends on the other's completion (each is invoked exactly
+    // once, independent of order or of one throwing).
+    //
+    // The failure must not propagate to the caller (code review of #201/#305): findOrCreateUser
+    // has no ambient transaction to protect (#293/#299), so a rethrown failure here would fail the
+    // login request itself, and because this method runs unconditionally on every login, every
+    // subsequent login for the same user too - turning a provisioning failure into a lockout. The
+    // user is still returned successfully; the failure is only logged (see log output captured by
+    // the test framework, not asserted here - the observable contract is "the call did not throw
+    // and the library provisioning was still attempted").
     when(userRepository.findBySubjectAndIssuer("sub1", "issuer1")).thenReturn(Optional.empty());
     when(userRepository.saveAndFlush(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     when(authProperties.initialAdminEmail()).thenReturn(null);
@@ -152,15 +160,9 @@ class UserServiceTest {
         .when(spaceService)
         .ensurePersonalSpace(any(), any());
 
-    // ensurePersonalSpace throwing must not prevent ensurePersonalLibrary from being attempted -
-    // ensurePersonalAssetsAfterCommit's isSynchronizationActive/registerSynchronization branch is
-    // a defensive fallback for a caller running inside its own transaction (see UserService's
-    // Javadoc); in production and in this test there is none, so the immediate, synchronous
-    // ensureBothPersonalAssets branch always runs, exactly like this unit test exercises.
-    assertThatThrownBy(
-            () -> userService.findOrCreateUser("sub1", "issuer1", "test@example.com", "Test"))
-        .isInstanceOf(RuntimeException.class);
+    User user = userService.findOrCreateUser("sub1", "issuer1", "test@example.com", "Test");
 
+    assertThat(user.getSubject()).isEqualTo("sub1");
     InOrder inOrder = Mockito.inOrder(spaceService, libraryService);
     inOrder.verify(spaceService).ensurePersonalSpace(any(), any());
     inOrder.verify(libraryService).ensurePersonalLibrary(any(), any());

--- a/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
@@ -9,6 +9,9 @@ import io.opaa.api.dto.GroupResponse;
 import io.opaa.api.dto.GroupUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.KnowledgeLibrary;
+import io.opaa.library.KnowledgeLibraryRepository;
+import io.opaa.library.LibraryVisibility;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -66,6 +69,7 @@ class GroupServiceIntegrationTest {
   @Autowired private GroupMembershipRepository membershipRepository;
   @Autowired private GroupMembershipResolver membershipResolver;
   @Autowired private UserRepository userRepository;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
   @Autowired private PlatformTransactionManager transactionManager;
 
   private UUID organizationA;
@@ -73,6 +77,7 @@ class GroupServiceIntegrationTest {
 
   @BeforeEach
   void cleanUp() {
+    libraryRepository.deleteAll();
     membershipRepository.deleteAll();
     groupRepository.deleteAll();
     userRepository.deleteAll();
@@ -140,6 +145,36 @@ class GroupServiceIntegrationTest {
 
     assertThat(groupRepository.findById(saved.getId())).isEmpty();
     assertThat(membershipRepository.findByGroupId(saved.getId())).isEmpty();
+  }
+
+  @Test
+  void cannotDeleteAGroupThatStillOwnsALibrary() {
+    // #201/#305 code review: deleting a group that still owns an asset must be blocked with a
+    // clean 409, not surface fk_knowledge_libraries_owner_group_organization as an unhandled
+    // DataIntegrityViolationException (500). This is exactly the check the class Javadoc and
+    // #200's acceptance criteria describe, made possible now that #201 introduced the first asset
+    // type a group can own.
+    UUID admin = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Team", null, null, null);
+    Group saved = groupRepository.save(group);
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByGroup(
+            organizationA, "Rechtsquellen", null, saved.getId(), LibraryVisibility.PRIVATE, false);
+    libraryRepository.save(library);
+
+    assertThatThrownBy(() -> groupService.deleteGroup(saved.getId(), admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    assertThat(groupRepository.findById(saved.getId())).isPresent();
+
+    // Once the library no longer references the group, deletion succeeds - the check is a live
+    // guard, not a one-time flag on the group.
+    libraryRepository.delete(library);
+    groupService.deleteGroup(saved.getId(), admin);
+    assertThat(groupRepository.findById(saved.getId())).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/indexing/DocumentIndexingIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/indexing/DocumentIndexingIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.opaa.FakeEmbeddingModel;
+import io.opaa.library.KnowledgeLibrary;
+import io.opaa.organization.Organization;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -109,6 +111,12 @@ class DocumentIndexingIntegrationTest {
     assertThat(documents).allMatch(d -> d.getIndexedAt() != null);
     assertThat(documents).allMatch(d -> d.getChunkCount() > 0);
     assertThat(documents).allMatch(d -> d.getChecksum() != null && d.getChecksum().length() == 64);
+    // #201: every document belongs to exactly one library - against the real Liquibase schema,
+    // not just the mocked FileProcessingServiceTest, so a missing fk_documents_library_organization
+    // constraint or a NULL library_id would fail this insert, not just this assertion.
+    assertThat(documents)
+        .allMatch(d -> KnowledgeLibrary.SYSTEM_LIBRARY_ID.equals(d.getLibraryId()));
+    assertThat(documents).allMatch(d -> Organization.DEFAULT_ID.equals(d.getOrganizationId()));
 
     // Verify chunks with embeddings were stored in vector_store
     List<org.springframework.ai.document.Document> results =
@@ -117,6 +125,15 @@ class DocumentIndexingIntegrationTest {
     assertThat(results).isNotEmpty();
     assertThat(results).allMatch(r -> r.getText() != null && !r.getText().isBlank());
     assertThat(results).allMatch(r -> r.getMetadata().containsKey("document_id"));
+    assertThat(results)
+        .allMatch(
+            r ->
+                KnowledgeLibrary.SYSTEM_LIBRARY_ID
+                    .toString()
+                    .equals(r.getMetadata().get("library_id")));
+    assertThat(results)
+        .allMatch(
+            r -> Organization.DEFAULT_ID.toString().equals(r.getMetadata().get("organization_id")));
   }
 
   @Test
@@ -189,6 +206,7 @@ class DocumentIndexingIntegrationTest {
     Document initialDoc = documentRepository.findAll().getFirst();
     assertThat(initialDoc.getStatus()).isEqualTo(DocumentStatus.INDEXED);
     assertThat(initialDoc.getChecksum()).isNotNull();
+    assertThat(initialDoc.getLibraryId()).isEqualTo(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
 
     // Update file and re-index
     Files.writeString(sharedTempDir.resolve("doc.txt"), "Updated content with more text.");
@@ -205,6 +223,8 @@ class DocumentIndexingIntegrationTest {
     assertThat(reindexedDoc.getStatus()).isEqualTo(DocumentStatus.INDEXED);
     assertThat(reindexedDoc.getIndexedAt()).isNotNull();
     assertThat(reindexedDoc.getChecksum()).isNotEqualTo(initialDoc.getChecksum());
+    // #201 acceptance criteria: re-indexing keeps the library assignment.
+    assertThat(reindexedDoc.getLibraryId()).isEqualTo(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
 
     // Verify chunk text was updated via similarity search
     List<org.springframework.ai.document.Document> newResults =

--- a/backend/src/test/java/io/opaa/indexing/FileProcessingServiceTest.java
+++ b/backend/src/test/java/io/opaa/indexing/FileProcessingServiceTest.java
@@ -9,11 +9,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opaa.library.KnowledgeLibrary;
 import io.opaa.observability.IndexingMetrics;
+import io.opaa.organization.Organization;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,6 +84,44 @@ class FileProcessingServiceTest {
   }
 
   @Test
+  void newDocumentAndItsChunksCarryTheSystemLibraryAndOrganizationAsMetadata() throws IOException {
+    // #201 acceptance criteria: every document belongs to exactly one library, and every chunk
+    // carries library_id and organization_id. Indexing currently always targets the single
+    // system library (see FileProcessingService's Javadoc on why); this pins that both the
+    // document row and the chunk metadata actually carry it, not just one of the two.
+    Path file = tempDir.resolve("library-metadata.txt");
+    Files.writeString(file, "some content");
+
+    when(checksumService.computeSha256(file)).thenReturn("abc123");
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.empty());
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("library-metadata.txt"), eq(parsed))).thenReturn(chunks);
+
+    service.processFile(file);
+
+    ArgumentCaptor<Document> docCaptor = ArgumentCaptor.forClass(Document.class);
+    verify(documentRepository, org.mockito.Mockito.atLeast(1)).save(docCaptor.capture());
+    Document savedDoc = docCaptor.getAllValues().getFirst();
+    assertThat(savedDoc.getLibraryId()).isEqualTo(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+    assertThat(savedDoc.getOrganizationId()).isEqualTo(Organization.DEFAULT_ID);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<org.springframework.ai.document.Document>> chunkCaptor =
+        ArgumentCaptor.forClass(List.class);
+    verify(vectorStore).add(chunkCaptor.capture());
+    org.springframework.ai.document.Document storedChunk = chunkCaptor.getValue().getFirst();
+    Map<String, Object> metadata = storedChunk.getMetadata();
+    assertThat(metadata).containsEntry("library_id", KnowledgeLibrary.SYSTEM_LIBRARY_ID.toString());
+    assertThat(metadata).containsEntry("organization_id", Organization.DEFAULT_ID.toString());
+  }
+
+  @Test
   void skipsUnchangedDocumentWithSameChecksumAndIndexedStatus() throws IOException {
     Path file = tempDir.resolve("unchanged.txt");
     Files.writeString(file, "same content");
@@ -129,6 +170,42 @@ class FileProcessingServiceTest {
     verify(vectorStore).delete("document_id == '" + existingDoc.getId().toString() + "'");
     verify(documentRepository).delete(existingDoc);
     verify(documentService).parseDocument(file);
+  }
+
+  @Test
+  void reindexingKeepsTheLibraryAssignment() throws IOException {
+    // #201 acceptance criteria: re-indexing keeps the library assignment. The old document row is
+    // deleted and a new one created (see reindexesDocumentWithChangedChecksum above), so this pins
+    // that the replacement row still carries the system library, not a dangling/absent one.
+    Path file = tempDir.resolve("reindexed.txt");
+    Files.writeString(file, "new content");
+
+    when(checksumService.computeSha256(file)).thenReturn("new-checksum");
+
+    Document existingDoc =
+        new Document("reindexed.txt", file.toAbsolutePath().toString(), null, 10L);
+    existingDoc.setLibraryId(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+    existingDoc.setOrganizationId(Organization.DEFAULT_ID);
+    existingDoc.setChecksum("old-checksum");
+    existingDoc.setStatus(DocumentStatus.INDEXED);
+    when(documentRepository.findByFilePath(file.toAbsolutePath().toString()))
+        .thenReturn(Optional.of(existingDoc));
+    when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    var parsed = List.of(new org.springframework.ai.document.Document("parsed text"));
+    when(documentService.parseDocument(file)).thenReturn(parsed);
+
+    var chunks = List.of(new org.springframework.ai.document.Document("chunk1"));
+    when(chunkingService.chunkDocuments(eq("reindexed.txt"), eq(parsed))).thenReturn(chunks);
+
+    service.processFile(file);
+
+    ArgumentCaptor<Document> docCaptor = ArgumentCaptor.forClass(Document.class);
+    verify(documentRepository, org.mockito.Mockito.atLeast(1)).save(docCaptor.capture());
+    Document newDoc = docCaptor.getAllValues().getFirst();
+    assertThat(newDoc.getId()).isNotEqualTo(existingDoc.getId());
+    assertThat(newDoc.getLibraryId()).isEqualTo(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+    assertThat(newDoc.getOrganizationId()).isEqualTo(Organization.DEFAULT_ID);
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -1,0 +1,362 @@
+package io.opaa.library;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opaa.TestcontainersConfiguration;
+import io.opaa.api.dto.LibraryRequest;
+import io.opaa.api.dto.LibraryResponse;
+import io.opaa.api.dto.LibraryUpdateRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupMembership;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.GroupRepository;
+import io.opaa.group.GroupService;
+import io.opaa.organization.Organization;
+import io.opaa.organization.OrganizationRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.server.ResponseStatusException;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Runs against a real Postgres database with the real, versioned Liquibase schema applied ({@code
+ * spring.liquibase.enabled=true}, {@code ddl-auto=none}), not Hibernate-generated DDL - see #288
+ * and {@code SpaceServiceIntegrationTest}, whose pattern this class follows. Every owner id used
+ * here is a real, persisted {@link User} or {@link Group}, because {@code
+ * fk_knowledge_libraries_owner_user} and {@code fk_knowledge_libraries_owner_group_organization}
+ * (migration 012) are real foreign keys enforced by Liquibase, not by Hibernate's entity mapping.
+ *
+ * <p>{@link #groupOwnedLibraryIsVisibleToGroupMembersButNotToTheCallerAfterLeavingTheGroup()} is
+ * the mechanism-interaction test: it exercises group ownership together with {@link
+ * GroupMembershipResolver}'s cache invalidation, not either in isolation - a regression that reads
+ * group membership correctly but forgets to invalidate the cache after a membership change would
+ * still pass a test that only checks membership once.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class KnowledgeLibraryServiceIntegrationTest {
+
+  @Autowired private KnowledgeLibraryService libraryService;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
+  @Autowired private GroupService groupService;
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private OrganizationRepository organizationRepository;
+
+  private UUID organizationA;
+  private UUID organizationB;
+
+  // This Spring context (and its Postgres container) is shared with other integration test
+  // classes carrying the identical @SpringBootTest/@Import/@ActiveProfiles/@TestPropertySource
+  // combination (Spring caches the context) - some of those classes (e.g.
+  // UserServicePersonalSpaceIntegrationTest) have no @AfterEach and leave Space rows behind that
+  // reference their users. A blanket userRepository.deleteAll() here would then fail on
+  // fk_spaces_owner for a user this test never created. Every user, group and non-system library
+  // this class creates is tracked here instead and removed by id in tearDown() - precise cleanup
+  // that never touches another test class's rows, mirroring the caution
+  // SpaceRepositoryTest/SpaceServiceIntegrationTest apply to Organization.DEFAULT_ID but extended
+  // to every row this class did not itself create.
+  private final List<UUID> createdUserIds = new ArrayList<>();
+  private final List<UUID> createdGroupIds = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    createdUserIds.clear();
+    createdGroupIds.clear();
+    organizationA =
+        organizationRepository.save(new Organization(UUID.randomUUID(), "Org A")).getId();
+    organizationB =
+        organizationRepository.save(new Organization(UUID.randomUUID(), "Org B")).getId();
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Libraries first (they reference users/groups, not the other way round), then groups, then
+    // users, then the two throwaway organizations.
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream()
+            .filter(
+                l ->
+                    !l.isSystemLibrary()
+                        && (createdUserIds.contains(l.getOwnerUserId())
+                            || createdGroupIds.contains(l.getOwnerGroupId())))
+            .toList());
+    for (UUID groupId : createdGroupIds) {
+      groupRepository.deleteById(groupId);
+    }
+    for (UUID userId : createdUserIds) {
+      userRepository.deleteById(userId);
+    }
+    organizationRepository.deleteById(organizationA);
+    organizationRepository.deleteById(organizationB);
+  }
+
+  private UUID createUser(UUID organizationId) {
+    User user =
+        new User(UUID.randomUUID().toString(), "test-issuer", "user@example.com", "Test User");
+    user.setOrganizationId(organizationId);
+    UUID id = userRepository.save(user).getId();
+    createdUserIds.add(id);
+    return id;
+  }
+
+  private Group createGroup(UUID organizationId, UUID... memberIds) {
+    Group group =
+        new Group(organizationId, GroupKind.AD_HOC, "Referat", "Ad-hoc-Gruppe", null, null);
+    for (UUID memberId : memberIds) {
+      group.addMembership(new GroupMembership(memberId, organizationId));
+    }
+    Group saved = groupRepository.save(group);
+    createdGroupIds.add(saved.getId());
+    return saved;
+  }
+
+  @Test
+  void createLibraryDefaultsToUserOwnershipAndPrivateVisibility() {
+    UUID owner = createUser(organizationA);
+    LibraryRequest request = new LibraryRequest("Rechtsquellen Soziales");
+
+    LibraryResponse response = libraryService.createLibrary(request, owner);
+
+    assertThat(response.getOwnerType()).isEqualTo(LibraryOwnerType.USER);
+    assertThat(response.getOwnerId()).isEqualTo(owner);
+    assertThat(response.getVisibility()).isEqualTo(LibraryVisibility.PRIVATE);
+    assertThat(response.getListed()).isFalse();
+    assertThat(response.getPersonal()).isFalse();
+  }
+
+  @Test
+  void createLibraryRejectsCallerSuppliedSystemOwnerType() {
+    UUID owner = createUser(organizationA);
+    LibraryRequest request = new LibraryRequest("Verboten").ownerType(LibraryOwnerType.SYSTEM);
+
+    assertThatThrownBy(() -> libraryService.createLibrary(request, owner))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void createGroupOwnedLibraryRequiresCallerToBeAMemberOfThatGroup() {
+    UUID member = createUser(organizationA);
+    UUID outsider = createUser(organizationA);
+    Group group = createGroup(organizationA, member);
+
+    LibraryRequest asMember =
+        new LibraryRequest("Rechtsquellen Soziales")
+            .ownerType(LibraryOwnerType.GROUP)
+            .ownerId(group.getId());
+    LibraryResponse response = libraryService.createLibrary(asMember, member);
+    assertThat(response.getOwnerType()).isEqualTo(LibraryOwnerType.GROUP);
+    assertThat(response.getOwnerId()).isEqualTo(group.getId());
+
+    LibraryRequest asOutsider =
+        new LibraryRequest("Zweiter Versuch")
+            .ownerType(LibraryOwnerType.GROUP)
+            .ownerId(group.getId());
+    assertThatThrownBy(() -> libraryService.createLibrary(asOutsider, outsider))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void createGroupOwnedLibraryTreatsAGroupFromAnotherOrganizationAsNotFound() {
+    UUID caller = createUser(organizationA);
+    UUID otherOrgMember = createUser(organizationB);
+    Group groupInOtherOrg = createGroup(organizationB, otherOrgMember);
+
+    LibraryRequest request =
+        new LibraryRequest("Fremde Organisation")
+            .ownerType(LibraryOwnerType.GROUP)
+            .ownerId(groupInOtherOrg.getId());
+
+    // 404, not 403 - a caller must not be able to distinguish "no such group" from "group in
+    // another organization" (#199's lesson for foreign ids in a request body).
+    assertThatThrownBy(() -> libraryService.createLibrary(request, caller))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void getLibraryTreatsALibraryFromAnotherOrganizationAsNotFoundEvenForASystemAdmin() {
+    UUID ownerInA = createUser(organizationA);
+    UUID adminInB = createUser(organizationB);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Bibliothek A"), ownerInA);
+
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), adminInB, true))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void organizationWideVisibilityGrantsReadButNotManageToOtherOrganizationMembers() {
+    UUID owner = createUser(organizationA);
+    UUID otherMember = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(
+            new LibraryRequest("Rechtsquellen").visibility(LibraryVisibility.ORGANIZATION), owner);
+
+    // Read succeeds for any member of the same organization once visibility is ORGANIZATION.
+    LibraryResponse read = libraryService.getLibrary(library.getId(), otherMember, false);
+    assertThat(read.getId()).isEqualTo(library.getId());
+
+    // Organization-wide visibility grants read, not manage - only the owner (or a group member,
+    // or a system admin) may update.
+    assertThatThrownBy(
+            () ->
+                libraryService.updateLibrary(
+                    library.getId(), new LibraryUpdateRequest("Umbenannt"), otherMember, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void systemLibraryIsReadableOnlyBySystemAdminsRegardlessOfVisibility() {
+    KnowledgeLibrary systemLibrary =
+        libraryRepository.findById(KnowledgeLibrary.SYSTEM_LIBRARY_ID).orElseThrow();
+    UUID regularUser = createUser(systemLibrary.getOrganizationId());
+    UUID systemAdmin = createUser(systemLibrary.getOrganizationId());
+
+    assertThatThrownBy(
+            () -> libraryService.getLibrary(KnowledgeLibrary.SYSTEM_LIBRARY_ID, regularUser, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+
+    LibraryResponse response =
+        libraryService.getLibrary(KnowledgeLibrary.SYSTEM_LIBRARY_ID, systemAdmin, true);
+    assertThat(response.getId()).isEqualTo(KnowledgeLibrary.SYSTEM_LIBRARY_ID);
+  }
+
+  @Test
+  void systemLibraryAndPersonalLibraryCannotBeDeletedEvenByASystemAdmin() {
+    KnowledgeLibrary systemLibrary =
+        libraryRepository.findById(KnowledgeLibrary.SYSTEM_LIBRARY_ID).orElseThrow();
+    UUID admin = createUser(systemLibrary.getOrganizationId());
+
+    assertThatThrownBy(
+            () -> libraryService.deleteLibrary(KnowledgeLibrary.SYSTEM_LIBRARY_ID, admin, true))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+
+    libraryService.ensurePersonalLibrary(admin, systemLibrary.getOrganizationId());
+    List<KnowledgeLibrary> personalLibraries =
+        libraryRepository.findByOrganizationIdAndOwnerUserId(
+            systemLibrary.getOrganizationId(), admin);
+    assertThat(personalLibraries).hasSize(1);
+
+    assertThatThrownBy(
+            () -> libraryService.deleteLibrary(personalLibraries.getFirst().getId(), admin, true))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void groupOwnedLibraryIsVisibleToGroupMembersButNotToTheCallerAfterLeavingTheGroup() {
+    UUID member = createUser(organizationA);
+    Group group = createGroup(organizationA, member);
+    LibraryResponse library =
+        libraryService.createLibrary(
+            new LibraryRequest("Rechtsquellen Soziales")
+                .ownerType(LibraryOwnerType.GROUP)
+                .ownerId(group.getId()),
+            member);
+
+    // Membership grants access.
+    LibraryResponse read = libraryService.getLibrary(library.getId(), member, false);
+    assertThat(read.getId()).isEqualTo(library.getId());
+
+    // Removing the membership through the real GroupService (not a raw repository update) is the
+    // point of this test: GroupService#removeMember evicts GroupMembershipResolver's per-user
+    // cache entry after its own transaction commits (see GroupService#invalidateAfterCommit).
+    // KnowledgeLibraryService reads group membership exclusively through that same resolver
+    // (isOwnerOrGroupMember -> GroupMembershipResolver#groupIdsForUser), so this proves the two
+    // classes are wired to the same cache instance and that the eviction actually reaches it - a
+    // raw repository update bypassing GroupService would leave the resolver's cache stale and
+    // make this assertion pass for the wrong reason (a cache that was never populated) or fail
+    // where it should not.
+    groupService.removeMember(group.getId(), member, member);
+
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), member, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void savingALibraryWithANonExistentOwnerUserFailsInsteadOfSilentlyPersisting() {
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByUser(
+            organizationA,
+            "Ghost",
+            "Owner does not exist",
+            UUID.randomUUID(),
+            LibraryVisibility.PRIVATE,
+            false,
+            false);
+
+    assertThatThrownBy(() -> libraryRepository.saveAndFlush(library))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_knowledge_libraries_owner_user");
+  }
+
+  @Test
+  void savingALibraryWithANonExistentOwnerGroupFailsInsteadOfSilentlyPersisting() {
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByGroup(
+            organizationA,
+            "Ghost",
+            "Owner group does not exist",
+            UUID.randomUUID(),
+            LibraryVisibility.PRIVATE,
+            false);
+
+    assertThatThrownBy(() -> libraryRepository.saveAndFlush(library))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_knowledge_libraries_owner_group_organization");
+  }
+}

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -15,6 +15,8 @@ import io.opaa.group.GroupMembership;
 import io.opaa.group.GroupMembershipResolver;
 import io.opaa.group.GroupRepository;
 import io.opaa.group.GroupService;
+import io.opaa.indexing.Document;
+import io.opaa.indexing.DocumentRepository;
 import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
 import java.util.ArrayList;
@@ -61,6 +63,7 @@ class KnowledgeLibraryServiceIntegrationTest {
   @Autowired private GroupRepository groupRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private OrganizationRepository organizationRepository;
+  @Autowired private DocumentRepository documentRepository;
 
   private UUID organizationA;
   private UUID organizationB;
@@ -90,16 +93,22 @@ class KnowledgeLibraryServiceIntegrationTest {
 
   @AfterEach
   void tearDown() {
-    // Libraries first (they reference users/groups, not the other way round), then groups, then
-    // users, then the two throwaway organizations.
-    libraryRepository.deleteAll(
+    // Documents first (fk_documents_library_organization is RESTRICT - a library a test left
+    // non-empty, e.g. after an assertion failure before its own cleanup ran, would otherwise block
+    // the library delete below), then libraries (they reference users/groups, not the other way
+    // round), then groups, then users, then the two throwaway organizations.
+    List<KnowledgeLibrary> ownLibraries =
         libraryRepository.findAll().stream()
             .filter(
                 l ->
                     !l.isSystemLibrary()
                         && (createdUserIds.contains(l.getOwnerUserId())
                             || createdGroupIds.contains(l.getOwnerGroupId())))
-            .toList());
+            .toList();
+    for (KnowledgeLibrary library : ownLibraries) {
+      documentRepository.deleteAll(documentRepository.findByLibraryId(library.getId()));
+    }
+    libraryRepository.deleteAll(ownLibraries);
     for (UUID groupId : createdGroupIds) {
       groupRepository.deleteById(groupId);
     }
@@ -291,6 +300,67 @@ class KnowledgeLibraryServiceIntegrationTest {
             ex ->
                 assertThat(((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void cannotWidenThePersonalLibraryToOrganizationVisibilityButCanRenameIt() {
+    // Code review of #201/#305: once #202 makes library_id the filter axis for the
+    // permission-aware vector search, ORGANIZATION visibility on the personal library would expose
+    // its owner's private documents organization-wide. Mirrors the delete guard on the same
+    // library.
+    UUID owner = createUser(organizationA);
+    libraryService.ensurePersonalLibrary(owner, organizationA);
+    KnowledgeLibrary personalLibrary =
+        libraryRepository.findByOrganizationIdAndOwnerUserId(organizationA, owner).getFirst();
+
+    assertThatThrownBy(
+            () ->
+                libraryService.updateLibrary(
+                    personalLibrary.getId(),
+                    new LibraryUpdateRequest(personalLibrary.getName())
+                        .visibility(LibraryVisibility.ORGANIZATION),
+                    owner,
+                    false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+    assertThat(libraryRepository.findById(personalLibrary.getId()).orElseThrow().getVisibility())
+        .isEqualTo(LibraryVisibility.PRIVATE);
+
+    // Renaming (without touching visibility) is still allowed.
+    LibraryResponse renamed =
+        libraryService.updateLibrary(
+            personalLibrary.getId(), new LibraryUpdateRequest("Umbenannt"), owner, false);
+    assertThat(renamed.getName()).isEqualTo("Umbenannt");
+  }
+
+  @Test
+  void cannotDeleteALibraryThatStillContainsDocuments() {
+    // #201/#305 code review: fk_documents_library_organization is RESTRICT, so deleting a library
+    // that still contains documents must be blocked with a clean 409, not surface an unhandled
+    // DataIntegrityViolationException (500).
+    UUID owner = createUser(organizationA);
+    LibraryResponse library = libraryService.createLibrary(new LibraryRequest("Nicht leer"), owner);
+    Document document = new Document("dienstanweisung.pdf", "/tmp/dienstanweisung.pdf", null, 10L);
+    document.setLibraryId(library.getId());
+    document.setOrganizationId(organizationA);
+    documentRepository.save(document);
+
+    assertThatThrownBy(() -> libraryService.deleteLibrary(library.getId(), owner, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    assertThat(libraryRepository.findById(library.getId())).isPresent();
+
+    // Once the library is empty, deletion succeeds - the check is a live guard, not a one-time
+    // flag on the library.
+    documentRepository.delete(document);
+    libraryService.deleteLibrary(library.getId(), owner, false);
+    assertThat(libraryRepository.findById(library.getId())).isEmpty();
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -32,6 +32,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -64,6 +66,7 @@ class KnowledgeLibraryServiceIntegrationTest {
   @Autowired private UserRepository userRepository;
   @Autowired private OrganizationRepository organizationRepository;
   @Autowired private DocumentRepository documentRepository;
+  @Autowired private PlatformTransactionManager transactionManager;
 
   private UUID organizationA;
   private UUID organizationB;
@@ -428,5 +431,39 @@ class KnowledgeLibraryServiceIntegrationTest {
     assertThatThrownBy(() -> libraryRepository.saveAndFlush(library))
         .isInstanceOf(DataIntegrityViolationException.class)
         .hasMessageContaining("fk_knowledge_libraries_owner_group_organization");
+  }
+
+  @Test
+  void insertPersonalLibraryIfAbsentWithANonExistentOwnerFailsInsteadOfSilentlyPersisting() {
+    // #201/#305 code review: ON CONFLICT ... DO NOTHING (see insertPersonalLibraryIfAbsent's
+    // Javadoc) only ever suppresses the one named partial unique index - a genuinely dangling
+    // owner must still violate fk_knowledge_libraries_owner_user exactly as the entity-based save
+    // above does, not be silently swallowed as if it were a race loss.
+    //
+    // A transaction is required around the call (unlike the saveAndFlush-based tests above):
+    // @Modifying custom @Query methods, unlike the inherited save/saveAndFlush methods, do not get
+    // an implicit transaction from the repository proxy and fail with "No active transaction for
+    // update or delete query" without one. A plain test-method @Transactional does not work here
+    // either - Spring wraps @BeforeEach/@AfterEach into that same transaction by default, and
+    // Postgres aborts the whole transaction on the constraint violation this test deliberately
+    // provokes, poisoning the next test method's setUp() on the same connection. Using this
+    // class's own TransactionTemplate mirrors exactly how KnowledgeLibraryService itself calls
+    // this method in production (its own requiresNewTransactionTemplate) and keeps the transaction
+    // - and its rollback on failure - fully scoped to this one call.
+    UUID nonExistentOwner = UUID.randomUUID();
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+    assertThatThrownBy(
+            () ->
+                transactionTemplate.executeWithoutResult(
+                    status ->
+                        libraryRepository.insertPersonalLibraryIfAbsent(
+                            UUID.randomUUID(),
+                            organizationA,
+                            "Meine Dokumente",
+                            "Private persoenliche Wissensbibliothek",
+                            nonExistentOwner)))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_knowledge_libraries_owner_user");
   }
 }

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
@@ -1,0 +1,98 @@
+package io.opaa.library;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opaa.auth.UserRepository;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.GroupRepository;
+import io.opaa.indexing.DocumentRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+
+/**
+ * Simulates the two concurrent first-login race #265 describes, without relying on real threads or
+ * timing - the library-side counterpart of {@code SpaceServiceTest}, which this class deliberately
+ * mirrors: {@link KnowledgeLibraryRepository#existsByOwnerUserIdAndPersonalTrue} is stubbed to
+ * answer as it would for the loser of the race (false before the attempt, true after a concurrent
+ * winner has committed), and {@link KnowledgeLibraryRepository#saveAndFlush} is stubbed to throw
+ * the {@link DataIntegrityViolationException} that {@code uk_knowledge_libraries_personal_owner}
+ * (migration 012) would raise for the losing insert.
+ */
+class KnowledgeLibraryServiceTest {
+
+  private KnowledgeLibraryRepository libraryRepository;
+  private PlatformTransactionManager transactionManager;
+  private KnowledgeLibraryService libraryService;
+
+  @BeforeEach
+  void setUp() {
+    libraryRepository = mock(KnowledgeLibraryRepository.class);
+    UserRepository userRepository = mock(UserRepository.class);
+    GroupRepository groupRepository = mock(GroupRepository.class);
+    GroupMembershipResolver membershipResolver = mock(GroupMembershipResolver.class);
+    DocumentRepository documentRepository = mock(DocumentRepository.class);
+    transactionManager = mock(PlatformTransactionManager.class);
+    when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
+    libraryService =
+        new KnowledgeLibraryService(
+            libraryRepository,
+            userRepository,
+            groupRepository,
+            membershipResolver,
+            documentRepository,
+            transactionManager);
+  }
+
+  @Test
+  void ensurePersonalLibraryReadsTheWinnersLibraryInsteadOfThrowing() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false, true);
+    when(libraryRepository.saveAndFlush(any(KnowledgeLibrary.class)))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint"
+                    + " \"uk_knowledge_libraries_personal_owner\""));
+
+    assertThatCode(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
+        .doesNotThrowAnyException();
+
+    verify(libraryRepository, times(2)).existsByOwnerUserIdAndPersonalTrue(userId);
+  }
+
+  @Test
+  void ensurePersonalLibraryPropagatesViolationsUnrelatedToTheRace() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false, false);
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("some other constraint violation");
+    when(libraryRepository.saveAndFlush(any(KnowledgeLibrary.class))).thenThrow(violation);
+
+    assertThatThrownBy(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
+        .isSameAs(violation);
+  }
+
+  @Test
+  void ensurePersonalLibraryIsANoOpWhenAPersonalLibraryAlreadyExists() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(true);
+
+    libraryService.ensurePersonalLibrary(userId, organizationId);
+
+    verify(libraryRepository, times(0)).saveAndFlush(any(KnowledgeLibrary.class));
+  }
+}

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
@@ -3,8 +3,10 @@ package io.opaa.library;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,13 +22,13 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 
 /**
- * Simulates the two concurrent first-login race #265 describes, without relying on real threads or
- * timing - the library-side counterpart of {@code SpaceServiceTest}, which this class deliberately
- * mirrors: {@link KnowledgeLibraryRepository#existsByOwnerUserIdAndPersonalTrue} is stubbed to
- * answer as it would for the loser of the race (false before the attempt, true after a concurrent
- * winner has committed), and {@link KnowledgeLibraryRepository#saveAndFlush} is stubbed to throw
- * the {@link DataIntegrityViolationException} that {@code uk_knowledge_libraries_personal_owner}
- * (migration 012) would raise for the losing insert.
+ * {@link KnowledgeLibraryService#ensurePersonalLibrary}'s race handling is delegated to {@link
+ * KnowledgeLibraryRepository#insertPersonalLibraryIfAbsent}'s {@code ON CONFLICT ... DO NOTHING}
+ * (#201/#305 code review) - the library-side counterpart of {@code SpaceServiceTest}, which this
+ * class deliberately mirrors after the same change there. What remains testable at the unit level
+ * is the one decision {@link KnowledgeLibraryService#ensurePersonalLibrary} itself still makes:
+ * skip the insert attempt entirely when {@code existsByOwnerUserIdAndPersonalTrue} already reports
+ * a personal library, otherwise delegate to the repository.
  */
 class KnowledgeLibraryServiceTest {
 
@@ -54,35 +56,16 @@ class KnowledgeLibraryServiceTest {
   }
 
   @Test
-  void ensurePersonalLibraryReadsTheWinnersLibraryInsteadOfThrowing() {
+  void ensurePersonalLibraryInsertsWhenNoPersonalLibraryExistsYet() {
     UUID userId = UUID.randomUUID();
     UUID organizationId = UUID.randomUUID();
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false);
 
-    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false, true);
-    when(libraryRepository.saveAndFlush(any(KnowledgeLibrary.class)))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key value violates unique constraint"
-                    + " \"uk_knowledge_libraries_personal_owner\""));
+    libraryService.ensurePersonalLibrary(userId, organizationId);
 
-    assertThatCode(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
-        .doesNotThrowAnyException();
-
-    verify(libraryRepository, times(2)).existsByOwnerUserIdAndPersonalTrue(userId);
-  }
-
-  @Test
-  void ensurePersonalLibraryPropagatesViolationsUnrelatedToTheRace() {
-    UUID userId = UUID.randomUUID();
-    UUID organizationId = UUID.randomUUID();
-
-    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false, false);
-    DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("some other constraint violation");
-    when(libraryRepository.saveAndFlush(any(KnowledgeLibrary.class))).thenThrow(violation);
-
-    assertThatThrownBy(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
-        .isSameAs(violation);
+    verify(libraryRepository)
+        .insertPersonalLibraryIfAbsent(
+            any(UUID.class), eq(organizationId), any(String.class), any(String.class), eq(userId));
   }
 
   @Test
@@ -93,6 +76,41 @@ class KnowledgeLibraryServiceTest {
 
     libraryService.ensurePersonalLibrary(userId, organizationId);
 
-    verify(libraryRepository, times(0)).saveAndFlush(any(KnowledgeLibrary.class));
+    verify(libraryRepository, never())
+        .insertPersonalLibraryIfAbsent(
+            any(UUID.class),
+            any(UUID.class),
+            any(String.class),
+            any(String.class),
+            any(UUID.class));
+  }
+
+  @Test
+  void ensurePersonalLibraryPropagatesAnyFailureFromTheInsert() {
+    // A genuine failure other than the partial-unique-index conflict (which the repository method
+    // itself absorbs via ON CONFLICT ... DO NOTHING and therefore never throws for) - e.g. a
+    // dangling ownerUserId - must still surface to the caller, not be swallowed.
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false);
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("fk_knowledge_libraries_owner_user violation");
+    doThrow(violation)
+        .when(libraryRepository)
+        .insertPersonalLibraryIfAbsent(
+            any(UUID.class), eq(organizationId), any(String.class), any(String.class), eq(userId));
+
+    assertThatThrownBy(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
+        .isSameAs(violation);
+  }
+
+  @Test
+  void ensurePersonalLibraryDoesNotThrowWhenTheInsertSucceedsOrIsANoOp() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(libraryRepository.existsByOwnerUserIdAndPersonalTrue(userId)).thenReturn(false);
+
+    assertThatCode(() -> libraryService.ensurePersonalLibrary(userId, organizationId))
+        .doesNotThrowAnyException();
   }
 }

--- a/backend/src/test/java/io/opaa/migration/Migration012KnowledgeLibrariesTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration012KnowledgeLibrariesTest.java
@@ -33,10 +33,12 @@ import org.testcontainers.utility.DockerImageName;
  * (see the package Javadoc, which names #201 explicitly).
  *
  * <p>The two mechanisms this test class exercises against each other, not just individually: {@link
- * #backfillIsResumableAcrossPartialProgress()} interrupts the batched backfill mid-run and re-runs
- * it, and {@link #compositeForeignKeyRejectsADocumentPointingAtALibraryFromAnotherOrganization()}
- * combines the composite foreign key with a cross-organization library to prove the constraint -
- * not just application code - is what stops the leak.
+ * #backfillOnlyTouchesRowsStillMissingALibraryAcrossASecondUpdateCall()} combines a second, real
+ * {@code liquibase.update()} call with rows the backfill's {@code WHERE library_id IS NULL}
+ * predicate must skip, and {@link
+ * #compositeForeignKeyRejectsADocumentPointingAtALibraryFromAnotherOrganization()} combines the
+ * composite foreign key with a cross-organization library to prove the constraint - not just
+ * application code - is what stops the leak.
  */
 @Testcontainers(disabledWithoutDocker = true)
 class Migration012KnowledgeLibrariesTest {
@@ -199,23 +201,27 @@ class Migration012KnowledgeLibrariesTest {
   }
 
   @Test
-  void backfillIsResumableAcrossPartialProgress() throws Exception {
-    // Simulates an interrupted migration run: apply only the changeSets up to and including the
-    // nullable column addition, seed documents, manually pre-assign some of them to the system
-    // library exactly as a partially completed backfill would have left them, then run the
-    // remaining changeSets (backfill + NOT NULL/FK enforcement) as the resumed run. The resumed
-    // run must only touch the still-NULL rows and must not fail or duplicate work on the
-    // already-migrated ones - the resumability the acceptance criteria require.
+  void backfillOnlyTouchesRowsStillMissingALibraryAcrossASecondUpdateCall() throws Exception {
+    // This does NOT test resumability within an interrupted transaction - the backfill changeSet
+    // is a single UPDATE inside one changeSet transaction (runInTransaction: true, Liquibase's
+    // default); a run that fails partway through rolls back entirely and is never partially
+    // applied (see the changeSet's own comment and the Resumierbarkeit section of
+    // docs/migrations/012-knowledge-library.md for why an earlier, batched version of this
+    // changeSet claimed otherwise and was wrong). What this test actually pins: the backfill's
+    // WHERE library_id IS NULL predicate only touches rows that still need it, so a second
+    // liquibase.update() call - the real DATABASECHANGELOG-level resumability this migration
+    // provides - does not fail or duplicate work if some rows were already assigned by other
+    // means (e.g. application code) between the two calls.
     applySchemaOnlyChangelog012();
 
-    UUID alreadyMigrated = UUID.randomUUID();
+    UUID alreadyAssigned = UUID.randomUUID();
     UUID stillPending1 = UUID.randomUUID();
     UUID stillPending2 = UUID.randomUUID();
-    insertDocument(alreadyMigrated, "already.pdf");
+    insertDocument(alreadyAssigned, "already.pdf");
     insertDocument(stillPending1, "pending1.pdf");
     insertDocument(stillPending2, "pending2.pdf");
-    // Hand-assign one document exactly as a partially completed backfill run would have left it -
-    // the knowledge_libraries table and the nullable columns already exist at this point (both are
+    // Assign one document by hand before the backfill changeSet ever runs - the
+    // knowledge_libraries table and the nullable columns already exist at this point (both are
     // part of the lib-schema context applied above), so this update is legal.
     try (Statement statement = connection.createStatement()) {
       statement.execute(
@@ -224,16 +230,16 @@ class Migration012KnowledgeLibrariesTest {
               + "', organization_id = '"
               + SEEDED_ORGANIZATION_ID
               + "' WHERE id = '"
-              + alreadyMigrated
+              + alreadyAssigned
               + "'");
     }
 
-    // Resume: apply the still-pending changeSets (backfill + enforcement) on top of the partial
-    // state above - a real second liquibase.update() call, not a simulation.
+    // Apply the still-pending changeSets (backfill + enforcement) as a second, real
+    // liquibase.update() call.
     resumeChangelog012();
 
     assertThat(countRows("documents")).isEqualTo(3);
-    for (UUID id : new UUID[] {alreadyMigrated, stillPending1, stillPending2}) {
+    for (UUID id : new UUID[] {alreadyAssigned, stillPending1, stillPending2}) {
       assertThat(columnValue("documents", "library_id", id.toString()))
           .isEqualTo(SYSTEM_LIBRARY_ID);
       assertThat(columnValue("documents", "organization_id", id.toString()))
@@ -249,7 +255,8 @@ class Migration012KnowledgeLibrariesTest {
             () ->
                 insertDocumentWithExplicitLibrary(
                     UUID.randomUUID(), "no-library.pdf", null, SEEDED_ORGANIZATION_ID))
-        .isInstanceOf(SQLException.class);
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("library_id");
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/migration/Migration012KnowledgeLibrariesTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration012KnowledgeLibrariesTest.java
@@ -1,0 +1,467 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 012 in isolation against a database built from the real, versioned
+ * changelog through changeSet 011 - the same pattern as {@code Migration011DirectorySyncTest}, with
+ * {@code test-master-through-011.yaml} as the pre-migration fixture. {@code
+ * connection.setAutoCommit(true)} is called after every {@code liquibase.update(...)} call, and the
+ * public schema is dropped and recreated between test methods, exactly as {@code
+ * Migration010SpaceUniquenessTest} established for multi-method migration tests in this package
+ * (see the package Javadoc, which names #201 explicitly).
+ *
+ * <p>The two mechanisms this test class exercises against each other, not just individually: {@link
+ * #backfillIsResumableAcrossPartialProgress()} interrupts the batched backfill mid-run and re-runs
+ * it, and {@link #compositeForeignKeyRejectsADocumentPointingAtALibraryFromAnotherOrganization()}
+ * combines the composite foreign key with a cross-organization library to prove the constraint -
+ * not just application code - is what stops the leak.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration012KnowledgeLibrariesTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+  private static final String SYSTEM_LIBRARY_ID = "00000000-0000-0000-0000-000000000002";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-011.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    connection.setAutoCommit(true);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+    connection.close();
+  }
+
+  @Test
+  void createsSystemLibraryReadableOnlyByDesignFailClosed() throws Exception {
+    applyChangelog012();
+
+    assertThat(columnValue("knowledge_libraries", "owner_type", SYSTEM_LIBRARY_ID))
+        .isEqualTo("SYSTEM");
+    assertThat(columnValueOrNull("knowledge_libraries", "owner_user_id", SYSTEM_LIBRARY_ID))
+        .isNull();
+    assertThat(columnValueOrNull("knowledge_libraries", "owner_group_id", SYSTEM_LIBRARY_ID))
+        .isNull();
+    assertThat(columnValue("knowledge_libraries", "visibility", SYSTEM_LIBRARY_ID))
+        .isEqualTo("PRIVATE");
+    assertThat(columnValue("knowledge_libraries", "listed", SYSTEM_LIBRARY_ID)).isEqualTo("f");
+    assertThat(columnValue("knowledge_libraries", "personal", SYSTEM_LIBRARY_ID)).isEqualTo("f");
+  }
+
+  @Test
+  void ownerCheckConstraintRejectsEveryMismatchBetweenOwnerTypeAndOwnerColumns() throws Exception {
+    applyChangelog012();
+    UUID someUser = insertUser(UUID.randomUUID());
+    UUID someGroup = insertGroup(UUID.randomUUID());
+
+    // USER without owner_user_id.
+    assertThatThrownBy(
+            () -> insertLibrary(UUID.randomUUID(), "USER", null, null, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_knowledge_libraries_owner");
+
+    // USER with owner_group_id set instead of owner_user_id.
+    assertThatThrownBy(
+            () ->
+                insertLibrary(UUID.randomUUID(), "USER", null, someGroup, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_knowledge_libraries_owner");
+
+    // GROUP without owner_group_id.
+    assertThatThrownBy(
+            () -> insertLibrary(UUID.randomUUID(), "GROUP", null, null, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_knowledge_libraries_owner");
+
+    // SYSTEM with an owner_user_id set.
+    assertThatThrownBy(
+            () ->
+                insertLibrary(UUID.randomUUID(), "SYSTEM", someUser, null, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_knowledge_libraries_owner");
+
+    // SYSTEM with an owner_group_id set.
+    assertThatThrownBy(
+            () ->
+                insertLibrary(
+                    UUID.randomUUID(), "SYSTEM", null, someGroup, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_knowledge_libraries_owner");
+  }
+
+  @Test
+  void foreignKeysRejectAnOwnerUserOrOwnerGroupThatDoesNotExist() throws Exception {
+    applyChangelog012();
+
+    assertThatThrownBy(
+            () ->
+                insertLibrary(
+                    UUID.randomUUID(), "USER", UUID.randomUUID(), null, "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_knowledge_libraries_owner_user");
+
+    assertThatThrownBy(
+            () ->
+                insertLibrary(
+                    UUID.randomUUID(), "GROUP", null, UUID.randomUUID(), "PRIVATE", false, false))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_knowledge_libraries_owner_group_organization");
+  }
+
+  @Test
+  void partialUniqueIndexAllowsOnlyOnePersonalLibraryPerOwnerButAnyNumberOfNonPersonalOnes()
+      throws Exception {
+    applyChangelog012();
+    UUID owner = insertUser(UUID.randomUUID());
+
+    insertLibrary(UUID.randomUUID(), "USER", owner, null, "PRIVATE", false, true);
+
+    assertThatThrownBy(
+            () -> insertLibrary(UUID.randomUUID(), "USER", owner, null, "PRIVATE", false, true))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uk_knowledge_libraries_personal_owner");
+
+    // A user may still own any number of non-personal libraries - the partial index must not
+    // restrict that, mirroring uk_spaces_personal_owner's guarantee for spaces (migration 010).
+    insertLibrary(UUID.randomUUID(), "USER", owner, null, "SHARED", true, false);
+    insertLibrary(UUID.randomUUID(), "USER", owner, null, "ORGANIZATION", true, false);
+  }
+
+  @Test
+  void backfillAssignsEveryPreExistingDocumentToTheSystemLibraryWithoutLosingRows()
+      throws Exception {
+    insertDocument(UUID.randomUUID(), "a.pdf");
+    insertDocument(UUID.randomUUID(), "b.pdf");
+    insertDocument(UUID.randomUUID(), "c.pdf");
+    assertThat(countRows("documents")).isEqualTo(3);
+
+    applyChangelog012();
+
+    assertThat(countRows("documents")).isEqualTo(3);
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery("SELECT library_id, organization_id FROM documents")) {
+      int rows = 0;
+      while (rs.next()) {
+        rows++;
+        assertThat(rs.getString("library_id")).isEqualTo(SYSTEM_LIBRARY_ID);
+        assertThat(rs.getString("organization_id")).isEqualTo(SEEDED_ORGANIZATION_ID);
+      }
+      assertThat(rows).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void backfillIsResumableAcrossPartialProgress() throws Exception {
+    // Simulates an interrupted migration run: apply only the changeSets up to and including the
+    // nullable column addition, seed documents, manually pre-assign some of them to the system
+    // library exactly as a partially completed backfill would have left them, then run the
+    // remaining changeSets (backfill + NOT NULL/FK enforcement) as the resumed run. The resumed
+    // run must only touch the still-NULL rows and must not fail or duplicate work on the
+    // already-migrated ones - the resumability the acceptance criteria require.
+    applySchemaOnlyChangelog012();
+
+    UUID alreadyMigrated = UUID.randomUUID();
+    UUID stillPending1 = UUID.randomUUID();
+    UUID stillPending2 = UUID.randomUUID();
+    insertDocument(alreadyMigrated, "already.pdf");
+    insertDocument(stillPending1, "pending1.pdf");
+    insertDocument(stillPending2, "pending2.pdf");
+    // Hand-assign one document exactly as a partially completed backfill run would have left it -
+    // the knowledge_libraries table and the nullable columns already exist at this point (both are
+    // part of the lib-schema context applied above), so this update is legal.
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "UPDATE documents SET library_id = '"
+              + SYSTEM_LIBRARY_ID
+              + "', organization_id = '"
+              + SEEDED_ORGANIZATION_ID
+              + "' WHERE id = '"
+              + alreadyMigrated
+              + "'");
+    }
+
+    // Resume: apply the still-pending changeSets (backfill + enforcement) on top of the partial
+    // state above - a real second liquibase.update() call, not a simulation.
+    resumeChangelog012();
+
+    assertThat(countRows("documents")).isEqualTo(3);
+    for (UUID id : new UUID[] {alreadyMigrated, stillPending1, stillPending2}) {
+      assertThat(columnValue("documents", "library_id", id.toString()))
+          .isEqualTo(SYSTEM_LIBRARY_ID);
+      assertThat(columnValue("documents", "organization_id", id.toString()))
+          .isEqualTo(SEEDED_ORGANIZATION_ID);
+    }
+  }
+
+  @Test
+  void enforcesNotNullAndCompositeForeignKeyOnDocumentsAfterBackfill() throws Exception {
+    applyChangelog012();
+
+    assertThatThrownBy(
+            () ->
+                insertDocumentWithExplicitLibrary(
+                    UUID.randomUUID(), "no-library.pdf", null, SEEDED_ORGANIZATION_ID))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  void compositeForeignKeyRejectsADocumentPointingAtALibraryFromAnotherOrganization()
+      throws Exception {
+    applyChangelog012();
+
+    UUID otherOrganization = UUID.randomUUID();
+    insertOrganization(otherOrganization);
+    UUID otherOrgOwner = insertUser(UUID.randomUUID(), otherOrganization.toString());
+    UUID libraryInOtherOrganization = UUID.randomUUID();
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO knowledge_libraries "
+              + "(id, organization_id, name, owner_type, owner_user_id, visibility, listed,"
+              + " personal, created_at, updated_at) VALUES ('"
+              + libraryInOtherOrganization
+              + "', '"
+              + otherOrganization
+              + "', 'Andere Organisation', 'USER', '"
+              + otherOrgOwner
+              + "', 'PRIVATE', false, false, now(), now())");
+    }
+
+    // library_id points at a real library, but organization_id on the document does not match
+    // that library's organization_id - the exact cross-tenant mismatch
+    // fk_documents_library_organization exists to reject at the database level, not just in
+    // application code.
+    assertThatThrownBy(
+            () ->
+                insertDocumentWithExplicitLibrary(
+                    UUID.randomUUID(),
+                    "cross-org.pdf",
+                    libraryInOtherOrganization.toString(),
+                    SEEDED_ORGANIZATION_ID))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_documents_library_organization");
+  }
+
+  private void applyChangelog012() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/012-knowledge-libraries.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  /**
+   * Applies only the {@code lib-schema}-context changeSets (table creation, system library seed,
+   * nullable column addition) - simulates a migration run interrupted before the backfill. See the
+   * context labels documented at the top of 012-knowledge-libraries.yaml.
+   */
+  private void applySchemaOnlyChangelog012() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/012-knowledge-libraries.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts("lib-schema"));
+    connection.setAutoCommit(true);
+  }
+
+  /**
+   * Applies every changeSet not yet recorded in DATABASECHANGELOG - an empty {@link Contexts}
+   * matches all changeSets regardless of their {@code context} attribute, so this resumes exactly
+   * where {@link #applySchemaOnlyChangelog012()} left off (the schema changeSets are skipped as
+   * already-applied; only the backfill and enforcement changeSets actually run).
+   */
+  private void resumeChangelog012() throws Exception {
+    applyChangelog012();
+  }
+
+  private void insertOrganization(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO organizations (id, name, created_at) VALUES ('"
+              + id
+              + "', 'Org "
+              + id
+              + "', now()) ON CONFLICT (id) DO NOTHING");
+    }
+  }
+
+  private void insertLibrary(
+      UUID id,
+      String ownerType,
+      UUID ownerUserId,
+      UUID ownerGroupId,
+      String visibility,
+      boolean listed,
+      boolean personal)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO knowledge_libraries "
+              + "(id, organization_id, name, owner_type, owner_user_id, owner_group_id,"
+              + " visibility, listed, personal, created_at, updated_at) VALUES ('"
+              + id
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', 'Bibliothek "
+              + id
+              + "', '"
+              + ownerType
+              + "', "
+              + (ownerUserId == null ? "NULL" : "'" + ownerUserId + "'")
+              + ", "
+              + (ownerGroupId == null ? "NULL" : "'" + ownerGroupId + "'")
+              + ", '"
+              + visibility
+              + "', "
+              + listed
+              + ", "
+              + personal
+              + ", now(), now())");
+    }
+  }
+
+  private UUID insertUser(UUID id) throws SQLException {
+    return insertUser(id, SEEDED_ORGANIZATION_ID);
+  }
+
+  private UUID insertUser(UUID id, String organizationId) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO users (id, subject, issuer, system_role, organization_id, created_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + id
+              + "', 'test-issuer', 'USER', '"
+              + organizationId
+              + "', now())");
+    }
+    return id;
+  }
+
+  private UUID insertGroup(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO groups (id, organization_id, kind, name, created_at, updated_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', 'AD_HOC', 'Gruppe "
+              + id
+              + "', now(), now())");
+    }
+    return id;
+  }
+
+  private void insertDocument(UUID id, String fileName) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO documents (id, file_name, file_path, status, source_type) VALUES ('"
+              + id
+              + "', '"
+              + fileName
+              + "', '/tmp/"
+              + fileName
+              + "', 'INDEXED', 'FILESYSTEM')");
+    }
+  }
+
+  private void insertDocumentWithExplicitLibrary(
+      UUID id, String fileName, String libraryId, String organizationId) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO documents (id, file_name, file_path, status, source_type, library_id,"
+              + " organization_id) VALUES ('"
+              + id
+              + "', '"
+              + fileName
+              + "', '/tmp/"
+              + fileName
+              + "', 'INDEXED', 'FILESYSTEM', "
+              + (libraryId == null ? "NULL" : "'" + libraryId + "'")
+              + ", "
+              + (organizationId == null ? "NULL" : "'" + organizationId + "'")
+              + ")");
+    }
+  }
+
+  private long countRows(String table) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs = statement.executeQuery("SELECT count(*) FROM " + table)) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private String columnValue(String table, String column, String id) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT " + column + " FROM " + table + " WHERE id = '" + id + "'")) {
+      rs.next();
+      return rs.getString(1);
+    }
+  }
+
+  private String columnValueOrNull(String table, String column, String id) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT " + column + " FROM " + table + " WHERE id = '" + id + "'")) {
+      rs.next();
+      String value = rs.getString(1);
+      return rs.wasNull() ? null : value;
+    }
+  }
+}

--- a/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
@@ -20,6 +20,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
@@ -52,6 +54,7 @@ class SpaceRepositoryTest {
   @Autowired private KnowledgeLibraryRepository libraryRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private OrganizationRepository organizationRepository;
+  @Autowired private PlatformTransactionManager transactionManager;
 
   private UUID org;
 
@@ -213,5 +216,40 @@ class SpaceRepositoryTest {
     assertThatThrownBy(() -> spaceRepository.saveAndFlush(space))
         .isInstanceOf(DataIntegrityViolationException.class)
         .hasMessageContaining("fk_spaces_organization");
+  }
+
+  @Test
+  void insertPersonalSpaceIfAbsentWithANonExistentOwnerFailsInsteadOfSilentlyPersisting() {
+    // #201/#305 code review: ON CONFLICT ... DO NOTHING (see insertPersonalSpaceIfAbsent's
+    // Javadoc) only ever suppresses the one named partial unique index - a genuinely dangling
+    // owner must still violate fk_spaces_owner exactly as the entity-based save above does, not be
+    // silently swallowed as if it were a race loss.
+    //
+    // A transaction is required around the call (unlike the saveAndFlush-based tests above):
+    // @Modifying custom @Query methods, unlike the inherited save/saveAndFlush methods, do not get
+    // an implicit transaction from the repository proxy and fail with "No active transaction for
+    // update or delete query" without one. A plain test-method @Transactional does not work here
+    // either - Spring wraps @BeforeEach/@AfterEach into that same transaction by default, and
+    // Postgres aborts the whole transaction on the constraint violation this test deliberately
+    // provokes, poisoning the next test method's cleanUp() on the same connection. Using this
+    // class's own TransactionTemplate mirrors exactly how SpaceService itself calls this method in
+    // production (its own requiresNewTransactionTemplate) and keeps the transaction - and its
+    // rollback on failure - fully scoped to this one call.
+    UUID nonExistentOwner = UUID.randomUUID();
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+    assertThatThrownBy(
+            () ->
+                transactionTemplate.executeWithoutResult(
+                    status ->
+                        spaceRepository.insertPersonalSpaceIfAbsent(
+                            UUID.randomUUID(),
+                            UUID.randomUUID(),
+                            "Meine Dokumente",
+                            "Privater persoenlicher Space",
+                            nonExistentOwner,
+                            org)))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("fk_spaces_owner");
   }
 }

--- a/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opaa.TestcontainersConfiguration;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.KnowledgeLibraryRepository;
 import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
 import java.util.List;
@@ -48,6 +49,7 @@ class SpaceRepositoryTest {
 
   @Autowired private SpaceRepository spaceRepository;
   @Autowired private SpaceMembershipRepository spaceMembershipRepository;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private OrganizationRepository organizationRepository;
 
@@ -62,6 +64,13 @@ class SpaceRepositoryTest {
     // it again in tearDown() - see tearDown() below.
     spaceMembershipRepository.deleteAll();
     spaceRepository.deleteAll();
+    // #201: fk_knowledge_libraries_owner_user also references users now, not just fk_spaces_owner
+    // - a leftover personal library from another test class sharing this context (e.g.
+    // UserServicePersonalSpaceIntegrationTest, which has no @AfterEach) would otherwise block
+    // userRepository.deleteAll() below with a RESTRICT violation on that unrelated user. Never
+    // touches the one seeded SYSTEM library.
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
     org = organizationRepository.save(new Organization(UUID.randomUUID(), "Org")).getId();
   }
@@ -73,6 +82,8 @@ class SpaceRepositoryTest {
     // Organization.DEFAULT_ID or organizations created by other tests sharing this context.
     spaceMembershipRepository.deleteAll();
     spaceRepository.deleteAll();
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
     organizationRepository.deleteById(org);
   }

--- a/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import io.opaa.api.dto.SpaceResponse;
 import io.opaa.api.dto.SpaceUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.KnowledgeLibraryRepository;
 import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
 import java.util.List;
@@ -47,6 +48,7 @@ class SpaceServiceIntegrationTest {
   @Autowired private SpaceService spaceService;
   @Autowired private SpaceRepository spaceRepository;
   @Autowired private SpaceMembershipRepository membershipRepository;
+  @Autowired private KnowledgeLibraryRepository libraryRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private OrganizationRepository organizationRepository;
 
@@ -62,6 +64,13 @@ class SpaceServiceIntegrationTest {
     // them again in tearDown() - see tearDown() below.
     membershipRepository.deleteAll();
     spaceRepository.deleteAll();
+    // #201: fk_knowledge_libraries_owner_user also references users now, not just fk_spaces_owner
+    // - a leftover personal library from another test class sharing this context (e.g.
+    // UserServicePersonalSpaceIntegrationTest, which has no @AfterEach) would otherwise block
+    // userRepository.deleteAll() below with a RESTRICT violation on that unrelated user. Never
+    // touches the one seeded SYSTEM library.
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
     organizationA =
         organizationRepository.save(new Organization(UUID.randomUUID(), "Org A")).getId();
@@ -77,6 +86,8 @@ class SpaceServiceIntegrationTest {
     // sharing this context.
     membershipRepository.deleteAll();
     spaceRepository.deleteAll();
+    libraryRepository.deleteAll(
+        libraryRepository.findAll().stream().filter(l -> !l.isSystemLibrary()).toList());
     userRepository.deleteAll();
     organizationRepository.deleteAllById(List.of(organizationA, organizationB));
   }

--- a/backend/src/test/java/io/opaa/space/SpaceServiceTest.java
+++ b/backend/src/test/java/io/opaa/space/SpaceServiceTest.java
@@ -3,8 +3,10 @@ package io.opaa.space;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,12 +19,18 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 
 /**
- * Simulates the two concurrent first-login race #265 describes, without relying on real threads or
- * timing: {@link SpaceRepository#existsByOwnerIdAndKind} is stubbed to answer as it would for the
- * loser of the race (false before the attempt, true after a concurrent winner has committed), and
- * {@link SpaceRepository#saveAndFlush} is stubbed to throw the {@link
- * DataIntegrityViolationException} that {@code uk_spaces_personal_owner} (migration 010) would
- * raise for the losing insert.
+ * {@link SpaceService#ensurePersonalSpace}'s race handling (#265) is now entirely delegated to
+ * {@link SpaceRepository#insertPersonalSpaceIfAbsent}'s {@code ON CONFLICT ... DO NOTHING} (#201/
+ * #305 code review) - there is no more application-level catch-and-reread branch to simulate here,
+ * unlike the version of this test that predates that change. What remains testable at the unit
+ * level is the one decision {@link SpaceService#ensurePersonalSpace} itself still makes: skip the
+ * insert attempt entirely when {@code existsByOwnerIdAndKind} already reports a personal space,
+ * otherwise delegate to the repository. A {@link PlatformTransactionManager} is still mocked here
+ * (not a real one) because {@link SpaceService} constructs its own {@link
+ * org.springframework.transaction.support.TransactionTemplate} from it in the constructor; {@code
+ * TransactionTemplate#executeWithoutResult} invokes the callback synchronously regardless of
+ * whether the underlying transaction manager is real, so the mocked repository call inside it is
+ * still observable via {@code verify(...)} below.
  */
 class SpaceServiceTest {
 
@@ -40,40 +48,21 @@ class SpaceServiceTest {
   }
 
   @Test
-  void ensurePersonalSpaceReadsTheWinnersSpaceInsteadOfThrowing() {
+  void ensurePersonalSpaceInsertsWhenNoPersonalSpaceExistsYet() {
     UUID userId = UUID.randomUUID();
     UUID organizationId = UUID.randomUUID();
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)).thenReturn(false);
 
-    // First call: this login has not created a personal space yet. Second call (the race-loss
-    // fallback check): a concurrent login already committed one while this insert was failing.
-    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL))
-        .thenReturn(false, true);
-    when(spaceRepository.saveAndFlush(any(Space.class)))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key value violates unique constraint \"uk_spaces_personal_owner\""));
+    spaceService.ensurePersonalSpace(userId, organizationId);
 
-    assertThatCode(() -> spaceService.ensurePersonalSpace(userId, organizationId))
-        .doesNotThrowAnyException();
-
-    verify(spaceRepository, times(2)).existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL);
-  }
-
-  @Test
-  void ensurePersonalSpacePropagatesViolationsUnrelatedToTheRace() {
-    UUID userId = UUID.randomUUID();
-    UUID organizationId = UUID.randomUUID();
-
-    // The personal space still does not exist after the failed insert - so the violation was not
-    // caused by a concurrent winner, and must not be swallowed.
-    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL))
-        .thenReturn(false, false);
-    DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("some other constraint violation");
-    when(spaceRepository.saveAndFlush(any(Space.class))).thenThrow(violation);
-
-    assertThatThrownBy(() -> spaceService.ensurePersonalSpace(userId, organizationId))
-        .isSameAs(violation);
+    verify(spaceRepository)
+        .insertPersonalSpaceIfAbsent(
+            any(UUID.class),
+            any(UUID.class),
+            any(String.class),
+            any(String.class),
+            eq(userId),
+            eq(organizationId));
   }
 
   @Test
@@ -84,6 +73,49 @@ class SpaceServiceTest {
 
     spaceService.ensurePersonalSpace(userId, organizationId);
 
-    verify(spaceRepository, times(0)).saveAndFlush(any(Space.class));
+    verify(spaceRepository, never())
+        .insertPersonalSpaceIfAbsent(
+            any(UUID.class),
+            any(UUID.class),
+            any(String.class),
+            any(String.class),
+            any(UUID.class),
+            any(UUID.class));
+  }
+
+  @Test
+  void ensurePersonalSpacePropagatesAnyFailureFromTheInsert() {
+    // A genuine failure other than the partial-unique-index conflict (which the repository method
+    // itself absorbs via ON CONFLICT ... DO NOTHING and therefore never throws for) - e.g. a
+    // dangling ownerId violating fk_spaces_owner - must still surface to the caller, not be
+    // swallowed. There is no "was it the race or a real violation" distinction to make anymore;
+    // whatever the repository throws propagates as-is.
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)).thenReturn(false);
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("fk_spaces_owner violation");
+    doThrow(violation)
+        .when(spaceRepository)
+        .insertPersonalSpaceIfAbsent(
+            any(UUID.class),
+            any(UUID.class),
+            any(String.class),
+            any(String.class),
+            eq(userId),
+            eq(organizationId));
+
+    assertThatThrownBy(() -> spaceService.ensurePersonalSpace(userId, organizationId))
+        .isSameAs(violation);
+  }
+
+  @Test
+  void ensurePersonalSpaceDoesNotThrowWhenTheInsertSucceedsOrIsANoOp() {
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    when(spaceRepository.existsByOwnerIdAndKind(userId, SpaceKind.PERSONAL)).thenReturn(false);
+
+    assertThatCode(() -> spaceService.ensurePersonalSpace(userId, organizationId))
+        .doesNotThrowAnyException();
   }
 }

--- a/backend/src/test/resources/db/changelog/test-master-through-011.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-011.yaml
@@ -1,3 +1,13 @@
+# Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
+# changeSet 011 - i.e. the schema exactly as it existed immediately before migration 012, which
+# builds on this same pre-migration state.
+#
+# Used by:
+# - Migration012KnowledgeLibrariesTest, to build a realistic pre-migration database (via the real,
+#   versioned changelog files, not a hand-rolled schema) and then apply 012 in isolation.
+#
+# See test-master-through-010.yaml and Migration011DirectorySyncTest for the pattern this fixture
+# follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml
@@ -21,5 +31,3 @@ databaseChangeLog:
       file: db/changelog/changes/010-space-uniqueness-and-membership-index.yaml
   - include:
       file: db/changelog/changes/011-directory-sync.yaml
-  - include:
-      file: db/changelog/changes/012-knowledge-libraries.yaml

--- a/docs/features/spaces-and-assets.md
+++ b/docs/features/spaces-and-assets.md
@@ -513,6 +513,14 @@ Der Gedanke, alles einheitlich als Asset zu modellieren, ist naheliegend, trägt
 
 ### Dokumente liegen in Bibliotheken
 
+**Umsetzungsstand:** Die Wissensbibliothek als Container ist mit #201 umgesetzt (Migration 012 in
+[docs/migrations/012-knowledge-library.md](../migrations/012-knowledge-library.md)) — Eigentümerschaft
+(Nutzer oder Gruppe), Organisationsgrenze, Sichtbarkeitsstufen, `listed`-Flag und die Zuweisung jedes
+bestehenden Dokuments an eine System-Bibliothek. Die abgestuften Asset-Rollen weiter unten
+(`USER`/`VIEWER`/`EDITOR`/`MANAGER`/`OWNER`) und die rechtebewusste Vektorsuche folgen mit #202 — bis
+dahin gilt eine grobe Zugriffslogik (Eigentümer, Gruppenmitglied, `ORGANIZATION`-Sichtbarkeit,
+System-Admin), dokumentiert auf `KnowledgeLibraryService`.
+
 Der Dokumentencontainer ist die Wissensbibliothek, nicht der Space. Jedes Dokument gehört zu genau einer Bibliothek; jeder Chunk trägt die Bibliotheks-Kennung als Filterachse.
 
 Das ist einfacher als das bisherige Konzept: Aus einer n:m-Beziehung Dokument→Workspaces wird eine n:1-Beziehung Dokument→Bibliothek. Die Mehrfachverwendung wandert eine Ebene höher — eine Bibliothek ist in mehreren Spaces assoziiert —, wo sie nichts kostet, weil sie nicht je Chunk materialisiert werden muss.

--- a/docs/migrations/010-space-uniqueness-and-membership-index.md
+++ b/docs/migrations/010-space-uniqueness-and-membership-index.md
@@ -43,15 +43,14 @@ Komplexität hinzu, wenn Löschen bereits verlustfrei ist.
 ### Race in `SpaceService.ensurePersonalSpace`
 
 `ensurePersonalSpace` prüfte bisher mit `existsByOwnerIdAndKind` und legte danach an — ohne
-Absicherung auf Datenbankebene. Der Index oben schließt die Lücke, verlagert das Problem aber auf
-den Anwendungscode: Der Verlierer eines gleichzeitigen ersten Logins erhält jetzt eine
-`DataIntegrityViolationException` beim Insert. `ensurePersonalSpace` fängt diese ab und liest den
-bereits vom Gewinner angelegten Space, statt einen 500 zu werfen. Der Insert-Versuch läuft dazu in
-einer eigenen `REQUIRES_NEW`-Transaktion: Auf Postgres bricht eine fehlgeschlagene Anweisung die
-gesamte umschließende Transaktion ab, sodass ein Auffangen der Verletzung innerhalb derselben
-Transaktion, die den Insert ausgeführt hat, jede nachfolgende Anweisung in dieser Transaktion
-ebenfalls scheitern ließe. Details siehe Klassenkommentar auf
-`SpaceService.ensurePersonalSpace`.
+Absicherung auf Datenbankebene. Der Index oben schließt die Lücke. Ursprünglich (bis #201/#305)
+fing `ensurePersonalSpace` dazu die `DataIntegrityViolationException` des Verlierers ab und las den
+bereits vom Gewinner angelegten Space erneut — dieser Mechanismus **existiert nicht mehr**: Seit
+#201/#305 übernimmt `SpaceRepository.insertPersonalSpaceIfAbsent` die Race-Behandlung vollständig
+in der Datenbank über ein einzelnes `INSERT ... ON CONFLICT (owner_id) WHERE kind = 'PERSONAL' DO
+NOTHING`, sodass ein Verlierer gar keine Exception mehr auslöst, die abgefangen werden müsste, und
+kein erneutes Lesen mehr nötig ist (der Aufrufer erhält ohnehin keinen Rückgabewert). Details siehe
+Klassenkommentar auf `SpaceService.ensurePersonalSpace` und `SpaceRepository.insertPersonalSpaceIfAbsent`.
 
 **Regression nach dem Merge (Fix-PR, Referenz statt eigener Nummer hier — siehe Git-Historie):**
 Die `REQUIRES_NEW`-Transaktion oben löst die Race zwischen zwei `ensurePersonalSpace`-Aufrufen,
@@ -125,8 +124,11 @@ es das `public`-Schema nach jeder Testmethode droppt und neu anlegt (`resetSchem
 Methode bei einer leeren Datenbank inklusive leerem `DATABASECHANGELOG` startet. Dieses Muster ist
 für künftige Migrationstests mit mehreren Testmethoden zu übernehmen (siehe #237, #238).
 
-Der race-sichere Anwendungscode-Pfad in `SpaceService.ensurePersonalSpace` ist separat in
-`SpaceServiceTest` abgedeckt (reiner Mockito-Test, kein Testcontainer): Er simuliert den
-gleichzeitigen ersten Login, indem `existsByOwnerIdAndKind` und `saveAndFlush` so gestubbt werden,
-wie sie sich für den Verlierer des Rennens verhalten würden — deterministisch statt über echte
-Threads und Timing.
+Der Anwendungscode-Pfad in `SpaceService.ensurePersonalSpace` ist separat in `SpaceServiceTest`
+abgedeckt (reiner Mockito-Test, kein Testcontainer): Er prüft die eine Entscheidung, die
+`ensurePersonalSpace` seit #201/#305 noch selbst trifft — den Insert-Versuch bei einem positiven
+`existsByOwnerIdAndKind`-Ergebnis zu überspringen — sowie, dass eine echte, vom Repository
+geworfene Verletzung (z. B. ein hängender `ownerId`) unverändert durchgereicht wird. Die eigentliche
+Race-Behandlung liegt seither vollständig in der Datenbank (`SpaceRepository.insertPersonalSpaceIfAbsent`,
+`ON CONFLICT ... DO NOTHING`) und wird gegen das echte Schema in `SpaceRepositoryTest` geprüft
+(`insertPersonalSpaceIfAbsentWithANonExistentOwnerFailsInsteadOfSilentlyPersisting`).

--- a/docs/migrations/012-knowledge-library.md
+++ b/docs/migrations/012-knowledge-library.md
@@ -211,11 +211,25 @@ das Fail-closed-Verhalten der System-Bibliothek, das Zusammenspiel mit
 `GroupMembershipResolver`s Cache-Invalidierung) ist separat in
 `backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java` abgedeckt (echtes
 Postgres-Schema über Liquibase, `ddl-auto=none`, nach demselben Muster wie
-`SpaceServiceIntegrationTest`). Die Race-Behandlung von
-`KnowledgeLibraryService#ensurePersonalLibrary` ist in
-`backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java` abgedeckt (reiner
-Mockito-Test, kein Testcontainer, spiegelt `SpaceServiceTest`). Das Zusammenspiel von persönlichem
-Space und persönlicher Bibliothek bei der Nutzeranlage — beide werden immer gemeinsam versucht, auch
-wenn einer der beiden Aufrufe fehlschlägt — ist in
+`SpaceServiceIntegrationTest`). Diese Klasse enthält seit #201/#305 auch
+`insertPersonalLibraryIfAbsentWithANonExistentOwnerFailsInsteadOfSilentlyPersisting`: den Nachweis
+gegen das echte Schema, dass `ON CONFLICT ... DO NOTHING` ausschließlich den benannten partiellen
+Unique-Index abfängt und eine echte Fremdschlüsselverletzung (hängender Eigentümer) weiterhin normal
+wirft.
+
+Die eigentliche Race-Behandlung von `KnowledgeLibraryService#ensurePersonalLibrary` liegt seit
+#201/#305 vollständig in der Datenbank
+(`KnowledgeLibraryRepository.insertPersonalLibraryIfAbsent`, `ON CONFLICT ... DO NOTHING` gegen
+`uk_knowledge_libraries_personal_owner`) — ein Verlierer löst keine Exception mehr aus, die
+`ensurePersonalLibrary` abfangen müsste. `KnowledgeLibraryServiceTest` (reiner Mockito-Test, kein
+Testcontainer, spiegelt `SpaceServiceTest`) prüft die eine Entscheidung, die die Methode noch selbst
+trifft: den Insert-Versuch bei bereits vorhandener persönlicher Bibliothek zu überspringen, und dass
+eine echte Repository-Verletzung unverändert durchgereicht wird.
+
+Das Zusammenspiel von persönlichem Space und persönlicher Bibliothek bei der Nutzeranlage — beide
+werden immer gemeinsam versucht, auch wenn einer der beiden Aufrufe fehlschlägt, über ein
+prozesslokales Lock je Nutzer serialisiert (`UserService#provisioningLockFor`) — ist in
 `backend/src/test/java/io/opaa/auth/UserServiceTest.java` und
-`backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java` abgedeckt.
+`backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java` abgedeckt; die
+12-Thread-Regression gegen echten Verbindungspool-Druck in
+`backend/src/test/java/io/opaa/auth/UserServiceCreationRaceIntegrationTest.java`.

--- a/docs/migrations/012-knowledge-library.md
+++ b/docs/migrations/012-knowledge-library.md
@@ -82,35 +82,39 @@ simulieren, statt ihn nur zu behaupten (siehe unten).
 
 ## Resumierbarkeit
 
-Jedes Changeset ist eine eigene Postgres-Transaktion (Liquibase-Standard). Bricht ein Lauf mitten in
-der Datei ab, sind bereits abgeschlossene Changesets in `DATABASECHANGELOG` vermerkt; ein erneuter
-Lauf setzt exakt beim ersten nicht abgeschlossenen Changeset fort.
+Jedes Changeset ist eine eigene Postgres-Transaktion (Liquibase-Standard, `runInTransaction: true`).
+Bricht ein Lauf mitten in der Datei ab, sind bereits abgeschlossene Changesets in
+`DATABASECHANGELOG` vermerkt; ein erneuter Lauf setzt exakt beim ersten nicht abgeschlossenen
+Changeset fort. Das ist die Ebene, auf der diese Migration tatsächlich resumierbar ist — nicht
+innerhalb eines einzelnen Changesets.
 
-Der Backfill selbst (`012-backfill-document-library-id`) geht darüber hinaus: Er ist **innerhalb**
-seines eigenen Changesets resumierbar, nicht nur zwischen Changesets. Statt eines einzelnen
-`UPDATE`-Statements über die gesamte Tabelle verarbeitet ein `DO`-Block Batches von 5 000 Zeilen in
-einer Schleife (`WHERE library_id IS NULL ... LIMIT batch_size FOR UPDATE SKIP LOCKED`), bis keine
-Zeile mehr fehlt. Das hat zwei Gründe:
+**Korrektur gegenüber einer früheren Fassung dieses Dokuments:** Der Backfill
+(`012-backfill-document-library-id`) war ursprünglich als Batch-Schleife in einem PL/pgSQL-`DO`-Block
+umgesetzt, mit der Behauptung, jeder Batch committe für sich und ein Abbruch hinterlasse einen Teil
+bereits zugewiesen. **Das ist falsch und wurde im Review widerlegt:** Ein `DO`-Block läuft vollständig
+innerhalb der einen Transaktion des umschließenden Changesets; er kann darin nicht committen. Ein
+Abbruch nach N Batches rollt alle N zurück, nicht nur den unfertigen Rest — empirisch nachgestellt mit
+`batch_size = 1` und einem simulierten Fehler nach zwei Batches: beide `RAISE NOTICE`-Meldungen
+erscheinen im Log, aber `rows assigned after the interruption = 0`.
 
-1. **Skalierung.** Ein einzelnes `UPDATE` über eine sehr große Tabelle hielte eine lange laufende
-   Transaktion offen. Batches vermeiden das, ohne die Garantie zu schwächen — jeder Batch committet
-   für sich (implizit, da `DO`-Blöcke innerhalb der äußeren Changeset-Transaktion laufen und diese am
-   Ende des Changesets committet; die Batches selbst sind idempotent, siehe Punkt 2).
-2. **Wiederaufsetzbarkeit.** Jeder Batch filtert erneut auf `library_id IS NULL` — bereits migrierte
-   Zeilen werden nie wieder angefasst. Ein Abbruch mitten im Lauf (Verbindungsabbruch, Neustart der
-   Anwendung während der Migration) hinterlässt einen Teil der Zeilen bereits zugewiesen und den Rest
-   unverändert `NULL`; ein erneuter Lauf des Changesets — oder des gesamten Changelogs beim nächsten
-   Anwendungsstart — führt exakt dort fort, wo der vorherige aufgehört hat, ohne Duplikate oder
-   übersprungene Zeilen.
+Der Changeset ist deshalb jetzt ein einzelnes `UPDATE documents SET library_id = ..., organization_id
+= ... WHERE library_id IS NULL` — eine Transaktion, alle passenden Zeilen oder keine. Das ist beim
+aktuellen Datenbestand (Projekt vor 1.0, kein produktiver Bestand in relevanter Größenordnung) die
+ehrlichere und einfachere Garantie, ohne die Batch-Schleife, die keine der ihr zugeschriebenen
+Eigenschaften tatsächlich hatte. Sollte die Dokumentenzahl irgendwann eine echte
+Batch-Wiederaufsetzbarkeit erfordern, braucht das `runInTransaction: false` auf dem Changeset und
+explizite Commits je Batch — dann, aber erst dann, ist `FOR UPDATE SKIP LOCKED` das richtige Werkzeug
+gegen konkurrierende Sperren statt eine Gefahrenquelle (eine Zeile, die eine andere Session sperrt,
+würde sonst übersprungen; blieben nur gesperrte Zeilen übrig, endete die Schleife vorzeitig mit
+`ROW_COUNT = 0`, und der nachfolgende `NOT NULL`-Changeset schlüge auf halb migriertem Bestand fehl).
 
-Jeder Batch meldet sein Ergebnis über `RAISE NOTICE` im Migrationslog — das Mengengerüst des
-Trockenlaufs (siehe unten) lässt sich damit auch während eines echten Laufs live beobachten.
-
-`Migration012KnowledgeLibrariesTest#backfillIsResumableAcrossPartialProgress` prüft die
-Wiederaufsetzbarkeit nicht nur behauptend, sondern tatsächlich: Es wendet zunächst nur die
-`lib-schema`-Changesets an, weist ein Dokument von Hand so zu, wie ein teilweise abgeschlossener
-Backfill es hinterlassen hätte, und wendet dann die verbleibenden Changesets als echten zweiten
-`liquibase.update()`-Aufruf an — nicht als Simulation innerhalb eines einzigen Laufs.
+`Migration012KnowledgeLibrariesTest#backfillHandlesInterruptedSchemaOnlyProgressOnResume` prüft, was
+diese Fassung tatsächlich leistet: Nach den `lib-schema`-Changesets (Tabelle, Seed, nullable Spalten)
+angewendet und einem Dokument von Hand so zugewiesen, wie es der Fall wäre, wenn zwischen zwei
+`liquibase.update()`-Läufen jemand manuell eingegriffen hätte, läuft der Backfill-Changeset als echter
+zweiter Aufruf und lässt das bereits zugewiesene Dokument unverändert, während die übrigen migriert
+werden — das idempotente `WHERE library_id IS NULL`-Prädikat, nicht Wiederaufsetzbarkeit innerhalb
+einer unterbrochenen Transaktion, die dieser Changeset nie erzeugen kann.
 
 ## Trockenlauf mit Mengengerüst
 
@@ -120,8 +124,7 @@ Liquibase-Gradle-Plugin-Task besitzt:
 
 1. Kopie der Zieldatenbank in einen frischen `docker compose up postgres`-Container einspielen.
 2. Die Anwendung gegen diese Kopie starten. Liquibase wendet automatisch alle ausstehenden
-   Changesets an, einschließlich `012-knowledge-libraries.yaml`. Das `RAISE NOTICE` des Backfills
-   erscheint im Anwendungslog mit der Anzahl migrierter Dokumente je Batch.
+   Changesets an, einschließlich `012-knowledge-libraries.yaml`.
 3. Das Mengengerüst vor und nach dem Lauf vergleichen:
 
    Vor der Migration:
@@ -195,8 +198,10 @@ zwischen Testmethoden. Er deckt:
   beschränkt aber nicht die Anzahl nicht-persönlicher Bibliotheken.
 - Der Backfill weist jedes bestehende Dokument der System-Bibliothek und ihrer Organisation zu, ohne
   eine Zeile zu verlieren.
-- Der Backfill ist über einen echten zweiten `liquibase.update()`-Aufruf hinweg wiederaufsetzbar
-  (siehe oben).
+- Ein zweiter `liquibase.update()`-Aufruf, der die `lib-schema`-Changesets bereits angewendet
+  vorfindet, lässt eine von Hand zugewiesene Zeile unverändert und migriert nur den Rest — das
+  idempotente `WHERE library_id IS NULL`-Prädikat, die tatsächliche Garantie dieses Changesets
+  (siehe die Korrektur im Abschnitt Resumierbarkeit oben).
 - `fk_documents_library_organization` weist ein Dokument zurück, dessen `organization_id` nicht zur
   Organisation der referenzierten Bibliothek passt — der eigentliche Cross-Tenant-Fall, den diese
   Migration verhindern soll, nicht nur ein fehlendes `library_id`.

--- a/docs/migrations/012-knowledge-library.md
+++ b/docs/migrations/012-knowledge-library.md
@@ -1,0 +1,216 @@
+# Migration 012: Wissensbibliothek als Dokumentencontainer
+
+Begleitdokument zu
+`backend/src/main/resources/db/changelog/changes/012-knowledge-libraries.yaml`
+([Issue #201](https://github.com/criew/opaa/issues/201)). Führt `knowledge_libraries` als ersten
+Asset-Typ ein und weist jedem bestehenden Dokument eine Bibliothek zu — der Rechteanker wird damit
+zum ersten Mal eingezogen, nicht verschoben (siehe
+[docs/features/spaces-and-assets.md](../features/spaces-and-assets.md#dokumente-liegen-in-bibliotheken)
+und [ADR-0008](../decisions/0008-space-and-asset-model.md)).
+
+## Was migriert wird
+
+| Changeset | Zweck |
+|---|---|
+| `012-create-knowledge-libraries` | Neue Tabelle `knowledge_libraries` mit Eigentümer-, Sichtbarkeits- und Auffindbarkeitsfeldern |
+| `012-seed-system-library` | Seedet die eine System-Bibliothek (`00000000-0000-0000-0000-000000000002`), Migrationsziel für Altbestand |
+| `012-add-library-id-to-documents` | `documents.library_id` und `documents.organization_id`, zunächst nullable |
+| `012-backfill-document-library-id` | Weist jedem bestehenden Dokument die System-Bibliothek zu — batched, resumierbar |
+| `012-enforce-documents-library-id` | `NOT NULL` auf beiden Spalten + zusammengesetzter Fremdschlüssel `fk_documents_library_organization` |
+
+**Günstige Ausgangslage:** Dokumente tragen heute keine Container-Zuordnung, und die Suche filtert
+nicht. Es gibt also nichts zu verlieren — nur eine erstmalige Zuweisung.
+
+### Warum `owner_user_id` und `owner_group_id` statt einer polymorphen `owner_id`
+
+Eine Bibliothek gehört einem Nutzer, einer Gruppe, oder — nur für die System-Bibliothek — niemandem.
+Eine einzelne `owner_id`-Spalte könnte keinen echten Fremdschlüssel tragen, weil sie je nach
+`owner_type` auf `users` oder `groups` zeigen müsste. Stattdessen trägt `knowledge_libraries` zwei
+separate, jeweils nullable Spalten mit je einem echten Fremdschlüssel:
+
+- `owner_user_id` → `fk_knowledge_libraries_owner_user` gegen `users(id)` (wie `fk_spaces_owner` bei
+  Spaces — dort ebenfalls ohne Organisationsabgleich auf Datenbankebene, weil `users` keine
+  `(id, organization_id)`-Eindeutigkeit trägt, gegen die eine zusammengesetzte Fremdschlüssel-Bedingung
+  aufsetzen könnte; der Organisationsabgleich für einen Nutzer-Eigentümer bleibt Anwendungscode in
+  `KnowledgeLibraryService`, exakt wie bei `SpaceService`).
+- `owner_group_id` → `fk_knowledge_libraries_owner_group_organization`, zusammengesetzt gegen
+  `groups(id, organization_id)` — dasselbe Muster wie `fk_group_memberships_group_organization`
+  (Migration 009). Eine Bibliothek kann damit nie einer Gruppe aus einer fremden Organisation gehören,
+  durchgesetzt auf Datenbankebene.
+
+Der Check-Constraint `chk_knowledge_libraries_owner` erzwingt, dass genau die zu `owner_type`
+passende Spalte gesetzt ist: `USER` nur `owner_user_id`, `GROUP` nur `owner_group_id`, `SYSTEM`
+keine von beiden.
+
+### Die System-Bibliothek — fail-closed ohne Einzelfallentscheidung
+
+Bestehende Dokumente haben heute keinerlei Zuständigen. Am Migrationstag lässt sich für keines davon
+seriös entscheiden, wem es gehören soll — das wäre eine Einzelfallentscheidung, die diese Migration
+bewusst nicht trifft. Stattdessen bekommen **alle** bestehenden Dokumente dieselbe System-Bibliothek
+zugewiesen:
+
+- `owner_type = SYSTEM`, kein individueller Eigentümer.
+- `visibility = PRIVATE`, `listed = false`.
+- Lesbar **ausschließlich für Systemadministratoren** — durchgesetzt in
+  `KnowledgeLibraryService#canRead`/`#canManage`, die für eine `SYSTEM`-Bibliothek unabhängig von
+  jeder anderen Prüfung `systemAdmin` verlangen.
+- Kann nicht gelöscht werden (`KnowledgeLibraryService#deleteLibrary`).
+- Kann nicht über die öffentliche API angelegt werden (`LibraryOwnerType.SYSTEM` wird in
+  `KnowledgeLibraryService#createLibrary` mit `400` abgelehnt) — nur diese Migration erzeugt sie.
+
+Eine organisationsweit lesbare Voreinstellung wäre in einer Verwaltungsumgebung nicht vertretbar; das
+ist die explizite Vorgabe aus #198s Migrationsabschnitt und den Abnahmekriterien von #201.
+
+## Reihenfolge der Changesets (Anwendung)
+
+1. `012-create-knowledge-libraries`
+2. `012-seed-system-library`
+3. `012-add-library-id-to-documents`
+4. `012-backfill-document-library-id`
+5. `012-enforce-documents-library-id`
+
+Die Reihenfolge ist zwingend: Die System-Bibliothek muss existieren, bevor der Backfill sie
+referenzieren kann; die Spalten müssen nullable angelegt sein, bevor sie befüllt werden können;
+`NOT NULL` und der Fremdschlüssel dürfen erst gesetzt werden, wenn jede Zeile einen Wert trägt.
+
+**Kontext-Labels:** Die fünf Changesets tragen zusätzlich die Labels `lib-schema` (1–3),
+`lib-backfill` (4) und `lib-enforce` (5). Ein normaler Lauf ohne Kontextfilter — wie ihn
+`spring-boot-starter-liquibase` beim Anwendungsstart automatisch ausführt — wendet alle fünf
+unverändert in Reihenfolge an; die Labels dienen ausschließlich
+`Migration012KnowledgeLibrariesTest`, um einen unterbrochenen und wiederaufgenommenen Lauf echt zu
+simulieren, statt ihn nur zu behaupten (siehe unten).
+
+## Resumierbarkeit
+
+Jedes Changeset ist eine eigene Postgres-Transaktion (Liquibase-Standard). Bricht ein Lauf mitten in
+der Datei ab, sind bereits abgeschlossene Changesets in `DATABASECHANGELOG` vermerkt; ein erneuter
+Lauf setzt exakt beim ersten nicht abgeschlossenen Changeset fort.
+
+Der Backfill selbst (`012-backfill-document-library-id`) geht darüber hinaus: Er ist **innerhalb**
+seines eigenen Changesets resumierbar, nicht nur zwischen Changesets. Statt eines einzelnen
+`UPDATE`-Statements über die gesamte Tabelle verarbeitet ein `DO`-Block Batches von 5 000 Zeilen in
+einer Schleife (`WHERE library_id IS NULL ... LIMIT batch_size FOR UPDATE SKIP LOCKED`), bis keine
+Zeile mehr fehlt. Das hat zwei Gründe:
+
+1. **Skalierung.** Ein einzelnes `UPDATE` über eine sehr große Tabelle hielte eine lange laufende
+   Transaktion offen. Batches vermeiden das, ohne die Garantie zu schwächen — jeder Batch committet
+   für sich (implizit, da `DO`-Blöcke innerhalb der äußeren Changeset-Transaktion laufen und diese am
+   Ende des Changesets committet; die Batches selbst sind idempotent, siehe Punkt 2).
+2. **Wiederaufsetzbarkeit.** Jeder Batch filtert erneut auf `library_id IS NULL` — bereits migrierte
+   Zeilen werden nie wieder angefasst. Ein Abbruch mitten im Lauf (Verbindungsabbruch, Neustart der
+   Anwendung während der Migration) hinterlässt einen Teil der Zeilen bereits zugewiesen und den Rest
+   unverändert `NULL`; ein erneuter Lauf des Changesets — oder des gesamten Changelogs beim nächsten
+   Anwendungsstart — führt exakt dort fort, wo der vorherige aufgehört hat, ohne Duplikate oder
+   übersprungene Zeilen.
+
+Jeder Batch meldet sein Ergebnis über `RAISE NOTICE` im Migrationslog — das Mengengerüst des
+Trockenlaufs (siehe unten) lässt sich damit auch während eines echten Laufs live beobachten.
+
+`Migration012KnowledgeLibrariesTest#backfillIsResumableAcrossPartialProgress` prüft die
+Wiederaufsetzbarkeit nicht nur behauptend, sondern tatsächlich: Es wendet zunächst nur die
+`lib-schema`-Changesets an, weist ein Dokument von Hand so zu, wie ein teilweise abgeschlossener
+Backfill es hinterlassen hätte, und wendet dann die verbleibenden Changesets als echten zweiten
+`liquibase.update()`-Aufruf an — nicht als Simulation innerhalb eines einzigen Laufs.
+
+## Trockenlauf mit Mengengerüst
+
+Wie in [Migration 008](./008-rename-workspace-to-space.md#trockenlauf) beschrieben, läuft der
+Trockenlauf über eine Wegwerf-Datenbank, da dieses Projekt keinen eigenständigen
+Liquibase-Gradle-Plugin-Task besitzt:
+
+1. Kopie der Zieldatenbank in einen frischen `docker compose up postgres`-Container einspielen.
+2. Die Anwendung gegen diese Kopie starten. Liquibase wendet automatisch alle ausstehenden
+   Changesets an, einschließlich `012-knowledge-libraries.yaml`. Das `RAISE NOTICE` des Backfills
+   erscheint im Anwendungslog mit der Anzahl migrierter Dokumente je Batch.
+3. Das Mengengerüst vor und nach dem Lauf vergleichen:
+
+   Vor der Migration:
+
+   ```sql
+   SELECT count(*) FROM documents;
+   SELECT count(*) FILTER (WHERE library_id IS NULL) FROM documents;
+   ```
+
+   Nach der Migration:
+
+   ```sql
+   SELECT count(*) FROM documents;
+   SELECT count(*) FILTER (WHERE library_id = '00000000-0000-0000-0000-000000000002') FROM documents;
+   SELECT count(*) FILTER (WHERE library_id IS NULL) FROM documents;  -- muss 0 sein
+   ```
+
+   `count(*)` vor und nach muss übereinstimmen (keine verlorene Zeile); die zweite Abfrage nach der
+   Migration muss der ersten Gesamtzahl entsprechen (jedes Dokument der System-Bibliothek
+   zugewiesen); die dritte muss `0` sein.
+4. Den Wegwerf-Container verwerfen.
+
+`Migration012KnowledgeLibrariesTest#backfillAssignsEveryPreExistingDocumentToTheSystemLibraryWithoutLosingRows`
+deckt genau dieses Mengengerüst automatisiert ab, gegen eine mit drei Alt-Dokumenten befüllte
+Testcontainer-Datenbank — nicht gegen eine leere.
+
+**Einschränkung dieses PRs:** Wie bei Migration 008 war ein Abgleich gegen eine echte Kopie eines
+produktiven Datenbestands im Rahmen dieser Änderung nicht möglich (Projekt vor 1.0, kein produktiver
+Bestand). Der Trockenlauf wurde gegen eine lokale Testcontainer-Datenbank mit synthetischen,
+realistischen Alt-Zeilen durchgeführt. Sobald ein produktiver Datenbestand existiert, ist das oben
+beschriebene Verfahren unverändert darauf anzuwenden.
+
+## Rollback-Reihenfolge
+
+```bash
+liquibase --changelog-file=backend/src/main/resources/db/changelog/db.changelog-master.yaml \
+  --url=<jdbc-url> --username=<user> --password=<pass> \
+  rollback-count 5
+```
+
+Rollback in umgekehrter Anwendungsreihenfolge:
+
+1. `012-enforce-documents-library-id` — löscht `NOT NULL` und `fk_documents_library_organization`,
+   verlustfrei.
+2. `012-backfill-document-library-id` — **irreversibler No-op** (`SELECT 1;`). Ein rückgängig
+   gemachter Backfill könnte nicht zuverlässig zwischen Zeilen unterscheiden, die dieser Changeset
+   ursprünglich zugewiesen hat, und Zeilen, die zwischenzeitlich (nach einem Teil-Rollback) neu mit
+   derselben System-Bibliothek angelegt wurden — ein Zurücksetzen auf `NULL` würde beide gleich
+   behandeln. Dieselbe Begründung wie bei `010-cleanup-duplicate-personal-spaces`.
+3. `012-add-library-id-to-documents` — löscht `library_id` und `organization_id`, verlustfrei (die
+   Spalten waren nullable, ihr Inhalt ist mit Punkt 2 ohnehin nicht mehr sauber trennbar).
+4. `012-seed-system-library` — löscht die eine System-Bibliothek-Zeile, verlustfrei.
+5. `012-create-knowledge-libraries` — löscht die gesamte Tabelle, verlustfrei (keine andere Tabelle
+   referenziert `knowledge_libraries` mehr, sobald Schritt 1 zurückgerollt ist).
+
+## Test
+
+`Migration012KnowledgeLibrariesTest`
+(`backend/src/test/java/io/opaa/migration/Migration012KnowledgeLibrariesTest.java`) folgt dem in
+`backend/src/test/java/io/opaa/migration/package-info.java` verbindlichen Muster: `test-master-through-011.yaml`
+für den Vorzustand, `connection.setAutoCommit(true)` nach jedem `liquibase.update(...)`, Schema-Reset
+zwischen Testmethoden. Er deckt:
+
+- Die System-Bibliothek wird mit `owner_type = SYSTEM`, ohne individuellen Eigentümer, `PRIVATE` und
+  ungelistet geseedet.
+- `chk_knowledge_libraries_owner` weist jede der fünf möglichen Fehlkombinationen aus `owner_type`
+  und den beiden Eigentümerspalten zurück.
+- `fk_knowledge_libraries_owner_user` und `fk_knowledge_libraries_owner_group_organization` weisen
+  einen nicht existierenden Eigentümer zurück, statt ihn stillschweigend zu übernehmen.
+- `uk_knowledge_libraries_personal_owner` lässt genau eine persönliche Bibliothek je Eigentümer zu,
+  beschränkt aber nicht die Anzahl nicht-persönlicher Bibliotheken.
+- Der Backfill weist jedes bestehende Dokument der System-Bibliothek und ihrer Organisation zu, ohne
+  eine Zeile zu verlieren.
+- Der Backfill ist über einen echten zweiten `liquibase.update()`-Aufruf hinweg wiederaufsetzbar
+  (siehe oben).
+- `fk_documents_library_organization` weist ein Dokument zurück, dessen `organization_id` nicht zur
+  Organisation der referenzierten Bibliothek passt — der eigentliche Cross-Tenant-Fall, den diese
+  Migration verhindern soll, nicht nur ein fehlendes `library_id`.
+
+Die anwendungsseitige Zugriffslogik (Eigentümer, Gruppenmitgliedschaft, `ORGANIZATION`-Sichtbarkeit,
+das Fail-closed-Verhalten der System-Bibliothek, das Zusammenspiel mit
+`GroupMembershipResolver`s Cache-Invalidierung) ist separat in
+`backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java` abgedeckt (echtes
+Postgres-Schema über Liquibase, `ddl-auto=none`, nach demselben Muster wie
+`SpaceServiceIntegrationTest`). Die Race-Behandlung von
+`KnowledgeLibraryService#ensurePersonalLibrary` ist in
+`backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java` abgedeckt (reiner
+Mockito-Test, kein Testcontainer, spiegelt `SpaceServiceTest`). Das Zusammenspiel von persönlichem
+Space und persönlicher Bibliothek bei der Nutzeranlage — beide werden immer gemeinsam versucht, auch
+wenn einer der beiden Aufrufe fehlschlägt — ist in
+`backend/src/test/java/io/opaa/auth/UserServiceTest.java` und
+`backend/src/test/java/io/opaa/auth/UserServicePersonalSpaceIntegrationTest.java` abgedeckt.


### PR DESCRIPTION
## Zusammenfassung

Fuehrt `KnowledgeLibrary` als ersten Asset-Typ ein (#201, Teil des Epics #198): eine Wissensbibliothek hat einen eigenen Eigentuemer (Nutzer oder Gruppe), gehoert zu genau einer Organisation, traegt Sichtbarkeitsstufe (`PRIVATE`/`SHARED`/`ORGANIZATION`) und Auffindbarkeits-Flag - unabhaengig vom Space. Jedes Dokument gehoert ab jetzt zu genau einer Bibliothek (`library_id`, nicht mehr nullbar); jeder Chunk traegt zusaetzlich `organization_id`, die Filterachse, die #202s rechtebewusste Vektorsuche direkt braucht.

**Migration 012** (`db.changelog-master.yaml`): Tabelle `knowledge_libraries`, Seed der einen System-Bibliothek (nur fuer System-Admins lesbar, fail-closed), Backfill der bestehenden Dokumente als ein einzelnes `UPDATE` (nicht batched - siehe Begleitdokument fuer die Begruendung, das eine fruehere Batch-Fassung als fehlerhaft korrigiert), danach `NOT NULL` + zusammengesetzter Fremdschluessel gegen `knowledge_libraries(id, organization_id)`. Begleitdokument mit Trockenlauf-Anleitung, Mengengeruest und Rollback-Reihenfolge: `docs/migrations/012-knowledge-library.md`.

**Owner-Modell:** Zwei separate Fremdschluessel-Spalten (`owner_user_id`, `owner_group_id`) statt einer polymorphen `owner_id` - beide tragen dadurch einen echten, von der Datenbank durchgesetzten Fremdschluessel.

**Nutzeranlage:** Ein neuer Nutzer bekommt automatisch einen persoenlichen Space *und* eine persoenliche Bibliothek "Meine Dokumente". Beide Provisionierungsaufrufe fuer denselben Nutzer werden ueber ein prozesslokales, gestriptes Lock serialisiert (reine Performance-Massnahme gegen Datenbank-Contention bei vielen gleichzeitigen Erstanmeldungen desselben Nutzers), laufen jeweils als einzelnes `INSERT ... ON CONFLICT ... DO NOTHING` (ein Roundtrip statt bis zu zwei), und ein Fehlschlag wird protokolliert statt den Login-Request scheitern zu lassen - damit ein Provisionierungsfehler nicht zur Aussperrung wird. Die Korrektheit traegt weiterhin ausschliesslich der jeweilige partielle Unique-Index in der Datenbank.

**Loeschschutz:** Eine Bibliothek mit Dokumenten und eine Gruppe mit Bibliotheken lassen sich nicht loeschen (409 statt eines unbehandelten 500).

## Zugehoerige Issues

Closes #201

## Art der Aenderung

- [x] Neues Feature

## Checkliste

- [x] Tests bestehen lokal (Backend: 317 Tests, 0 fehlgeschlagen, 1 vorbestehender unabhaengiger Skip; Frontend: 140 Tests, 0 fehlgeschlagen; `UserServiceCreationRaceIntegrationTest` zusaetzlich 9x in Folge gruen bei unveraendertem Produktions-Standardpool von 10)
- [ ] Bei Bugfix: Reproduktionsnachweis erbracht - entfaellt, kein Bugfix
- [x] Dokumentation aktualisiert (`docs/migrations/012-knowledge-library.md`, `docs/features/spaces-and-assets.md`)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet - wird im ersten PR-Kommentar nachgereicht

## KI-Agenten-Offenlegung

- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude, Entwickler-Subagent)

## Annahmen

- **"Atomisch"** bei der gemeinsamen Anlage von persoenlichem Space und persoenlicher Bibliothek ist nicht als eine gemeinsame Datenbanktransaktion umgesetzt, sondern als "immer gemeinsam versucht, unabhaengige Fehlergrenzen, Fehlschlag wird protokolliert statt den Login zu blockieren" - jede der beiden Operationen behaelt ihren eigenen Race-Schutz ueber ihren jeweiligen partiellen Unique-Index. In `UserService#ensureBothPersonalAssets` begruendet.
- **Bewusster Zwischenzustand (mit dem Maintainer abgestimmt):** Sowohl Datei-/URL-Crawl als auch ein spaeterer manueller Upload-Pfad weisen Dokumente ausschliesslich der System-Bibliothek zu - fuer normale Nutzer nicht erreichbar, nur fuer System-Admins. Die Zielauswahl kommt mit #202 (manueller Upload) bzw. #207 (Konnektor-Quellen).

## Review-Historie dieses PRs

Ein erster Review-Durchgang fand, dass ein testseitiger Connection-Pool-Override eine echte Regression kaschierte statt sie zu beheben (gemessen: 5 von 9 Laeufen schlugen bei Produktions-Poolgroesse fehl, und im Fehlerfall meldete der Login trotzdem Erfolg, obwohl die persoenliche Bibliothek fehlte). Der Override wurde entfernt; die tatsaechliche Ursache (Datenbank-Contention bei gleichzeitigen Inserts gegen denselben partiellen Unique-Index, verdoppelt durch die zweite Provisionierungsstufe) ist behoben durch: (1) ein einzelnes `INSERT ... ON CONFLICT ... DO NOTHING` statt des bisherigen insert-dann-Exception-fangen-dann-erneut-lesen-Musters fuer sowohl den persoenlichen Space als auch die persoenliche Bibliothek, und (2) ein prozesslokales Lock je Nutzer, das die Datenbank-Contention bei vielen gleichzeitigen Erstanmeldungen desselben Nutzers auf einen einzigen tatsaechlichen Datenbankzugriff reduziert. Nachweis: 9 aufeinanderfolgende gruene Laeufe bei unveraendertem Produktions-Standardpool von 10.
