### PR TITLE
feat(library): Asset-Rechte und rechtebewusste Vektorsuche

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -203,6 +203,8 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "LibraryVisibility" to "LibraryVisibility",
         "DocumentStatus" to "DocumentStatus",
         "DocumentSourceType" to "DocumentSourceType",
+        "AssetRole" to "AssetRole",
+        "PermissionSubjectType" to "PermissionSubjectType",
     ))
     importMappings.set(mapOf(
         "Instant" to "java.time.Instant",
@@ -216,6 +218,8 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         "LibraryVisibility" to "io.opaa.library.LibraryVisibility",
         "DocumentStatus" to "io.opaa.indexing.DocumentStatus",
         "DocumentSourceType" to "io.opaa.indexing.DocumentSourceType",
+        "AssetRole" to "io.opaa.library.AssetRole",
+        "PermissionSubjectType" to "io.opaa.group.PermissionSubjectType",
     ))
 }
 
@@ -224,7 +228,7 @@ tasks.named<org.openapitools.generator.gradle.plugin.tasks.GenerateTask>("openAp
         // Remove generated enum files that are mapped to existing domain enums via typeMappings.
         // The generator still creates these files even with typeMappings configured.
         val generatedDir = layout.buildDirectory.dir("generated/openapi/src/main/java/io/opaa/api/dto").get().asFile
-        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java", "DirectorySyncOutcome.java", "LibraryOwnerType.java", "LibraryVisibility.java", "DocumentStatus.java", "DocumentSourceType.java").forEach { fileName ->
+        listOf("SpaceRole.java", "SpaceKind.java", "SpaceVisibility.java", "SystemRole.java", "GroupKind.java", "DirectorySyncOutcome.java", "LibraryOwnerType.java", "LibraryVisibility.java", "DocumentStatus.java", "DocumentSourceType.java", "AssetRole.java", "PermissionSubjectType.java").forEach { fileName ->
             file("$generatedDir/$fileName").delete()
         }
     }

--- a/backend/src/main/java/io/opaa/api/LibraryController.java
+++ b/backend/src/main/java/io/opaa/api/LibraryController.java
@@ -1,5 +1,7 @@
 package io.opaa.api;
 
+import io.opaa.api.dto.AssetGrantRequest;
+import io.opaa.api.dto.AssetGrantResponse;
 import io.opaa.api.dto.LibraryDocumentResponse;
 import io.opaa.api.dto.LibraryListResponse;
 import io.opaa.api.dto.LibraryRequest;
@@ -8,6 +10,7 @@ import io.opaa.api.dto.LibraryUpdateRequest;
 import io.opaa.auth.SystemRole;
 import io.opaa.auth.User;
 import io.opaa.auth.UserService;
+import io.opaa.library.AssetGrantService;
 import io.opaa.library.KnowledgeLibraryService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -35,10 +38,15 @@ public class LibraryController {
   private static final String UNKNOWN_ISSUER = "unknown";
 
   private final KnowledgeLibraryService libraryService;
+  private final AssetGrantService grantService;
   private final UserService userService;
 
-  public LibraryController(KnowledgeLibraryService libraryService, UserService userService) {
+  public LibraryController(
+      KnowledgeLibraryService libraryService,
+      AssetGrantService grantService,
+      UserService userService) {
     this.libraryService = libraryService;
+    this.grantService = grantService;
     this.userService = userService;
   }
 
@@ -92,6 +100,39 @@ public class LibraryController {
     User currentUser = currentUser(jwt);
     return libraryService.listDocuments(
         libraryId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  @GetMapping("/{libraryId}/grants")
+  public List<AssetGrantResponse> listAssetGrants(
+      @PathVariable UUID libraryId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return grantService.listGrants(
+        libraryId, currentUser.getId(), currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  @PostMapping("/{libraryId}/grants")
+  public AssetGrantResponse upsertAssetGrant(
+      @PathVariable UUID libraryId,
+      @Valid @RequestBody AssetGrantRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return grantService.upsertGrant(
+        libraryId,
+        request,
+        currentUser.getId(),
+        currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+  }
+
+  @DeleteMapping("/{libraryId}/grants/{grantId}")
+  public ResponseEntity<Void> revokeAssetGrant(
+      @PathVariable UUID libraryId, @PathVariable UUID grantId, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    grantService.revokeGrant(
+        libraryId,
+        grantId,
+        currentUser.getId(),
+        currentUser.getSystemRole() == SystemRole.SYSTEM_ADMIN);
+    return ResponseEntity.noContent().build();
   }
 
   private User currentUser(Jwt jwt) {

--- a/backend/src/main/java/io/opaa/api/QueryController.java
+++ b/backend/src/main/java/io/opaa/api/QueryController.java
@@ -2,25 +2,52 @@ package io.opaa.api;
 
 import io.opaa.api.dto.QueryRequest;
 import io.opaa.api.dto.QueryResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserService;
 import io.opaa.query.QueryService;
 import jakarta.validation.Valid;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+@Profile({"oidc", "basic"})
 @RestController
 @RequestMapping("/api/v1")
 public class QueryController {
 
-  private final QueryService queryService;
+  private static final String UNKNOWN_ISSUER = "unknown";
 
-  public QueryController(QueryService queryService) {
+  private final QueryService queryService;
+  private final UserService userService;
+
+  public QueryController(QueryService queryService, UserService userService) {
     this.queryService = queryService;
+    this.userService = userService;
   }
 
   @PostMapping("/query")
-  public QueryResponse query(@Valid @RequestBody QueryRequest request) {
-    return queryService.query(request.getQuestion(), request.getConversationId());
+  public QueryResponse query(
+      @Valid @RequestBody QueryRequest request, @AuthenticationPrincipal Jwt jwt) {
+    User currentUser = currentUser(jwt);
+    return queryService.query(
+        request.getQuestion(), request.getConversationId(), currentUser.getId());
+  }
+
+  private User currentUser(Jwt jwt) {
+    String issuer = jwt.getClaimAsString("iss");
+    if (issuer == null || issuer.isBlank()) {
+      issuer = UNKNOWN_ISSUER;
+    }
+
+    return userService
+        .findBySubjectAndIssuer(jwt.getSubject(), issuer)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
   }
 }

--- a/backend/src/main/java/io/opaa/group/GroupService.java
+++ b/backend/src/main/java/io/opaa/group/GroupService.java
@@ -7,6 +7,7 @@ import io.opaa.api.dto.GroupResponse;
 import io.opaa.api.dto.GroupUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.AssetGrantRepository;
 import io.opaa.library.KnowledgeLibraryRepository;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +35,15 @@ import org.springframework.web.server.ResponseStatusException;
  * the first asset type ({@link io.opaa.library.KnowledgeLibrary}), so {@link #deleteGroup} now has
  * something to check against; a fuller asset model (agents, prompt libraries) in later stages of
  * the epic extends the same check, it does not replace it.
+ *
+ * <p>#202 code review: deleting a group that merely <em>holds a grant</em> - not necessarily owns
+ * anything - must be blocked too, and independently of the ownership check above. {@code
+ * fk_asset_grants_subject_group_organization} (migration 013) is RESTRICT, exactly like {@code
+ * fk_knowledge_libraries_owner_group_organization}; without the check in {@link #deleteGroup}, the
+ * everyday case the feature spec's "Freigabestufen und Auffindbarkeit" describes - "an Abteilung 5
+ * freigeben" is a grant to the group representing Abteilung 5, not ownership - would surface as an
+ * unhandled {@code DataIntegrityViolationException} (HTTP 500) the first time anyone tried to
+ * delete such a group.
  */
 @Service
 @Transactional(readOnly = true)
@@ -46,16 +56,19 @@ public class GroupService {
   private final UserRepository userRepository;
   private final GroupMembershipResolver membershipResolver;
   private final KnowledgeLibraryRepository libraryRepository;
+  private final AssetGrantRepository grantRepository;
 
   public GroupService(
       GroupRepository groupRepository,
       UserRepository userRepository,
       GroupMembershipResolver membershipResolver,
-      KnowledgeLibraryRepository libraryRepository) {
+      KnowledgeLibraryRepository libraryRepository,
+      AssetGrantRepository grantRepository) {
     this.groupRepository = groupRepository;
     this.userRepository = userRepository;
     this.membershipResolver = membershipResolver;
     this.libraryRepository = libraryRepository;
+    this.grantRepository = grantRepository;
   }
 
   @Transactional
@@ -116,6 +129,13 @@ public class GroupService {
       throw new ResponseStatusException(
           HttpStatus.CONFLICT,
           "Die Gruppe besitzt noch Bibliotheken und kann nicht geloescht werden");
+    }
+    // #202 code review: a group that merely holds a grant (never owns anything) hits the same
+    // RESTRICT constraint via fk_asset_grants_subject_group_organization - see the class Javadoc.
+    if (grantRepository.existsBySubjectGroupId(groupId)) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die Gruppe hat noch Berechtigungen auf Bibliotheken und kann nicht geloescht werden");
     }
 
     List<UUID> affectedUserIds =

--- a/backend/src/main/java/io/opaa/library/AssetGrant.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrant.java
@@ -1,0 +1,201 @@
+package io.opaa.library;
+
+import io.opaa.group.PermissionSubject;
+import io.opaa.group.PermissionSubjectType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A grant of an {@link AssetRole} on a {@link KnowledgeLibrary} to a {@link PermissionSubject} -
+ * the actual mechanism behind "readable libraries" (#202, see
+ * docs/features/spaces-and-assets.md#rechte-an-einem-asset-erhalten). Every grant carries an
+ * optional {@code expiresAt} from the start, even though recertification only arrives with #241:
+ * adding the field later is cheap, assessing an existing body of grants without one is not.
+ *
+ * <p>Ownership uses the same two-nullable-columns pattern as {@link
+ * KnowledgeLibrary#getOwnerUserId()} / {@link KnowledgeLibrary#getOwnerGroupId()} rather than one
+ * polymorphic subject id, so each column carries a real foreign key to its own target table
+ * (migration 013) instead of an unenforced UUID. {@code chk_asset_grants_subject} enforces that
+ * exactly the column matching {@link #subjectType} is non-null.
+ */
+@Entity
+@Table(name = "asset_grants")
+public class AssetGrant {
+
+  @Id private UUID id;
+
+  @Column(name = "library_id", nullable = false)
+  private UUID libraryId;
+
+  @Column(name = "organization_id", nullable = false)
+  private UUID organizationId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "subject_type", nullable = false, length = 20)
+  private PermissionSubjectType subjectType;
+
+  @Column(name = "subject_user_id")
+  private UUID subjectUserId;
+
+  @Column(name = "subject_group_id")
+  private UUID subjectGroupId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "role", nullable = false, length = 20)
+  private AssetRole role;
+
+  /** Null means the grant never expires. */
+  @Column(name = "expires_at")
+  private Instant expiresAt;
+
+  @Column(name = "granted_by_user_id")
+  private UUID grantedByUserId;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected AssetGrant() {}
+
+  private AssetGrant(
+      UUID libraryId,
+      UUID organizationId,
+      PermissionSubjectType subjectType,
+      UUID subjectUserId,
+      UUID subjectGroupId,
+      AssetRole role,
+      Instant expiresAt,
+      UUID grantedByUserId) {
+    this.id = UUID.randomUUID();
+    this.libraryId = libraryId;
+    this.organizationId = organizationId;
+    this.subjectType = subjectType;
+    this.subjectUserId = subjectUserId;
+    this.subjectGroupId = subjectGroupId;
+    this.role = role;
+    this.expiresAt = expiresAt;
+    this.grantedByUserId = grantedByUserId;
+  }
+
+  public static AssetGrant forUser(
+      UUID libraryId,
+      UUID organizationId,
+      UUID subjectUserId,
+      AssetRole role,
+      Instant expiresAt,
+      UUID grantedByUserId) {
+    return new AssetGrant(
+        libraryId,
+        organizationId,
+        PermissionSubjectType.USER,
+        subjectUserId,
+        null,
+        role,
+        expiresAt,
+        grantedByUserId);
+  }
+
+  public static AssetGrant forGroup(
+      UUID libraryId,
+      UUID organizationId,
+      UUID subjectGroupId,
+      AssetRole role,
+      Instant expiresAt,
+      UUID grantedByUserId) {
+    return new AssetGrant(
+        libraryId,
+        organizationId,
+        PermissionSubjectType.GROUP,
+        null,
+        subjectGroupId,
+        role,
+        expiresAt,
+        grantedByUserId);
+  }
+
+  @PrePersist
+  void onCreate() {
+    Instant now = Instant.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
+
+  public void updateRole(AssetRole role, Instant expiresAt) {
+    this.role = role;
+    this.expiresAt = expiresAt;
+  }
+
+  public boolean isExpired(Instant now) {
+    return expiresAt != null && expiresAt.isBefore(now);
+  }
+
+  /** The subject this grant reaches, for {@link io.opaa.group.GroupMembershipResolver}. */
+  public PermissionSubject subject() {
+    UUID subjectId = subjectType == PermissionSubjectType.USER ? subjectUserId : subjectGroupId;
+    return new PermissionSubject(subjectType, subjectId, organizationId);
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getLibraryId() {
+    return libraryId;
+  }
+
+  public UUID getOrganizationId() {
+    return organizationId;
+  }
+
+  public PermissionSubjectType getSubjectType() {
+    return subjectType;
+  }
+
+  public UUID getSubjectUserId() {
+    return subjectUserId;
+  }
+
+  public UUID getSubjectGroupId() {
+    return subjectGroupId;
+  }
+
+  /** The subject id regardless of {@link #subjectType}, for callers that only need "who". */
+  public UUID getSubjectId() {
+    return subjectType == PermissionSubjectType.USER ? subjectUserId : subjectGroupId;
+  }
+
+  public AssetRole getRole() {
+    return role;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public UUID getGrantedByUserId() {
+    return grantedByUserId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
@@ -73,4 +73,16 @@ public interface AssetGrantRepository extends JpaRepository<AssetGrant, UUID> {
       @Param("groupIds") Set<UUID> groupIds,
       @Param("organizationId") UUID organizationId,
       @Param("now") Instant now);
+
+  /**
+   * Whether the given group is the subject of any grant, on any library - used by {@code
+   * GroupService#deleteGroup} to reject deleting a group that still holds a grant (#202 code
+   * review: {@code fk_asset_grants_subject_group_organization} is RESTRICT, migration 013, so
+   * without this check the delete would surface as an unhandled {@code
+   * DataIntegrityViolationException} -> HTTP 500). This is deliberately a second, independent check
+   * next to {@code KnowledgeLibraryRepository#existsByOwnerGroupId} (ownership), not a replacement
+   * for it - a group can be both the owner of a library and hold a grant on an unrelated one;
+   * deleting it must be rejected for either reason.
+   */
+  boolean existsBySubjectGroupId(UUID subjectGroupId);
 }

--- a/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
@@ -40,22 +40,78 @@ public interface AssetGrantRepository extends JpaRepository<AssetGrant, UUID> {
   List<AssetGrant> findByLibraryId(UUID libraryId);
 
   /**
-   * The locked counterpart of {@link #findByLibraryId}, used only by {@code AssetGrantService}'s
-   * last-active-OWNER guard before it revokes or downgrades an OWNER grant (#202 code review nit
-   * 2). {@code SELECT ... FOR UPDATE} takes a row lock on every grant of the library for the
-   * remainder of the caller's transaction, so two concurrent calls that would each, read in
-   * isolation, see the other's OWNER grant as still active and both proceed - the exact race a
-   * plain read-then-decide check cannot rule out - instead serialize: the second blocks until the
-   * first commits (releasing the lock) or rolls back, and then re-reads the now-current state
-   * before making its own decision. Deliberately scoped to only the mutations that touch an active
-   * OWNER grant, not every grant write, since this is real row-level database contention, not an
-   * in-process lock - see {@code io.opaa.auth.UserService#provisioningLockFor} for why that
-   * distinction matters.
+   * A namespace for {@link #lockLibraryGrantsForMutation}'s Postgres advisory locks, arbitrary but
+   * fixed and documented so a future, unrelated advisory lock elsewhere in the codebase (see the
+   * one sketched in {@code DirectorySyncService}'s Javadoc) can pick a different one instead of
+   * colliding. The issue this locking scheme was introduced for.
+   */
+  int ASSET_GRANT_MUTATION_LOCK_NAMESPACE = 202;
+
+  /**
+   * Acquires a transaction-scoped Postgres advisory lock keyed on {@code libraryId} (namespaced
+   * under {@link #ASSET_GRANT_MUTATION_LOCK_NAMESPACE} to avoid colliding with an unrelated
+   * advisory lock elsewhere), serializing every concurrent grant mutation on the same library -
+   * called first, before {@link #countOtherActiveOwnerGrants}, by {@code AssetGrantService}'s
+   * last-active-OWNER guard (#202 code review round 2 nit 2, round 3 blocker 2).
+   *
+   * <p><b>Why an advisory lock rather than {@code SELECT ... FOR UPDATE} on the grant rows (round
+   * 3, blocker 2, second half):</b> the first version of this guard row-locked every grant of the
+   * library directly. That fixed the entity-staleness bug (see {@link
+   * #countOtherActiveOwnerGrants}'s Javadoc) but introduced a real Postgres deadlock, measured with
+   * two real threads: two concurrent mutations on the same library each try to {@code FOR UPDATE}
+   * lock <em>every</em> grant row of that library (not just the one each is changing), and even
+   * with a deterministic {@code ORDER BY id} on the locking query, the deadlock persisted -
+   * Postgres executes the {@code Sort} before the {@code LockRows} step for that query shape, so
+   * order alone was not sufficient to explain or fix it, and root-causing the exact interleaving
+   * further was not worth it when a strictly simpler mechanism removes the entire class: a single
+   * advisory lock per library has only one lock to acquire, so there are no two differently-ordered
+   * locks to deadlock over in the first place. Automatically released at transaction end ({@code
+   * _xact_}) - commit or rollback - so it can never be forgotten and leaked like a {@code
+   * pg_advisory_lock}/{@code pg_advisory_unlock} pair would risk if a method returned via an
+   * exception. This is a real database lock, not an in-process one - see {@code
+   * io.opaa.auth.UserService#provisioningLockFor} for why that distinction matters here (multiple
+   * application instances).
    */
   @Query(
-      value = "SELECT * FROM asset_grants WHERE library_id = :libraryId FOR UPDATE",
+      value =
+          "SELECT 1 FROM (SELECT pg_advisory_xact_lock("
+              + ASSET_GRANT_MUTATION_LOCK_NAMESPACE
+              + ", hashtext(CAST(:libraryId AS text)))) acquired",
       nativeQuery = true)
-  List<AssetGrant> findByLibraryIdForUpdate(@Param("libraryId") UUID libraryId);
+  int lockLibraryGrantsForMutation(@Param("libraryId") UUID libraryId);
+
+  /**
+   * The number of active {@code OWNER} grants on {@code libraryId}, excluding {@code
+   * excludingGrantId} - used only by {@code AssetGrantService}'s last-active-OWNER guard, and only
+   * after {@link #lockLibraryGrantsForMutation} has been called in the same transaction for the
+   * same {@code libraryId}; see that method's Javadoc for why a plain scalar read is safe to rely
+   * on once the advisory lock is held.
+   *
+   * <p><b>Why a scalar aggregate, not an entity list (round 3, blocker 2, first half):</b> the very
+   * first version of this guard read {@code findByLibraryId}'s already-mapped {@link AssetGrant}
+   * entities. By the time it ran, {@code AssetGrantService}'s caller had already loaded the very
+   * same rows as managed entities in this transaction's persistence context - every mutating method
+   * resolves {@code effectiveRole} first, which populates {@link LibraryAccessService}'s cache via
+   * {@link #findByLibraryId} inside the same transaction. Hibernate's first-level cache then
+   * returned the <em>original</em>, now-stale managed instances for the same ids instead of the
+   * current row values, so the guard decided on outdated data - measured: a concurrent downgrade
+   * committed between the two reads, and a subsequent revoke of the second {@code OWNER} grant
+   * still succeeded, leaving zero active owners. A plain scalar query has no entity identity to
+   * resolve against the persistence context, so it always reflects the row values as they stand at
+   * the time it runs.
+   */
+  @Query(
+      value =
+          "SELECT count(*) FROM asset_grants"
+              + " WHERE library_id = :libraryId"
+              + "   AND role = 'OWNER'"
+              + "   AND (expires_at IS NULL OR expires_at > :now)"
+              + "   AND id <> :excludingGrantId",
+      nativeQuery = true)
+  long countOtherActiveOwnerGrants(
+      @Param("libraryId") UUID libraryId,
+      @Param("excludingGrantId") UUID excludingGrantId,
+      @Param("now") Instant now);
 
   Optional<AssetGrant> findByLibraryIdAndSubjectTypeAndSubjectUserId(
       UUID libraryId, PermissionSubjectType subjectType, UUID subjectUserId);

--- a/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
@@ -1,0 +1,76 @@
+package io.opaa.library;
+
+import io.opaa.group.PermissionSubjectType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AssetGrantRepository extends JpaRepository<AssetGrant, UUID> {
+
+  /**
+   * Grants the owner of a personal library {@link AssetRole#OWNER} on it, in a single
+   * insert-or-noop round trip keyed off the library row itself rather than a passed-in library id -
+   * mirrors {@link KnowledgeLibraryRepository#insertPersonalLibraryIfAbsent}'s {@code ON CONFLICT
+   * ... DO NOTHING} race handling, targeting the partial unique index {@code
+   * uk_asset_grants_user_subject} (migration 013) so a concurrent call for the same user is a
+   * silent no-op rather than a duplicate-grant error. Used only by {@code
+   * KnowledgeLibraryService#ensurePersonalLibrary}, after the library itself has been
+   * inserted-or-confirmed-existing in the same {@code REQUIRES_NEW} transaction.
+   */
+  @Modifying
+  @Query(
+      value =
+          "INSERT INTO asset_grants"
+              + "  (id, library_id, organization_id, subject_type, subject_user_id, role, granted_by_user_id, created_at, updated_at)"
+              + " SELECT :grantId, kl.id, kl.organization_id, 'USER', :ownerUserId, 'OWNER', :ownerUserId, now(), now()"
+              + " FROM knowledge_libraries kl"
+              + " WHERE kl.owner_user_id = :ownerUserId AND kl.personal = true"
+              + " ON CONFLICT (library_id, subject_user_id) WHERE subject_type = 'USER' DO NOTHING",
+      nativeQuery = true)
+  void insertOwnerGrantForPersonalLibraryIfAbsent(
+      @Param("grantId") UUID grantId, @Param("ownerUserId") UUID ownerUserId);
+
+  /** All grants on a library, used to populate {@link LibraryAccessService}'s per-library cache. */
+  List<AssetGrant> findByLibraryId(UUID libraryId);
+
+  Optional<AssetGrant> findByLibraryIdAndSubjectTypeAndSubjectUserId(
+      UUID libraryId, PermissionSubjectType subjectType, UUID subjectUserId);
+
+  Optional<AssetGrant> findByLibraryIdAndSubjectTypeAndSubjectGroupId(
+      UUID libraryId, PermissionSubjectType subjectType, UUID subjectGroupId);
+
+  /**
+   * Every library id the given user can read via a direct grant, not expired as of {@code now}.
+   * Only used as one branch of {@link LibraryAccessService#readableLibraryIds} - deliberately not
+   * cached (unlike the per-library grant cache used for single-library checks): the vector search
+   * filter must reflect a revoked grant on the very next query (#202 acceptance criteria), and a
+   * single indexed query is simpler and safer than a second cache-invalidation path to keep
+   * correct.
+   */
+  @Query(
+      "select g.libraryId from AssetGrant g "
+          + "where g.subjectType = io.opaa.group.PermissionSubjectType.USER "
+          + "and g.subjectUserId = :userId and g.organizationId = :organizationId "
+          + "and (g.expiresAt is null or g.expiresAt > :now)")
+  Set<UUID> findReadableLibraryIdsByDirectGrant(
+      @Param("userId") UUID userId,
+      @Param("organizationId") UUID organizationId,
+      @Param("now") Instant now);
+
+  /** The group-grant counterpart of {@link #findReadableLibraryIdsByDirectGrant}. */
+  @Query(
+      "select g.libraryId from AssetGrant g "
+          + "where g.subjectType = io.opaa.group.PermissionSubjectType.GROUP "
+          + "and g.subjectGroupId in :groupIds and g.organizationId = :organizationId "
+          + "and (g.expiresAt is null or g.expiresAt > :now)")
+  Set<UUID> findReadableLibraryIdsByGroupGrant(
+      @Param("groupIds") Set<UUID> groupIds,
+      @Param("organizationId") UUID organizationId,
+      @Param("now") Instant now);
+}

--- a/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantRepository.java
@@ -39,6 +39,24 @@ public interface AssetGrantRepository extends JpaRepository<AssetGrant, UUID> {
   /** All grants on a library, used to populate {@link LibraryAccessService}'s per-library cache. */
   List<AssetGrant> findByLibraryId(UUID libraryId);
 
+  /**
+   * The locked counterpart of {@link #findByLibraryId}, used only by {@code AssetGrantService}'s
+   * last-active-OWNER guard before it revokes or downgrades an OWNER grant (#202 code review nit
+   * 2). {@code SELECT ... FOR UPDATE} takes a row lock on every grant of the library for the
+   * remainder of the caller's transaction, so two concurrent calls that would each, read in
+   * isolation, see the other's OWNER grant as still active and both proceed - the exact race a
+   * plain read-then-decide check cannot rule out - instead serialize: the second blocks until the
+   * first commits (releasing the lock) or rolls back, and then re-reads the now-current state
+   * before making its own decision. Deliberately scoped to only the mutations that touch an active
+   * OWNER grant, not every grant write, since this is real row-level database contention, not an
+   * in-process lock - see {@code io.opaa.auth.UserService#provisioningLockFor} for why that
+   * distinction matters.
+   */
+  @Query(
+      value = "SELECT * FROM asset_grants WHERE library_id = :libraryId FOR UPDATE",
+      nativeQuery = true)
+  List<AssetGrant> findByLibraryIdForUpdate(@Param("libraryId") UUID libraryId);
+
   Optional<AssetGrant> findByLibraryIdAndSubjectTypeAndSubjectUserId(
       UUID libraryId, PermissionSubjectType subjectType, UUID subjectUserId);
 

--- a/backend/src/main/java/io/opaa/library/AssetGrantService.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantService.java
@@ -1,0 +1,208 @@
+package io.opaa.library;
+
+import io.opaa.api.dto.AssetGrantRequest;
+import io.opaa.api.dto.AssetGrantResponse;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupRepository;
+import io.opaa.group.PermissionSubjectType;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Manages {@link AssetGrant}s on a {@link KnowledgeLibrary} - the "who has which {@link AssetRole}"
+ * side of #202. Every mutating method requires {@link AssetRole#MANAGER} on the target library,
+ * resolved through {@link LibraryAccessService}, which is also where the cache this class
+ * invalidates after every write lives.
+ */
+@Service
+@Transactional(readOnly = true)
+public class AssetGrantService {
+
+  private final AssetGrantRepository grantRepository;
+  private final KnowledgeLibraryRepository libraryRepository;
+  private final UserRepository userRepository;
+  private final GroupRepository groupRepository;
+  private final LibraryAccessService accessService;
+
+  public AssetGrantService(
+      AssetGrantRepository grantRepository,
+      KnowledgeLibraryRepository libraryRepository,
+      UserRepository userRepository,
+      GroupRepository groupRepository,
+      LibraryAccessService accessService) {
+    this.grantRepository = grantRepository;
+    this.libraryRepository = libraryRepository;
+    this.userRepository = userRepository;
+    this.groupRepository = groupRepository;
+    this.accessService = accessService;
+  }
+
+  public List<AssetGrantResponse> listGrants(
+      UUID libraryId, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = requireManageable(libraryId, currentUserId, systemAdmin);
+    return grantRepository.findByLibraryId(library.getId()).stream()
+        .map(AssetGrantService::toResponse)
+        .toList();
+  }
+
+  @Transactional
+  public AssetGrantResponse upsertGrant(
+      UUID libraryId, AssetGrantRequest request, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = requireManageable(libraryId, currentUserId, systemAdmin);
+    User currentUser = requireUser(currentUserId);
+
+    if (request.getSubjectType() == null || request.getSubjectId() == null) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "subjectType und subjectId sind erforderlich");
+    }
+    if (request.getRole() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "role ist erforderlich");
+    }
+
+    AssetGrant grant;
+    if (request.getSubjectType() == PermissionSubjectType.USER) {
+      requireUserInOrganization(request.getSubjectId(), library.getOrganizationId());
+      grant =
+          grantRepository
+              .findByLibraryIdAndSubjectTypeAndSubjectUserId(
+                  library.getId(), PermissionSubjectType.USER, request.getSubjectId())
+              .orElse(null);
+      if (grant == null) {
+        grant =
+            AssetGrant.forUser(
+                library.getId(),
+                library.getOrganizationId(),
+                request.getSubjectId(),
+                request.getRole(),
+                request.getExpiresAt(),
+                currentUser.getId());
+      } else {
+        grant.updateRole(request.getRole(), request.getExpiresAt());
+      }
+    } else {
+      requireGroupInOrganization(request.getSubjectId(), library.getOrganizationId());
+      grant =
+          grantRepository
+              .findByLibraryIdAndSubjectTypeAndSubjectGroupId(
+                  library.getId(), PermissionSubjectType.GROUP, request.getSubjectId())
+              .orElse(null);
+      if (grant == null) {
+        grant =
+            AssetGrant.forGroup(
+                library.getId(),
+                library.getOrganizationId(),
+                request.getSubjectId(),
+                request.getRole(),
+                request.getExpiresAt(),
+                currentUser.getId());
+      } else {
+        grant.updateRole(request.getRole(), request.getExpiresAt());
+      }
+    }
+
+    AssetGrant saved = grantRepository.save(grant);
+    invalidateAfterCommit(library.getId());
+    return toResponse(saved);
+  }
+
+  @Transactional
+  public void revokeGrant(UUID libraryId, UUID grantId, UUID currentUserId, boolean systemAdmin) {
+    KnowledgeLibrary library = requireManageable(libraryId, currentUserId, systemAdmin);
+    AssetGrant grant =
+        grantRepository
+            .findById(grantId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Berechtigung nicht gefunden"));
+    if (!grant.getLibraryId().equals(library.getId())) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Berechtigung nicht gefunden");
+    }
+
+    grantRepository.delete(grant);
+    invalidateAfterCommit(library.getId());
+  }
+
+  private KnowledgeLibrary requireManageable(
+      UUID libraryId, UUID currentUserId, boolean systemAdmin) {
+    User currentUser = requireUser(currentUserId);
+    KnowledgeLibrary library =
+        libraryRepository
+            .findById(libraryId)
+            .orElseThrow(
+                () ->
+                    new ResponseStatusException(HttpStatus.NOT_FOUND, "Bibliothek nicht gefunden"));
+    if (!library.getOrganizationId().equals(currentUser.getOrganizationId())) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Bibliothek nicht gefunden");
+    }
+    if (!accessService.canManage(library, currentUserId, systemAdmin)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
+    }
+    return library;
+  }
+
+  private User requireUser(UUID userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer nicht gefunden"));
+  }
+
+  private void requireUserInOrganization(UUID userId, UUID organizationId) {
+    User user = requireUser(userId);
+    if (!user.getOrganizationId().equals(organizationId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Benutzer nicht gefunden");
+    }
+  }
+
+  private void requireGroupInOrganization(UUID groupId, UUID organizationId) {
+    Group group =
+        groupRepository
+            .findById(groupId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden"));
+    if (!group.getOrganizationId().equals(organizationId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden");
+    }
+  }
+
+  /**
+   * Defers cache invalidation until the enclosing transaction has finished - the same reasoning and
+   * the same {@code afterCompletion} (not {@code afterCommit}) choice as {@code
+   * GroupService#invalidateAfterCommit}, so a rollback also evicts the entry this transaction may
+   * have touched. Falls back to running immediately when no transaction is active.
+   */
+  private void invalidateAfterCommit(UUID libraryId) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      accessService.invalidateLibrary(libraryId);
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            accessService.invalidateLibrary(libraryId);
+          }
+        });
+  }
+
+  private static AssetGrantResponse toResponse(AssetGrant grant) {
+    return new AssetGrantResponse(
+            grant.getId(),
+            grant.getSubjectType(),
+            grant.getSubjectId(),
+            grant.getRole(),
+            grant.getCreatedAt(),
+            grant.getUpdatedAt())
+        .expiresAt(grant.getExpiresAt())
+        .grantedByUserId(grant.getGrantedByUserId());
+  }
+}

--- a/backend/src/main/java/io/opaa/library/AssetGrantService.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantService.java
@@ -48,10 +48,14 @@ import org.springframework.web.server.ResponseStatusException;
  * including any new {@code expiresAt} the caller is setting (#202 code review round 2, nit 1): an
  * {@code OWNER} renewing their own grant with {@code role = OWNER} does not by itself prove the
  * grant stays active if the caller also supplies an {@code expiresAt} in the past. See {@link
- * #requireNotDowngradingTheLastActiveOwnerGrant} and {@link
- * AssetGrantRepository#findByLibraryIdForUpdate} for how this count is additionally protected
+ * #requireNotDowngradingTheLastActiveOwnerGrant}, {@link
+ * AssetGrantRepository#lockLibraryGrantsForMutation} and {@link
+ * AssetGrantRepository#countOtherActiveOwnerGrants} for how this count is additionally protected
  * against two concurrent callers each observing the other's OWNER grant as still active (#202 code
- * review round 2, nit 2).
+ * review round 2 nit 2), first via a locked entity read that turned out to be stale under that
+ * exact scenario, then via a {@code SELECT ... FOR UPDATE} on the grant rows that fixed the
+ * staleness but deadlocked under real concurrency, and settling on a per-library advisory lock plus
+ * a plain scalar count (round 3, blocker 2) - see both methods' Javadoc for the full history.
  *
  * <p>Also enforces two narrower rules from the feature spec: a grant can never be created or
  * updated on the automatic personal library (it is meant to reach only its owner, see {@code
@@ -196,16 +200,14 @@ public class AssetGrantService {
     // Last-active-OWNER guard, the mirror image of upsertGrant's downgrade guard: removing the
     // last non-expired OWNER grant would leave the library in a state the application can no
     // longer manage - nobody left with the role required to grant, revoke or delete. See the class
-    // Javadoc for why the count is taken under a row lock (findByLibraryIdForUpdate), not the plain
-    // cached read used elsewhere.
-    if (grant.getRole() == AssetRole.OWNER && !grant.isExpired(Instant.now())) {
-      List<AssetGrant> lockedLibraryGrants =
-          grantRepository.findByLibraryIdForUpdate(library.getId());
-      if (isLastActiveOwnerGrant(lockedLibraryGrants, grant.getId())) {
-        throw new ResponseStatusException(
-            HttpStatus.CONFLICT,
-            "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht entfernt werden");
-      }
+    // Javadoc and AssetGrantRepository#lockLibraryGrantsForMutation for why this locks per library
+    // via an advisory lock before counting, rather than row-locking the grants directly.
+    if (grant.getRole() == AssetRole.OWNER
+        && !grant.isExpired(Instant.now())
+        && isLastActiveOwnerGrant(library.getId(), grant.getId())) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht entfernt werden");
     }
 
     grantRepository.delete(grant);
@@ -237,11 +239,18 @@ public class AssetGrantService {
     }
   }
 
-  private boolean isLastActiveOwnerGrant(List<AssetGrant> libraryGrants, UUID excludingGrantId) {
-    Instant now = Instant.now();
-    return libraryGrants.stream()
-        .filter(g -> !g.getId().equals(excludingGrantId))
-        .noneMatch(g -> g.getRole() == AssetRole.OWNER && !g.isExpired(now));
+  /**
+   * Whether {@code excludingGrantId} is the library's only active {@code OWNER} grant, i.e.
+   * removing or downgrading it would leave zero. Acquires {@link
+   * AssetGrantRepository#lockLibraryGrantsForMutation}'s per-library advisory lock first, then
+   * counts via {@link AssetGrantRepository#countOtherActiveOwnerGrants} - see both methods' Javadoc
+   * for why this two-step, lock-then-plain-read sequence is both deadlock- and staleness-safe where
+   * a single {@code SELECT ... FOR UPDATE} on the grant rows was neither.
+   */
+  private boolean isLastActiveOwnerGrant(UUID libraryId, UUID excludingGrantId) {
+    grantRepository.lockLibraryGrantsForMutation(libraryId);
+    return grantRepository.countOtherActiveOwnerGrants(libraryId, excludingGrantId, Instant.now())
+        == 0;
   }
 
   /**
@@ -266,10 +275,10 @@ public class AssetGrantService {
     if (staysActiveOwner) {
       return;
     }
-    // See AssetGrantRepository#findByLibraryIdForUpdate for why this read is taken under a row
-    // lock rather than the plain cached read used elsewhere (#202 code review round 2, nit 2).
-    List<AssetGrant> lockedLibraryGrants = grantRepository.findByLibraryIdForUpdate(libraryId);
-    if (isLastActiveOwnerGrant(lockedLibraryGrants, existingGrant.getId())) {
+    // See AssetGrantRepository#lockLibraryGrantsForMutation for why this locks per library via an
+    // advisory lock before counting, rather than row-locking the grants directly (#202 code review
+    // round 2 nit 2, round 3 blocker 2).
+    if (isLastActiveOwnerGrant(libraryId, existingGrant.getId())) {
       throw new ResponseStatusException(
           HttpStatus.CONFLICT,
           "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht herabgestuft werden");

--- a/backend/src/main/java/io/opaa/library/AssetGrantService.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantService.java
@@ -7,6 +7,7 @@ import io.opaa.auth.UserRepository;
 import io.opaa.group.Group;
 import io.opaa.group.GroupRepository;
 import io.opaa.group.PermissionSubjectType;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,23 @@ import org.springframework.web.server.ResponseStatusException;
  * side of #202. Every mutating method requires {@link AssetRole#MANAGER} on the target library,
  * resolved through {@link LibraryAccessService}, which is also where the cache this class
  * invalidates after every write lives.
+ *
+ * <p><b>Escalation guards (#202 code review):</b> {@code MANAGER} being able to grant roles at all
+ * does not mean it may grant a role higher than its own - {@link #upsertGrant} caps the requested
+ * {@link AssetRole} at the caller's own {@link LibraryAccessService#effectiveRole effective role},
+ * otherwise a {@code MANAGER} could grant itself {@code OWNER} and then delete the library or
+ * transfer ownership, rights the specification reserves for {@code OWNER} alone. Symmetrically,
+ * {@link #revokeGrant} refuses to remove the last non-expired {@code OWNER} grant on a library -
+ * without that guard, a {@code MANAGER} could remove the actual owner's grant and leave the library
+ * in a state the application can no longer manage at all.
+ *
+ * <p>Also enforces two narrower rules from the feature spec: a grant can never be created or
+ * updated on the automatic personal library (it is meant to reach only its owner, see {@code
+ * KnowledgeLibraryService#updateLibrary}'s identical guard against widening its visibility), and a
+ * grant can never be created or updated to target a dissolved group ({@code
+ * docs/features/spaces-and-assets.md#reorganisation-umbenennung-zusammenlegung}: "bestehende Grants
+ * bleiben bestehen ... koennen aber nicht erweitert werden" - existing grants to a group that was
+ * dissolved keep working, but no new or updated grant may target it).
  */
 @Service
 @Transactional(readOnly = true)
@@ -66,6 +84,22 @@ public class AssetGrantService {
     if (request.getRole() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "role ist erforderlich");
     }
+    // The personal library is meant to reach only its owner (KnowledgeLibraryService#createLibrary
+    // grants that OWNER role directly) - a grant through this API would reopen exactly the leak
+    // KnowledgeLibraryService#updateLibrary already closes for widening its visibility.
+    if (library.isPersonal()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Auf die persoenliche Bibliothek koennen keine Berechtigungen vergeben werden");
+    }
+    // Escalation guard: a caller may never grant a role higher than the one they themselves hold -
+    // see the class Javadoc. requireManageable already established callerRole is at least MANAGER.
+    AssetRole callerRole = accessService.effectiveRole(library, currentUserId, systemAdmin);
+    if (callerRole == null || request.getRole().ordinal() > callerRole.ordinal()) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN,
+          "Die eigene Rolle reicht nicht aus, um die Rolle " + request.getRole() + " zu vergeben");
+    }
 
     AssetGrant grant;
     if (request.getSubjectType() == PermissionSubjectType.USER) {
@@ -85,10 +119,11 @@ public class AssetGrantService {
                 request.getExpiresAt(),
                 currentUser.getId());
       } else {
+        requireNotDowngradingTheLastActiveOwnerGrant(library.getId(), grant, request.getRole());
         grant.updateRole(request.getRole(), request.getExpiresAt());
       }
     } else {
-      requireGroupInOrganization(request.getSubjectId(), library.getOrganizationId());
+      requireGrantableGroup(request.getSubjectId(), library.getOrganizationId());
       grant =
           grantRepository
               .findByLibraryIdAndSubjectTypeAndSubjectGroupId(
@@ -104,6 +139,7 @@ public class AssetGrantService {
                 request.getExpiresAt(),
                 currentUser.getId());
       } else {
+        requireNotDowngradingTheLastActiveOwnerGrant(library.getId(), grant, request.getRole());
         grant.updateRole(request.getRole(), request.getExpiresAt());
       }
     }
@@ -126,9 +162,46 @@ public class AssetGrantService {
     if (!grant.getLibraryId().equals(library.getId())) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Berechtigung nicht gefunden");
     }
+    // Escalation guard, the mirror image of upsertGrant's: removing the last non-expired OWNER
+    // grant would leave the library in a state the application can no longer manage - nobody left
+    // with the role required to grant, revoke or delete. See the class Javadoc.
+    if (grant.getRole() == AssetRole.OWNER
+        && !grant.isExpired(Instant.now())
+        && isLastActiveOwnerGrant(library.getId(), grant.getId())) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht entfernt werden");
+    }
 
     grantRepository.delete(grant);
     invalidateAfterCommit(library.getId());
+  }
+
+  private boolean isLastActiveOwnerGrant(UUID libraryId, UUID excludingGrantId) {
+    Instant now = Instant.now();
+    return grantRepository.findByLibraryId(libraryId).stream()
+        .filter(g -> !g.getId().equals(excludingGrantId))
+        .noneMatch(g -> g.getRole() == AssetRole.OWNER && !g.isExpired(now));
+  }
+
+  /**
+   * The same guard as {@link #revokeGrant}'s, applied to {@link #upsertGrant}'s update path:
+   * lowering an existing OWNER grant's role is exactly as dangerous as revoking it outright if it
+   * is the last active one - both leave nobody able to manage the library at all. {@code newRole ==
+   * OWNER} is always allowed (that path cannot reduce the active-owner count).
+   */
+  private void requireNotDowngradingTheLastActiveOwnerGrant(
+      UUID libraryId, AssetGrant existingGrant, AssetRole newRole) {
+    if (newRole == AssetRole.OWNER
+        || existingGrant.getRole() != AssetRole.OWNER
+        || existingGrant.isExpired(Instant.now())) {
+      return;
+    }
+    if (isLastActiveOwnerGrant(libraryId, existingGrant.getId())) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht herabgestuft werden");
+    }
   }
 
   private KnowledgeLibrary requireManageable(
@@ -163,7 +236,13 @@ public class AssetGrantService {
     }
   }
 
-  private void requireGroupInOrganization(UUID groupId, UUID organizationId) {
+  /**
+   * Resolves a group, enforces the organization boundary, and rejects a dissolved group as a grant
+   * target - see the class Javadoc for why: existing grants to a dissolved group keep working (see
+   * {@link LibraryAccessService#effectiveRole}, which does not check {@link Group#isDissolved()}
+   * either), but no new or updated grant may target it.
+   */
+  private void requireGrantableGroup(UUID groupId, UUID organizationId) {
     Group group =
         groupRepository
             .findById(groupId)
@@ -171,6 +250,11 @@ public class AssetGrantService {
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden"));
     if (!group.getOrganizationId().equals(organizationId)) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Gruppe nicht gefunden");
+    }
+    if (group.isDissolved()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Die Gruppe ist aufgeloest und kann keine neuen Berechtigungen mehr erhalten");
     }
   }
 

--- a/backend/src/main/java/io/opaa/library/AssetGrantService.java
+++ b/backend/src/main/java/io/opaa/library/AssetGrantService.java
@@ -23,14 +23,35 @@ import org.springframework.web.server.ResponseStatusException;
  * resolved through {@link LibraryAccessService}, which is also where the cache this class
  * invalidates after every write lives.
  *
- * <p><b>Escalation guards (#202 code review):</b> {@code MANAGER} being able to grant roles at all
- * does not mean it may grant a role higher than its own - {@link #upsertGrant} caps the requested
- * {@link AssetRole} at the caller's own {@link LibraryAccessService#effectiveRole effective role},
- * otherwise a {@code MANAGER} could grant itself {@code OWNER} and then delete the library or
- * transfer ownership, rights the specification reserves for {@code OWNER} alone. Symmetrically,
- * {@link #revokeGrant} refuses to remove the last non-expired {@code OWNER} grant on a library -
- * without that guard, a {@code MANAGER} could remove the actual owner's grant and leave the library
- * in a state the application can no longer manage at all.
+ * <p><b>Escalation guards (#202 code review), both directions:</b> {@code MANAGER} being able to
+ * touch grants at all does not mean it may act on a role higher than its own, in either direction -
+ * {@link #requireCallerRoleAtLeast} enforces {@code callerRole >= otherRole} everywhere a role is
+ * compared, and every mutating path calls it twice:
+ *
+ * <ul>
+ *   <li><b>The role being granted or requested</b> ({@link #upsertGrant}) - a {@code MANAGER} could
+ *       otherwise grant itself {@code OWNER} and then delete the library or transfer ownership,
+ *       rights the specification reserves for {@code OWNER} alone.
+ *   <li><b>The role already held by the grant being changed or removed</b> ({@link #upsertGrant}'s
+ *       update path and {@link #revokeGrant}) - without this half, a {@code MANAGER} could
+ *       downgrade or revoke an {@code OWNER}'s own grant even though it could never have granted
+ *       {@code OWNER} in the first place (#202 code review round 2, "Rollen-Deckelung wirkt nur in
+ *       eine Richtung"): the class Javadoc's earlier claim that these two checks were already a
+ *       "mirror image" was wrong until this second half was added - only capping the requested role
+ *       left the role of an <em>existing</em> grant uncompared to the caller's own.
+ * </ul>
+ *
+ * <p>Independently of the role-escalation guards above, {@link #revokeGrant} and {@link
+ * #upsertGrant}'s update path also refuse to leave a library with zero active {@code OWNER} grants
+ * - removing or downgrading the last one would leave nobody able to manage the library at all, not
+ * even to grant a new {@code OWNER}. This count is taken <em>after</em> the intended change,
+ * including any new {@code expiresAt} the caller is setting (#202 code review round 2, nit 1): an
+ * {@code OWNER} renewing their own grant with {@code role = OWNER} does not by itself prove the
+ * grant stays active if the caller also supplies an {@code expiresAt} in the past. See {@link
+ * #requireNotDowngradingTheLastActiveOwnerGrant} and {@link
+ * AssetGrantRepository#findByLibraryIdForUpdate} for how this count is additionally protected
+ * against two concurrent callers each observing the other's OWNER grant as still active (#202 code
+ * review round 2, nit 2).
  *
  * <p>Also enforces two narrower rules from the feature spec: a grant can never be created or
  * updated on the automatic personal library (it is meant to reach only its owner, see {@code
@@ -92,14 +113,14 @@ public class AssetGrantService {
           HttpStatus.BAD_REQUEST,
           "Auf die persoenliche Bibliothek koennen keine Berechtigungen vergeben werden");
     }
-    // Escalation guard: a caller may never grant a role higher than the one they themselves hold -
-    // see the class Javadoc. requireManageable already established callerRole is at least MANAGER.
+    // Escalation guard, half 1: a caller may never grant a role higher than the one they
+    // themselves hold - see the class Javadoc. requireManageable already established callerRole is
+    // at least MANAGER.
     AssetRole callerRole = accessService.effectiveRole(library, currentUserId, systemAdmin);
-    if (callerRole == null || request.getRole().ordinal() > callerRole.ordinal()) {
-      throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN,
-          "Die eigene Rolle reicht nicht aus, um die Rolle " + request.getRole() + " zu vergeben");
-    }
+    requireCallerRoleAtLeast(
+        callerRole,
+        request.getRole(),
+        "Die eigene Rolle reicht nicht aus, um die Rolle " + request.getRole() + " zu vergeben");
 
     AssetGrant grant;
     if (request.getSubjectType() == PermissionSubjectType.USER) {
@@ -119,7 +140,9 @@ public class AssetGrantService {
                 request.getExpiresAt(),
                 currentUser.getId());
       } else {
-        requireNotDowngradingTheLastActiveOwnerGrant(library.getId(), grant, request.getRole());
+        requireCallerCanTouchExistingGrant(callerRole, grant, "aendern");
+        requireNotDowngradingTheLastActiveOwnerGrant(
+            library.getId(), grant, request.getRole(), request.getExpiresAt());
         grant.updateRole(request.getRole(), request.getExpiresAt());
       }
     } else {
@@ -139,7 +162,9 @@ public class AssetGrantService {
                 request.getExpiresAt(),
                 currentUser.getId());
       } else {
-        requireNotDowngradingTheLastActiveOwnerGrant(library.getId(), grant, request.getRole());
+        requireCallerCanTouchExistingGrant(callerRole, grant, "aendern");
+        requireNotDowngradingTheLastActiveOwnerGrant(
+            library.getId(), grant, request.getRole(), request.getExpiresAt());
         grant.updateRole(request.getRole(), request.getExpiresAt());
       }
     }
@@ -162,24 +187,59 @@ public class AssetGrantService {
     if (!grant.getLibraryId().equals(library.getId())) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Berechtigung nicht gefunden");
     }
-    // Escalation guard, the mirror image of upsertGrant's: removing the last non-expired OWNER
-    // grant would leave the library in a state the application can no longer manage - nobody left
-    // with the role required to grant, revoke or delete. See the class Javadoc.
-    if (grant.getRole() == AssetRole.OWNER
-        && !grant.isExpired(Instant.now())
-        && isLastActiveOwnerGrant(library.getId(), grant.getId())) {
-      throw new ResponseStatusException(
-          HttpStatus.CONFLICT,
-          "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht entfernt werden");
+    // Escalation guard, half 2 - see the class Javadoc: a caller may never touch a grant that
+    // already carries a role higher than their own, regardless of whether they could have
+    // *granted* that role in the first place.
+    AssetRole callerRole = accessService.effectiveRole(library, currentUserId, systemAdmin);
+    requireCallerCanTouchExistingGrant(callerRole, grant, "entfernen");
+
+    // Last-active-OWNER guard, the mirror image of upsertGrant's downgrade guard: removing the
+    // last non-expired OWNER grant would leave the library in a state the application can no
+    // longer manage - nobody left with the role required to grant, revoke or delete. See the class
+    // Javadoc for why the count is taken under a row lock (findByLibraryIdForUpdate), not the plain
+    // cached read used elsewhere.
+    if (grant.getRole() == AssetRole.OWNER && !grant.isExpired(Instant.now())) {
+      List<AssetGrant> lockedLibraryGrants =
+          grantRepository.findByLibraryIdForUpdate(library.getId());
+      if (isLastActiveOwnerGrant(lockedLibraryGrants, grant.getId())) {
+        throw new ResponseStatusException(
+            HttpStatus.CONFLICT,
+            "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht entfernt werden");
+      }
     }
 
     grantRepository.delete(grant);
     invalidateAfterCommit(library.getId());
   }
 
-  private boolean isLastActiveOwnerGrant(UUID libraryId, UUID excludingGrantId) {
+  /**
+   * Escalation guard, half 2 (see the class Javadoc): whether {@code callerRole} is at least as
+   * privileged as the role an existing grant already carries, before that grant may be changed or
+   * removed. {@code action} is the German verb ("aendern"/"entfernen") for the resulting message.
+   */
+  private void requireCallerCanTouchExistingGrant(
+      AssetRole callerRole, AssetGrant existingGrant, String action) {
+    requireCallerRoleAtLeast(
+        callerRole,
+        existingGrant.getRole(),
+        "Die eigene Rolle reicht nicht aus, um eine bestehende "
+            + existingGrant.getRole()
+            + "-Berechtigung zu "
+            + action);
+  }
+
+  /**
+   * Throws {@code 403} unless {@code callerRole} is at least as privileged as {@code otherRole}.
+   */
+  private void requireCallerRoleAtLeast(AssetRole callerRole, AssetRole otherRole, String message) {
+    if (callerRole == null || otherRole.ordinal() > callerRole.ordinal()) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, message);
+    }
+  }
+
+  private boolean isLastActiveOwnerGrant(List<AssetGrant> libraryGrants, UUID excludingGrantId) {
     Instant now = Instant.now();
-    return grantRepository.findByLibraryId(libraryId).stream()
+    return libraryGrants.stream()
         .filter(g -> !g.getId().equals(excludingGrantId))
         .noneMatch(g -> g.getRole() == AssetRole.OWNER && !g.isExpired(now));
   }
@@ -187,17 +247,29 @@ public class AssetGrantService {
   /**
    * The same guard as {@link #revokeGrant}'s, applied to {@link #upsertGrant}'s update path:
    * lowering an existing OWNER grant's role is exactly as dangerous as revoking it outright if it
-   * is the last active one - both leave nobody able to manage the library at all. {@code newRole ==
-   * OWNER} is always allowed (that path cannot reduce the active-owner count).
+   * is the last active one - both leave nobody able to manage the library at all.
+   *
+   * <p>The count is taken <em>after</em> the intended change (#202 code review round 2, nit 1):
+   * {@code newRole == OWNER} alone does not prove the grant stays an active owner - the caller may
+   * also be setting {@code newExpiresAt} to a point in the past, which expires it immediately. Only
+   * {@code newRole == OWNER} combined with a {@code newExpiresAt} that is either absent or still in
+   * the future counts as "stays active" and skips the check below.
    */
   private void requireNotDowngradingTheLastActiveOwnerGrant(
-      UUID libraryId, AssetGrant existingGrant, AssetRole newRole) {
-    if (newRole == AssetRole.OWNER
-        || existingGrant.getRole() != AssetRole.OWNER
-        || existingGrant.isExpired(Instant.now())) {
+      UUID libraryId, AssetGrant existingGrant, AssetRole newRole, Instant newExpiresAt) {
+    Instant now = Instant.now();
+    if (existingGrant.getRole() != AssetRole.OWNER || existingGrant.isExpired(now)) {
       return;
     }
-    if (isLastActiveOwnerGrant(libraryId, existingGrant.getId())) {
+    boolean staysActiveOwner =
+        newRole == AssetRole.OWNER && (newExpiresAt == null || newExpiresAt.isAfter(now));
+    if (staysActiveOwner) {
+      return;
+    }
+    // See AssetGrantRepository#findByLibraryIdForUpdate for why this read is taken under a row
+    // lock rather than the plain cached read used elsewhere (#202 code review round 2, nit 2).
+    List<AssetGrant> lockedLibraryGrants = grantRepository.findByLibraryIdForUpdate(libraryId);
+    if (isLastActiveOwnerGrant(lockedLibraryGrants, existingGrant.getId())) {
       throw new ResponseStatusException(
           HttpStatus.CONFLICT,
           "Die letzte OWNER-Berechtigung einer Bibliothek kann nicht herabgestuft werden");

--- a/backend/src/main/java/io/opaa/library/AssetRole.java
+++ b/backend/src/main/java/io/opaa/library/AssetRole.java
@@ -1,0 +1,35 @@
+package io.opaa.library;
+
+/**
+ * The graded asset role an {@link AssetGrant} carries - a ranking deliberately separate from {@code
+ * io.opaa.space.SpaceRole} (see #202, docs/features/spaces-and-assets.md#asset-rollen). No role
+ * name occurs in both role systems: the managing asset role is {@link #MANAGER}, not {@code ADMIN},
+ * so "I have admin rights here" always refers to a space and "I have manager/owner rights" always
+ * refers to an asset.
+ *
+ * <p>Declared in ascending order so {@link #atLeast(AssetRole)} can compare via {@link #ordinal()};
+ * the separation between {@link #USER} (use without seeing configuration) and {@link #VIEWER} (see
+ * configuration) is the feature's central gain - a vetted agent or library can be rolled out widely
+ * without exposing its sources to every user of it.
+ */
+public enum AssetRole {
+  /** Use the asset (query a library, invoke an agent) without seeing its configuration. */
+  USER,
+
+  /** Additionally see the configuration: description, bound libraries, document list. */
+  VIEWER,
+
+  /** Additionally change the configuration. */
+  EDITOR,
+
+  /** Additionally share, grant roles to others, and set visibility/listed. */
+  MANAGER,
+
+  /** Additionally delete the asset and transfer ownership. */
+  OWNER;
+
+  /** Whether this role is at least as privileged as {@code other}, per the declared ordering. */
+  public boolean atLeast(AssetRole other) {
+    return this.ordinal() >= other.ordinal();
+  }
+}

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -27,20 +27,22 @@ import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Manages knowledge libraries - the first asset type (#201, see
- * docs/features/spaces-and-assets.md#assets). Read/write access implemented here is deliberately
- * the coarse subset the model already fixes for #201: the owner (a matching user, or any member of
- * an owning group), organization-wide read for {@link LibraryVisibility#ORGANIZATION}, and full
- * access for system administrators. It does not implement the graded asset roles ({@code
- * USER}/{@code VIEWER}/{@code EDITOR}/{@code MANAGER}/{@code OWNER}) or a grants table - that is
- * #202's "asset permissions and permission-aware vector search", the actual linchpin of the epic.
- * Building that here would be speculative: #201 only needs "does this library have a responsible
- * owner and can documents be attributed to it", not the full sharing model.
+ * docs/features/spaces-and-assets.md#assets). Read/write access checks are delegated to {@link
+ * LibraryAccessService} (#202), which replaced this class's former coarse {@code canRead}/{@code
+ * canManage} - see that class's Javadoc for the full reasoning, in particular why group ownership
+ * alone no longer implies management rights.
+ *
+ * <p>{@link #createLibrary} grants the creator {@link AssetRole#OWNER} explicitly via an {@link
+ * AssetGrant}, regardless of {@link LibraryOwnerType} - ownership of a group-owned library is
+ * attributed to the group (for succession, see #240), but the actual right to manage the library
+ * comes only from this grant and any further grants a {@link AssetRole#MANAGER} makes explicitly,
+ * never from group membership alone.
  *
  * <p>{@link LibraryOwnerType#SYSTEM} libraries (exactly one per organization, see {@link
- * KnowledgeLibrary#SYSTEM_LIBRARY_ID}) are fail-closed by construction: {@link #canRead} and {@link
- * #canManage} both require {@code systemAdmin} for them regardless of any other check, and {@link
- * #createLibrary} rejects a caller-supplied {@code SYSTEM} owner type outright - only the migration
- * (012-seed-system-library) ever creates one.
+ * KnowledgeLibrary#SYSTEM_LIBRARY_ID}) are fail-closed by construction: {@link
+ * LibraryAccessService#effectiveRole} requires {@code systemAdmin} for them regardless of any
+ * grant, and {@link #createLibrary} rejects a caller-supplied {@code SYSTEM} owner type outright -
+ * only the migration (012-seed-system-library) ever creates one.
  */
 @Service
 @Transactional(readOnly = true)
@@ -55,6 +57,8 @@ public class KnowledgeLibraryService {
   private final GroupRepository groupRepository;
   private final GroupMembershipResolver membershipResolver;
   private final DocumentRepository documentRepository;
+  private final AssetGrantRepository grantRepository;
+  private final LibraryAccessService accessService;
   private final TransactionTemplate requiresNewTransactionTemplate;
 
   public KnowledgeLibraryService(
@@ -63,12 +67,16 @@ public class KnowledgeLibraryService {
       GroupRepository groupRepository,
       GroupMembershipResolver membershipResolver,
       DocumentRepository documentRepository,
+      AssetGrantRepository grantRepository,
+      LibraryAccessService accessService,
       PlatformTransactionManager transactionManager) {
     this.libraryRepository = libraryRepository;
     this.userRepository = userRepository;
     this.groupRepository = groupRepository;
     this.membershipResolver = membershipResolver;
     this.documentRepository = documentRepository;
+    this.grantRepository = grantRepository;
+    this.accessService = accessService;
     this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
     this.requiresNewTransactionTemplate.setPropagationBehavior(
         TransactionDefinition.PROPAGATION_REQUIRES_NEW);
@@ -128,6 +136,17 @@ public class KnowledgeLibraryService {
     }
 
     KnowledgeLibrary saved = libraryRepository.save(library);
+    // The creator always becomes explicit OWNER via a grant, regardless of ownerType - see the
+    // class Javadoc for why this replaces deriving management rights from the owner columns
+    // (#202 code review of #201's coarse canManage).
+    grantRepository.save(
+        AssetGrant.forUser(
+            saved.getId(),
+            saved.getOrganizationId(),
+            currentUserId,
+            AssetRole.OWNER,
+            null,
+            currentUserId));
     return toLibraryResponse(saved);
   }
 
@@ -166,7 +185,7 @@ public class KnowledgeLibraryService {
 
   public LibraryResponse getLibrary(UUID libraryId, UUID currentUserId, boolean systemAdmin) {
     KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
-    if (!canRead(library, currentUserId, systemAdmin)) {
+    if (!accessService.canRead(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
     return toLibraryResponse(library);
@@ -176,7 +195,7 @@ public class KnowledgeLibraryService {
   public LibraryResponse updateLibrary(
       UUID libraryId, LibraryUpdateRequest request, UUID currentUserId, boolean systemAdmin) {
     KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
-    if (!canManage(library, currentUserId, systemAdmin)) {
+    if (!accessService.canManage(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
     // Mirrors the delete guard on the personal library (code review of #201/#305): once #202 makes
@@ -211,7 +230,7 @@ public class KnowledgeLibraryService {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Die persoenliche Bibliothek kann nicht geloescht werden");
     }
-    if (!canManage(library, currentUserId, systemAdmin)) {
+    if (!accessService.canManage(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
     // fk_documents_library_organization is RESTRICT (migration 012): deleting a library that
@@ -231,7 +250,7 @@ public class KnowledgeLibraryService {
   public List<LibraryDocumentResponse> listDocuments(
       UUID libraryId, UUID currentUserId, boolean systemAdmin) {
     KnowledgeLibrary library = loadLibrary(libraryId, currentUserId);
-    if (!canRead(library, currentUserId, systemAdmin)) {
+    if (!accessService.canRead(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
 
@@ -278,53 +297,18 @@ public class KnowledgeLibraryService {
     }
 
     requiresNewTransactionTemplate.executeWithoutResult(
-        status ->
-            libraryRepository.insertPersonalLibraryIfAbsent(
-                UUID.randomUUID(),
-                organizationId,
-                PERSONAL_LIBRARY_NAME,
-                "Private persoenliche Wissensbibliothek",
-                userId));
-  }
-
-  private boolean canRead(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
-    if (library.isSystemLibrary()) {
-      return systemAdmin;
-    }
-    if (systemAdmin) {
-      return true;
-    }
-    if (library.getVisibility() == LibraryVisibility.ORGANIZATION) {
-      return true;
-    }
-    return isOwnerOrGroupMember(library, userId);
-  }
-
-  /**
-   * <b>#202 must replace this, not just extend it</b> (code review of #201/#305): for a group-owned
-   * library, every member of the owning group can rename, change visibility and delete it - there
-   * is no distinction between an ordinary member and the {@code MANAGER}/{@code OWNER} asset roles
-   * the feature spec defines (see docs/features/spaces-and-assets.md#asset-rollen). For a
-   * directory-synchronised group this circle grows without any human decision point in this
-   * codebase (see #237's directory synchronisation), which is acceptable only as the coarse #201
-   * interim this class's own class Javadoc describes, never as the long-term model.
-   */
-  private boolean canManage(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
-    if (library.isSystemLibrary()) {
-      return systemAdmin;
-    }
-    if (systemAdmin) {
-      return true;
-    }
-    return isOwnerOrGroupMember(library, userId);
-  }
-
-  private boolean isOwnerOrGroupMember(KnowledgeLibrary library, UUID userId) {
-    if (library.isOwnedByUser(userId)) {
-      return true;
-    }
-    return library.getOwnerType() == LibraryOwnerType.GROUP
-        && membershipResolver.groupIdsForUser(userId).contains(library.getOwnerGroupId());
+        status -> {
+          libraryRepository.insertPersonalLibraryIfAbsent(
+              UUID.randomUUID(),
+              organizationId,
+              PERSONAL_LIBRARY_NAME,
+              "Private persoenliche Wissensbibliothek",
+              userId);
+          // Same connection/transaction as the insert above, so it always sees the row it just
+          // wrote (or the pre-existing one another concurrent call won the race for) - see
+          // AssetGrantRepository#insertOwnerGrantForPersonalLibraryIfAbsent.
+          grantRepository.insertOwnerGrantForPersonalLibraryIfAbsent(UUID.randomUUID(), userId);
+        });
   }
 
   private String validateName(String name) {

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -32,11 +32,15 @@ import org.springframework.web.server.ResponseStatusException;
  * canManage} - see that class's Javadoc for the full reasoning, in particular why group ownership
  * alone no longer implies management rights.
  *
- * <p>{@link #createLibrary} grants the creator {@link AssetRole#OWNER} explicitly via an {@link
- * AssetGrant}, regardless of {@link LibraryOwnerType} - ownership of a group-owned library is
- * attributed to the group (for succession, see #240), but the actual right to manage the library
- * comes only from this grant and any further grants a {@link AssetRole#MANAGER} makes explicitly,
- * never from group membership alone.
+ * <p>{@link #createLibrary} always grants the creator {@link AssetRole#OWNER} explicitly via an
+ * {@link AssetGrant} - the right to delete the library and transfer ownership always sits on a
+ * named person, never on group membership alone. For a {@link LibraryOwnerType#GROUP} library the
+ * owning group additionally gets {@link AssetRole#MANAGER} (sharing and granting roles to others),
+ * <em>not</em> {@code OWNER}: every member automatically holding {@code OWNER} would grow without a
+ * human decision point as a directory-synchronised group's membership grows (#237) and could never
+ * be downgraded once it became the library's only {@code OWNER} grant (#202 code review round 2).
+ * The accepted price is that the personal {@code OWNER} grant is lost when its holder leaves - #240
+ * (succession instead of blocking) is what regulates that case, not this class.
  *
  * <p>{@link LibraryOwnerType#SYSTEM} libraries (exactly one per organization, see {@link
  * KnowledgeLibrary#SYSTEM_LIBRARY_ID}) are fail-closed by construction: {@link
@@ -137,35 +141,44 @@ public class KnowledgeLibraryService {
     }
 
     KnowledgeLibrary saved = libraryRepository.save(library);
-    // #202 code review (blocker 4): the OWNER grant must follow ownerType, exactly like the
-    // migration 013 backfill does for pre-existing libraries - a GROUP-owned library grants OWNER
-    // to the *group*, not the creator, so a centrally maintained library (the feature spec's
-    // leitbeispiel "Rechtsquellen Soziales", owner "Referat 50 * Grundsatz") survives its
-    // creator's departure instead of hanging on a grant to a person who has since left. The
-    // creator still gets access immediately: membership in ownerGroup (already required above)
-    // resolves through the same group grant via LibraryAccessService#effectiveRole - no separate
-    // personal grant needed, and none is created, so no other member of the group inherits rights
-    // beyond what the group grant itself carries (see the class Javadoc on why mere membership
-    // must never imply management on its own).
+    // #202 code review round 2 (Befund 2): a GROUP-owned library grants the *group* MANAGER, not
+    // OWNER, and grants the *creator* (a person) OWNER separately - the round-1 fix (group gets
+    // OWNER) went a step too far. Every current and future member of the owning group is
+    // automatically OWNER under that rule - able to delete the library and transfer ownership -
+    // and grows without a human decision point as a directory-synchronised group's membership
+    // grows (#237), which is structurally the same defect #201 had, one level up. It is also not
+    // demotable: the round-1 group grant is the library's only OWNER grant, so both
+    // requireCallerCanTouchExistingGrant and the last-active-OWNER guard permanently protect it -
+    // measured as a 409 on both the downgrade and the revoke path.
+    //
+    // Splitting the two roles keeps the group's real benefit (a centrally maintained library like
+    // the feature spec's leitbeispiel "Rechtsquellen Soziales", owner "Referat 50 * Grundsatz",
+    // survives its creator's departure - MANAGER already covers sharing and granting roles to
+    // others) while keeping the two highest-stakes rights, delete and ownership transfer, on a
+    // named person who can be held accountable for them. The accepted price - that OWNER hangs on
+    // a person and is lost when they leave - is exactly the case #240 (succession instead of
+    // blocking) exists to regulate: the library does not lock, it goes to "Nachfolge offen",
+    // usable and frozen against growing reach until a curator is assigned. No other member of the
+    // group inherits rights beyond what the group's MANAGER grant itself carries (see the class
+    // Javadoc on why mere membership must never imply management on its own).
     if (ownerGroup != null) {
       grantRepository.save(
           AssetGrant.forGroup(
               saved.getId(),
               saved.getOrganizationId(),
               ownerGroup.getId(),
-              AssetRole.OWNER,
-              null,
-              currentUserId));
-    } else {
-      grantRepository.save(
-          AssetGrant.forUser(
-              saved.getId(),
-              saved.getOrganizationId(),
-              currentUserId,
-              AssetRole.OWNER,
+              AssetRole.MANAGER,
               null,
               currentUserId));
     }
+    grantRepository.save(
+        AssetGrant.forUser(
+            saved.getId(),
+            saved.getOrganizationId(),
+            currentUserId,
+            AssetRole.OWNER,
+            null,
+            currentUserId));
     return toLibraryResponse(saved);
   }
 

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -262,7 +262,14 @@ public class KnowledgeLibraryService {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Die persoenliche Bibliothek kann nicht geloescht werden");
     }
-    if (!accessService.canManage(library, currentUserId, systemAdmin)) {
+    // #202 code review round 3 (Blocker 1): deleting requires OWNER, not MANAGER - AssetRole's
+    // Javadoc reserves "delete the asset and transfer ownership" for OWNER alone, and canManage
+    // (MANAGER) was the wrong gate here: a group's MANAGER grant (round 2's fix for group-owned
+    // libraries) could otherwise delete the whole library, taking every grant on it - including the
+    // creator's OWNER grant - down with it via ON DELETE CASCADE, sidestepping the round-1/round-2
+    // escalation guards entirely instead of being blocked by them. See
+    // LibraryAccessService#canDelete.
+    if (!accessService.canDelete(library, currentUserId, systemAdmin)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Kein Zugriff auf diese Bibliothek");
     }
     // fk_documents_library_organization is RESTRICT (migration 012): deleting a library that

--- a/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
+++ b/backend/src/main/java/io/opaa/library/KnowledgeLibraryService.java
@@ -103,14 +103,15 @@ public class KnowledgeLibraryService {
     boolean listed = Boolean.TRUE.equals(request.getListed());
 
     KnowledgeLibrary library;
+    Group ownerGroup = null;
     if (ownerType == LibraryOwnerType.GROUP) {
       if (request.getOwnerId() == null) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "ownerId ist erforderlich, wenn ownerType GROUP ist");
       }
-      Group group =
+      ownerGroup =
           requireGroupInOrganization(request.getOwnerId(), currentUser.getOrganizationId());
-      if (!membershipResolver.groupIdsForUser(currentUserId).contains(group.getId())) {
+      if (!membershipResolver.groupIdsForUser(currentUserId).contains(ownerGroup.getId())) {
         throw new ResponseStatusException(
             HttpStatus.FORBIDDEN,
             "Nur Mitglieder der Gruppe koennen eine Bibliothek in ihrem Namen anlegen");
@@ -120,7 +121,7 @@ public class KnowledgeLibraryService {
               currentUser.getOrganizationId(),
               normalizedName,
               request.getDescription(),
-              group.getId(),
+              ownerGroup.getId(),
               visibility,
               listed);
     } else {
@@ -136,17 +137,35 @@ public class KnowledgeLibraryService {
     }
 
     KnowledgeLibrary saved = libraryRepository.save(library);
-    // The creator always becomes explicit OWNER via a grant, regardless of ownerType - see the
-    // class Javadoc for why this replaces deriving management rights from the owner columns
-    // (#202 code review of #201's coarse canManage).
-    grantRepository.save(
-        AssetGrant.forUser(
-            saved.getId(),
-            saved.getOrganizationId(),
-            currentUserId,
-            AssetRole.OWNER,
-            null,
-            currentUserId));
+    // #202 code review (blocker 4): the OWNER grant must follow ownerType, exactly like the
+    // migration 013 backfill does for pre-existing libraries - a GROUP-owned library grants OWNER
+    // to the *group*, not the creator, so a centrally maintained library (the feature spec's
+    // leitbeispiel "Rechtsquellen Soziales", owner "Referat 50 * Grundsatz") survives its
+    // creator's departure instead of hanging on a grant to a person who has since left. The
+    // creator still gets access immediately: membership in ownerGroup (already required above)
+    // resolves through the same group grant via LibraryAccessService#effectiveRole - no separate
+    // personal grant needed, and none is created, so no other member of the group inherits rights
+    // beyond what the group grant itself carries (see the class Javadoc on why mere membership
+    // must never imply management on its own).
+    if (ownerGroup != null) {
+      grantRepository.save(
+          AssetGrant.forGroup(
+              saved.getId(),
+              saved.getOrganizationId(),
+              ownerGroup.getId(),
+              AssetRole.OWNER,
+              null,
+              currentUserId));
+    } else {
+      grantRepository.save(
+          AssetGrant.forUser(
+              saved.getId(),
+              saved.getOrganizationId(),
+              currentUserId,
+              AssetRole.OWNER,
+              null,
+              currentUserId));
+    }
     return toLibraryResponse(saved);
   }
 

--- a/backend/src/main/java/io/opaa/library/LibraryAccessService.java
+++ b/backend/src/main/java/io/opaa/library/LibraryAccessService.java
@@ -21,8 +21,11 @@ import org.springframework.stereotype.Component;
  * it let every member of a group-owned library manage it, growing without a human decision point as
  * a directory-synchronised group's membership grows (#237). Under this class, management rights
  * come exclusively from an explicit {@link AssetGrant} (see {@code
- * KnowledgeLibraryService#createLibrary}, which grants the creator {@link AssetRole#OWNER}
- * explicitly instead of deriving it from the owner columns) or from organization-wide visibility.
+ * KnowledgeLibraryService#createLibrary}, which grants the creator {@link AssetRole#OWNER} and, for
+ * a group-owned library, additionally grants the owning group {@link AssetRole#MANAGER} - never
+ * {@code OWNER} to the group, which would reintroduce the same unbounded, non-downgradable grant
+ * this class replaced #201's coarse check to avoid, see that method's Javadoc) or from
+ * organization-wide visibility.
  *
  * <p>Two access paths, deliberately not unified:
  *

--- a/backend/src/main/java/io/opaa/library/LibraryAccessService.java
+++ b/backend/src/main/java/io/opaa/library/LibraryAccessService.java
@@ -75,11 +75,38 @@ public class LibraryAccessService {
   }
 
   /**
-   * Whether the user may rename, change visibility/listed, or delete - requires {@link
-   * AssetRole#MANAGER}.
+   * Whether the user may rename, change visibility/listed, or manage grants - requires {@link
+   * AssetRole#MANAGER}. Deliberately <b>not</b> sufficient for deleting the library or (once it
+   * exists) transferring ownership - see {@link #canDelete} and {@link AssetRole#OWNER}'s Javadoc
+   * ("additionally delete the asset and transfer ownership"). Code review round 3 of #202: this
+   * method's own Javadoc used to list "delete" here, and {@code
+   * KnowledgeLibraryService#deleteLibrary} called it directly - the exact gap that let a group's
+   * {@code MANAGER} grant (post round-2's group-gets-MANAGER fix) delete a library it could never
+   * have downgraded or revoked the {@code OWNER} grant on, taking that grant down with it.
    */
   public boolean canManage(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
     return atLeast(effectiveRole(library, userId, systemAdmin), AssetRole.MANAGER);
+  }
+
+  /**
+   * Whether the user may delete the library (and, once it exists, transfer its ownership) -
+   * requires {@link AssetRole#OWNER}, one level above {@link #canManage}. Split out in #202 code
+   * review round 3: before this method existed, {@code KnowledgeLibraryService#deleteLibrary}
+   * called {@link #canManage}, so a group's {@code MANAGER} grant (round 2's fix for the
+   * group-owned-library case) could delete the library outright - taking every grant on it,
+   * including the creator's {@code OWNER} grant, down with it via {@code
+   * fk_asset_grants_library_organization}'s {@code ON DELETE CASCADE} (migration 013). That is
+   * strictly worse than the escalation the round-1/round-2 guards close: those guards stop a {@code
+   * MANAGER} from touching the {@code OWNER} grant directly, but deleting the library was an
+   * untouched detour around them. For a migrated, backfilled group-owned library - deliberately
+   * left without any {@code OWNER} grant at all, see 013-asset-grants.yaml's backfill comment -
+   * this meant nobody could downgrade the group's grant, yet any member could still delete the
+   * library wholesale; this method closes that gap by requiring a role nobody currently holds on
+   * such a library, matching the "Nachfolge offen" intent (only a system admin, or a person granted
+   * {@code OWNER} once a curator is assigned, may delete or transfer such a library).
+   */
+  public boolean canDelete(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    return atLeast(effectiveRole(library, userId, systemAdmin), AssetRole.OWNER);
   }
 
   /**

--- a/backend/src/main/java/io/opaa/library/LibraryAccessService.java
+++ b/backend/src/main/java/io/opaa/library/LibraryAccessService.java
@@ -1,0 +1,160 @@
+package io.opaa.library;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.opaa.group.GroupMembershipResolver;
+import io.opaa.group.PermissionSubjectType;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the {@link AssetRole} a user effectively holds on a {@link KnowledgeLibrary}, and the
+ * set of libraries a user may read - the linchpin of #202
+ * (docs/features/spaces-and-assets.md#rechte-an-einem-asset-erhalten). Replaces {@code
+ * KnowledgeLibraryService}'s former {@code canRead}/{@code canManage}, which the class Javadoc
+ * there marked as a deliberately coarse #201 interim to be replaced, not extended - in particular
+ * it let every member of a group-owned library manage it, growing without a human decision point as
+ * a directory-synchronised group's membership grows (#237). Under this class, management rights
+ * come exclusively from an explicit {@link AssetGrant} (see {@code
+ * KnowledgeLibraryService#createLibrary}, which grants the creator {@link AssetRole#OWNER}
+ * explicitly instead of deriving it from the owner columns) or from organization-wide visibility.
+ *
+ * <p>Two access paths, deliberately not unified:
+ *
+ * <ul>
+ *   <li>{@link #effectiveRole}, backing {@code canRead}/{@code canManage} for the library CRUD
+ *       endpoints, is a single-library lookup on the hot path of every such request and is cached
+ *       per library id, invalidated after commit whenever a grant on that library changes -
+ *       mirroring {@link GroupMembershipResolver}'s cache and invalidation pattern.
+ *   <li>{@link #readableLibraryIds}, backing the permission-aware vector search filter (#202's
+ *       actual acceptance criteria), is deliberately <b>not</b> cached: it is a single indexed
+ *       query per call, so a revoked grant takes effect on the very next query without depending on
+ *       a second cache-invalidation path being correct - the search filter is where a stale cache
+ *       would leak data, not merely delay a UI refresh.
+ * </ul>
+ */
+@Component
+public class LibraryAccessService {
+
+  private final AssetGrantRepository grantRepository;
+  private final KnowledgeLibraryRepository libraryRepository;
+  private final GroupMembershipResolver membershipResolver;
+  private final Cache<UUID, List<AssetGrant>> grantsByLibrary;
+
+  public LibraryAccessService(
+      AssetGrantRepository grantRepository,
+      KnowledgeLibraryRepository libraryRepository,
+      GroupMembershipResolver membershipResolver) {
+    this.grantRepository = grantRepository;
+    this.libraryRepository = libraryRepository;
+    this.membershipResolver = membershipResolver;
+    // Same reasoning as GroupMembershipResolver#groupIdsByUser: a stale entry only ever grants
+    // access a moment too long between a completed transaction's invalidation and the next read,
+    // never too little - invalidateLibrary below, called post-commit, is the primary correctness
+    // mechanism. Time-based expiry is a safety net only.
+    this.grantsByLibrary =
+        Caffeine.newBuilder().maximumSize(50_000).expireAfterWrite(Duration.ofMinutes(10)).build();
+  }
+
+  /**
+   * Whether the user may see a library's configuration (name, description, owner, document list) -
+   * requires at least {@link AssetRole#VIEWER}. Not the same as being able to use the library in a
+   * query, which only requires {@link AssetRole#USER} and is what {@link #readableLibraryIds}
+   * grants; see docs/features/spaces-and-assets.md#asset-rollen for the distinction.
+   */
+  public boolean canRead(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    return atLeast(effectiveRole(library, userId, systemAdmin), AssetRole.VIEWER);
+  }
+
+  /**
+   * Whether the user may rename, change visibility/listed, or delete - requires {@link
+   * AssetRole#MANAGER}.
+   */
+  public boolean canManage(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    return atLeast(effectiveRole(library, userId, systemAdmin), AssetRole.MANAGER);
+  }
+
+  /**
+   * The highest {@link AssetRole} the user holds on the library, or {@code null} if none. System
+   * libraries are fail-closed to system admins regardless of any grant, mirroring the previous
+   * behaviour this class replaces. Organization-wide visibility grants {@link AssetRole#VIEWER} to
+   * every user of the same organization - the same level the pre-#202 {@code canRead} granted for
+   * {@code LibraryVisibility#ORGANIZATION}, kept unchanged here since #202's mandate is fixing the
+   * group-ownership overreach, not narrowing this path.
+   */
+  public AssetRole effectiveRole(KnowledgeLibrary library, UUID userId, boolean systemAdmin) {
+    if (library.isSystemLibrary()) {
+      return systemAdmin ? AssetRole.OWNER : null;
+    }
+    if (systemAdmin) {
+      return AssetRole.OWNER;
+    }
+
+    AssetRole best = null;
+    if (library.getVisibility() == LibraryVisibility.ORGANIZATION) {
+      best = AssetRole.VIEWER;
+    }
+
+    Instant now = Instant.now();
+    Set<UUID> groupIds = membershipResolver.groupIdsForUser(userId);
+    for (AssetGrant grant :
+        grantsByLibrary.get(library.getId(), grantRepository::findByLibraryId)) {
+      if (grant.isExpired(now)) {
+        continue;
+      }
+      boolean reaches =
+          (grant.getSubjectType() == PermissionSubjectType.USER
+                  && grant.getSubjectUserId().equals(userId))
+              || (grant.getSubjectType() == PermissionSubjectType.GROUP
+                  && groupIds.contains(grant.getSubjectGroupId()));
+      if (reaches && (best == null || grant.getRole().atLeast(best))) {
+        best = grant.getRole();
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Every library id readable by the user in {@code organizationId}: direct grants, group grants
+   * for the groups the user currently belongs to, and every organization-wide library - exactly the
+   * formula in docs/features/spaces-and-assets.md#rechte-an-einem-asset-erhalten. Space
+   * associations deliberately do not appear anywhere in this computation, per the same
+   * specification section. No system-admin bypass: the vector search always reads with the calling
+   * user's own rights, with no second rights context (see #202 scope and ADR-0008 §5) - unlike
+   * {@link #effectiveRole}, which still fail-opens system admins for library administration.
+   */
+  public Set<UUID> readableLibraryIds(UUID userId, UUID organizationId) {
+    Instant now = Instant.now();
+    Set<UUID> groupIds = membershipResolver.groupIdsForUser(userId);
+
+    Set<UUID> readable = new HashSet<>();
+    readable.addAll(
+        grantRepository.findReadableLibraryIdsByDirectGrant(userId, organizationId, now));
+    if (!groupIds.isEmpty()) {
+      readable.addAll(
+          grantRepository.findReadableLibraryIdsByGroupGrant(groupIds, organizationId, now));
+    }
+    libraryRepository
+        .findByOrganizationIdAndVisibility(organizationId, LibraryVisibility.ORGANIZATION)
+        .forEach(library -> readable.add(library.getId()));
+    return readable;
+  }
+
+  /**
+   * Evicts the cached grant list for a library, called after commit (or rollback) whenever one of
+   * its grants changes - see {@code AssetGrantService#invalidateAfterCommit} for why "after commit"
+   * rather than inline.
+   */
+  public void invalidateLibrary(UUID libraryId) {
+    grantsByLibrary.invalidate(libraryId);
+  }
+
+  private static boolean atLeast(AssetRole role, AssetRole required) {
+    return role != null && role.atLeast(required);
+  }
+}

--- a/backend/src/main/java/io/opaa/query/QueryConfiguration.java
+++ b/backend/src/main/java/io/opaa/query/QueryConfiguration.java
@@ -2,7 +2,9 @@ package io.opaa.query;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opaa.auth.UserRepository;
 import io.opaa.indexing.DocumentRepository;
+import io.opaa.library.LibraryAccessService;
 import io.opaa.observability.QueryMetrics;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -78,6 +80,8 @@ public class QueryConfiguration {
       ChatMemory chatMemory,
       CitationParser citationParser,
       DocumentRepository documentRepository,
+      UserRepository userRepository,
+      LibraryAccessService libraryAccessService,
       QueryMetrics queryMetrics,
       QueryProperties queryProperties) {
     return new QueryService(
@@ -86,6 +90,8 @@ public class QueryConfiguration {
         chatMemory,
         citationParser,
         documentRepository,
+        userRepository,
+        libraryAccessService,
         queryMetrics,
         queryProperties);
   }

--- a/backend/src/main/java/io/opaa/query/QueryService.java
+++ b/backend/src/main/java/io/opaa/query/QueryService.java
@@ -5,7 +5,10 @@ import static java.util.stream.Collectors.toMap;
 import io.opaa.api.dto.QueryMetadata;
 import io.opaa.api.dto.QueryResponse;
 import io.opaa.api.dto.SourceReference;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
 import io.opaa.indexing.DocumentRepository;
+import io.opaa.library.LibraryAccessService;
 import io.opaa.observability.QueryMetrics;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -24,19 +27,26 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 public class QueryService {
 
   private static final Logger log = LoggerFactory.getLogger(QueryService.class);
 
   private static final Pattern VALID_CONVERSATION_ID = Pattern.compile("^[a-zA-Z0-9-]{1,50}$");
+  private static final String LIBRARY_ID_METADATA_KEY = "library_id";
 
   private final VectorStore vectorStore;
   private final AnswerGenerationService answerGenerationService;
   private final ChatMemory chatMemory;
   private final CitationParser citationParser;
   private final DocumentRepository documentRepository;
+  private final UserRepository userRepository;
+  private final LibraryAccessService libraryAccessService;
   private final QueryMetrics metrics;
   private final QueryProperties queryProperties;
 
@@ -46,6 +56,8 @@ public class QueryService {
       ChatMemory chatMemory,
       CitationParser citationParser,
       DocumentRepository documentRepository,
+      UserRepository userRepository,
+      LibraryAccessService libraryAccessService,
       QueryMetrics metrics,
       QueryProperties queryProperties) {
     this.vectorStore = vectorStore;
@@ -53,30 +65,62 @@ public class QueryService {
     this.chatMemory = chatMemory;
     this.citationParser = citationParser;
     this.documentRepository = documentRepository;
+    this.userRepository = userRepository;
+    this.libraryAccessService = libraryAccessService;
     this.metrics = metrics;
     this.queryProperties = queryProperties;
   }
 
+  /**
+   * Answers {@code question}, restricted to chunks from libraries {@code currentUserId} may read
+   * (#202 - the permission-aware vector search, the central gap the epic set out to close: before
+   * this, the similarity search ran with no metadata filter whatsoever). The filter is part of the
+   * {@link VectorStore#similaritySearch} call itself, not a post-filter applied to its result - an
+   * unauthorized chunk is never loaded or ranked, let alone returned. There is no bypass for a
+   * system admin here (unlike {@code LibraryAccessService#effectiveRole}, used for library
+   * administration): a query always reads with the calling user's own rights, with no second rights
+   * context (ADR-0008 §5).
+   *
+   * <p>An empty readable set short-circuits before the vector store is even called, skipping
+   * straight to answer generation with zero chunks - the same code path a query with genuinely no
+   * matching content takes, so the resulting message cannot be used to distinguish "no permission
+   * on anything" from "nothing matched" (#202 acceptance criteria).
+   */
   @Transactional(readOnly = true)
-  public QueryResponse query(String question, String conversationId) {
+  public QueryResponse query(String question, String conversationId, UUID currentUserId) {
     return metrics
         .queryTimer()
         .record(
             () -> {
               try {
+                User currentUser =
+                    userRepository
+                        .findById(currentUserId)
+                        .orElseThrow(
+                            () ->
+                                new ResponseStatusException(
+                                    HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden"));
+
                 String effectiveConversationId = validateConversationId(conversationId);
 
                 String searchQuery = buildSearchQuery(question, effectiveConversationId);
 
                 long startTime = System.currentTimeMillis();
 
+                Set<UUID> readableLibraryIds =
+                    libraryAccessService.readableLibraryIds(
+                        currentUserId, currentUser.getOrganizationId());
+
                 List<Document> relevantChunks =
-                    vectorStore.similaritySearch(
-                        SearchRequest.builder()
-                            .query(searchQuery)
-                            .topK(queryProperties.topK())
-                            .similarityThreshold(queryProperties.similarityThreshold())
-                            .build());
+                    readableLibraryIds.isEmpty()
+                        ? List.of()
+                        : vectorStore.similaritySearch(
+                            SearchRequest.builder()
+                                .query(searchQuery)
+                                .topK(queryProperties.topK())
+                                .similarityThreshold(queryProperties.similarityThreshold())
+                                .filterExpression(libraryFilter(readableLibraryIds))
+                                .build());
 
                 log.debug("Found {} relevant chunks for query", relevantChunks.size());
 
@@ -112,6 +156,17 @@ public class QueryService {
                 throw e;
               }
             });
+  }
+
+  /**
+   * Builds the {@code library_id IN (...)} filter passed straight into {@link
+   * VectorStore#similaritySearch} - see {@link #query} for why this must be part of the search
+   * call, never a filter applied to its result afterwards.
+   */
+  private Filter.Expression libraryFilter(Set<UUID> readableLibraryIds) {
+    List<Object> libraryIdValues =
+        readableLibraryIds.stream().map(UUID::toString).map(Object.class::cast).toList();
+    return new FilterExpressionBuilder().in(LIBRARY_ID_METADATA_KEY, libraryIdValues).build();
   }
 
   private Map<String, Integer> countMatchesPerFile(List<Document> chunks) {

--- a/backend/src/main/resources/db/changelog/changes/013-asset-grants.yaml
+++ b/backend/src/main/resources/db/changelog/changes/013-asset-grants.yaml
@@ -201,14 +201,34 @@ databaseChangeLog:
       id: 013-backfill-owner-grants
       author: opaa
       comment: >
-        Every library that already has an individual or group owner (i.e. everything except the
-        SYSTEM library, which stays fail-closed to system admins with no grant at all) gets an
-        explicit OWNER grant for that owner. This is not a new decision: it makes the decision
-        already made when the library was created explicit as a revocable, auditable grant row -
-        the same shift #202 makes going forward for every new library via
+        Every library that already has an individual owner (i.e. USER, not GROUP or the SYSTEM
+        library, which stays fail-closed to system admins with no grant at all) gets an explicit
+        OWNER grant for that owner. This is not a new decision: it makes the decision already made
+        when the library was created explicit as a revocable, auditable grant row - the same shift
+        #202 makes going forward for every new USER-owned library via
         KnowledgeLibraryService#createLibrary. Without this backfill, #202's replacement of the
         coarse #201 canRead/canManage (which derived rights from the owner columns directly) would
-        silently lock every existing owner out of their own library.
+        silently lock every existing individual owner out of their own library.
+
+        A GROUP-owned library instead gets its owning group an explicit MANAGER grant, not OWNER -
+        matching the rule #202's round-2 review settled on for newly created group-owned libraries
+        (see KnowledgeLibraryService#createLibrary): OWNER must sit on a named person who can be
+        held accountable for deleting the library or transferring ownership, and a bulk-granted
+        OWNER to every group member would be exactly as unbounded and non-downgradable as the #201
+        defect this migration accompanies fixing. For a pre-existing GROUP-owned library there is,
+        by construction, no recorded "creator" to attribute that personal OWNER grant to - the
+        owner_user_id/owner_group_id columns this backfill reads from never carried one. Rather
+        than fabricate a creator (there is no principled way to pick one member of the group over
+        another), this backfill deliberately leaves such a library without any OWNER grant at all:
+        every current group member keeps working access via the new MANAGER grant (share, grant
+        further roles, rename, change visibility), but nobody can delete the library or transfer
+        ownership until a system admin (who still resolves to an implicit OWNER-equivalent via
+        LibraryAccessService#effectiveRole's systemAdmin bypass, unlike the search path) grants an
+        explicit OWNER to a named person - functionally the same "Nachfolge offen" state #240
+        formalises for a departed owner, present here from the very first migration run rather than
+        introduced later by an ownership change. This was raised explicitly for maintainer
+        confirmation rather than decided silently (#202 code review round 2) - see the PR
+        description for the alternatives considered and why they were rejected.
       changes:
         - sql:
             sql: >
@@ -221,7 +241,7 @@ databaseChangeLog:
             sql: >
               INSERT INTO asset_grants
                 (id, library_id, organization_id, subject_type, subject_group_id, role, created_at, updated_at)
-              SELECT gen_random_uuid(), kl.id, kl.organization_id, 'GROUP', kl.owner_group_id, 'OWNER', now(), now()
+              SELECT gen_random_uuid(), kl.id, kl.organization_id, 'GROUP', kl.owner_group_id, 'MANAGER', now(), now()
               FROM knowledge_libraries kl
               WHERE kl.owner_type = 'GROUP';
       rollback:

--- a/backend/src/main/resources/db/changelog/changes/013-asset-grants.yaml
+++ b/backend/src/main/resources/db/changelog/changes/013-asset-grants.yaml
@@ -1,0 +1,234 @@
+databaseChangeLog:
+  # Two changeSets, in dependency order, introducing asset permissions (#202, see
+  # docs/features/spaces-and-assets.md#rechte-an-einem-asset-erhalten):
+  #   1. 013-create-asset-grants          - the table itself
+  #   2. 013-backfill-owner-grants        - makes every existing library owner's implicit
+  #                                          management right an explicit grant, so #202's
+  #                                          replacement of the coarse #201 canRead/canManage does
+  #                                          not silently lock out an existing owner
+  #
+  # Rollback order (reverse of apply order):
+  # 013-backfill-owner-grants
+  # 013-create-asset-grants
+
+  - changeSet:
+      id: 013-create-asset-grants
+      author: opaa
+      comment: >
+        Create asset_grants - a grant of a graded AssetRole (USER < VIEWER < EDITOR < MANAGER <
+        OWNER, a ranking deliberately separate from space_memberships.role, see AssetRole and
+        ADR-0008 #7) on a knowledge_libraries row to a user or a group. Subject uses the same
+        two-nullable-columns pattern as knowledge_libraries.owner_user_id/owner_group_id (migration
+        012) rather than one polymorphic subject_id, so each carries a real foreign key to its own
+        target table. expires_at is present from the start even though recertification only
+        arrives with #241 - adding the column later is cheap, assessing an existing body of grants
+        without one is not. library_id plus organization_id together (not library_id alone) is the
+        filter axis the permission-aware vector search (#202) uses, mirroring
+        documents.library_id/organization_id from migration 012.
+      changes:
+        - createTable:
+            tableName: asset_grants
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: library_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: organization_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: subject_type
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: subject_user_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: subject_group_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: role
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: true
+              - column:
+                  name: granted_by_user_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: asset_grants
+            baseColumnNames: library_id, organization_id
+            referencedTableName: knowledge_libraries
+            referencedColumnNames: id, organization_id
+            constraintName: fk_asset_grants_library_organization
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: asset_grants
+            baseColumnNames: subject_user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_asset_grants_subject_user
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            baseTableName: asset_grants
+            baseColumnNames: subject_group_id, organization_id
+            referencedTableName: groups
+            referencedColumnNames: id, organization_id
+            constraintName: fk_asset_grants_subject_group_organization
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            baseTableName: asset_grants
+            baseColumnNames: granted_by_user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_asset_grants_granted_by_user
+            onDelete: RESTRICT
+        - sql:
+            comment: "Add check constraint for subject_type values"
+            sql: >
+              ALTER TABLE asset_grants
+              ADD CONSTRAINT chk_asset_grants_subject_type
+              CHECK (subject_type IN ('USER', 'GROUP'));
+        - sql:
+            comment: "Add check constraint for role values - AssetRole, disjoint from SpaceRole"
+            sql: >
+              ALTER TABLE asset_grants
+              ADD CONSTRAINT chk_asset_grants_role
+              CHECK (role IN ('USER', 'VIEWER', 'EDITOR', 'MANAGER', 'OWNER'));
+        - sql:
+            comment: >
+              Exactly one subject column matches subject_type: USER carries subject_user_id only,
+              GROUP carries subject_group_id only - mirrors chk_knowledge_libraries_owner
+              (migration 012).
+            sql: >
+              ALTER TABLE asset_grants
+              ADD CONSTRAINT chk_asset_grants_subject
+              CHECK (
+                (subject_type = 'USER' AND subject_user_id IS NOT NULL AND subject_group_id IS NULL)
+                OR (subject_type = 'GROUP' AND subject_group_id IS NOT NULL AND subject_user_id IS NULL)
+              );
+        - sql:
+            comment: >
+              At most one grant per (library, user subject) - the target AssetGrantService#upsertGrant
+              upserts against, and the ON CONFLICT target
+              AssetGrantRepository#insertOwnerGrantForPersonalLibraryIfAbsent races against.
+            sql: >
+              CREATE UNIQUE INDEX uk_asset_grants_user_subject
+              ON asset_grants (library_id, subject_user_id)
+              WHERE subject_type = 'USER';
+        - sql:
+            comment: "The group-subject counterpart of uk_asset_grants_user_subject."
+            sql: >
+              CREATE UNIQUE INDEX uk_asset_grants_group_subject
+              ON asset_grants (library_id, subject_group_id)
+              WHERE subject_type = 'GROUP';
+        - sql:
+            comment: >
+              Supports LibraryAccessService#readableLibraryIds's direct- and group-grant queries,
+              which always filter on subject plus organization_id together.
+            sql: >
+              CREATE INDEX idx_asset_grants_subject_user_organization
+              ON asset_grants (subject_user_id, organization_id)
+              WHERE subject_type = 'USER';
+        - sql:
+            sql: >
+              CREATE INDEX idx_asset_grants_subject_group_organization
+              ON asset_grants (subject_group_id, organization_id)
+              WHERE subject_type = 'GROUP';
+      rollback:
+        - sql:
+            sql: "DROP INDEX IF EXISTS idx_asset_grants_subject_group_organization;"
+        - sql:
+            sql: "DROP INDEX IF EXISTS idx_asset_grants_subject_user_organization;"
+        - sql:
+            sql: "DROP INDEX IF EXISTS uk_asset_grants_group_subject;"
+        - sql:
+            sql: "DROP INDEX IF EXISTS uk_asset_grants_user_subject;"
+        - sql:
+            sql: "ALTER TABLE asset_grants DROP CONSTRAINT IF EXISTS chk_asset_grants_subject;"
+        - sql:
+            sql: "ALTER TABLE asset_grants DROP CONSTRAINT IF EXISTS chk_asset_grants_role;"
+        - sql:
+            sql: "ALTER TABLE asset_grants DROP CONSTRAINT IF EXISTS chk_asset_grants_subject_type;"
+        - dropForeignKeyConstraint:
+            baseTableName: asset_grants
+            constraintName: fk_asset_grants_granted_by_user
+        - dropForeignKeyConstraint:
+            baseTableName: asset_grants
+            constraintName: fk_asset_grants_subject_group_organization
+        - dropForeignKeyConstraint:
+            baseTableName: asset_grants
+            constraintName: fk_asset_grants_subject_user
+        - dropForeignKeyConstraint:
+            baseTableName: asset_grants
+            constraintName: fk_asset_grants_library_organization
+        - dropTable:
+            tableName: asset_grants
+
+  - changeSet:
+      id: 013-backfill-owner-grants
+      author: opaa
+      comment: >
+        Every library that already has an individual or group owner (i.e. everything except the
+        SYSTEM library, which stays fail-closed to system admins with no grant at all) gets an
+        explicit OWNER grant for that owner. This is not a new decision: it makes the decision
+        already made when the library was created explicit as a revocable, auditable grant row -
+        the same shift #202 makes going forward for every new library via
+        KnowledgeLibraryService#createLibrary. Without this backfill, #202's replacement of the
+        coarse #201 canRead/canManage (which derived rights from the owner columns directly) would
+        silently lock every existing owner out of their own library.
+      changes:
+        - sql:
+            sql: >
+              INSERT INTO asset_grants
+                (id, library_id, organization_id, subject_type, subject_user_id, role, created_at, updated_at)
+              SELECT gen_random_uuid(), kl.id, kl.organization_id, 'USER', kl.owner_user_id, 'OWNER', now(), now()
+              FROM knowledge_libraries kl
+              WHERE kl.owner_type = 'USER';
+        - sql:
+            sql: >
+              INSERT INTO asset_grants
+                (id, library_id, organization_id, subject_type, subject_group_id, role, created_at, updated_at)
+              SELECT gen_random_uuid(), kl.id, kl.organization_id, 'GROUP', kl.owner_group_id, 'OWNER', now(), now()
+              FROM knowledge_libraries kl
+              WHERE kl.owner_type = 'GROUP';
+      rollback:
+        - sql:
+            comment: >
+              Irreversible for the same reason 012-backfill-document-library-id's rollback is a
+              no-op: a grant created by application code after this changeSet ran is
+              indistinguishable here from one this changeSet inserted. Deliberate no-op so the
+              rollback of the surrounding, lossless changeSets is not blocked.
+            sql: "SELECT 1;"

--- a/backend/src/main/resources/openapi/opaa-api.yaml
+++ b/backend/src/main/resources/openapi/opaa-api.yaml
@@ -815,6 +815,89 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/libraries/{libraryId}/grants:
+    parameters:
+      - name: libraryId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      operationId: listAssetGrants
+      tags: [library]
+      summary: >
+        List the grants on a library (MANAGER role or above required). See
+        docs/features/spaces-and-assets.md#asset-rollen.
+      responses:
+        "200":
+          description: List of grants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AssetGrantResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    post:
+      operationId: upsertAssetGrant
+      tags: [library]
+      summary: >
+        Grant (or update the role of) a user or group on a library (MANAGER role or above
+        required). Idempotent per subject: submitting again for the same subject replaces its role
+        and expiry.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssetGrantRequest"
+      responses:
+        "200":
+          description: Grant created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetGrantResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/libraries/{libraryId}/grants/{grantId}:
+    parameters:
+      - name: libraryId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: grantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    delete:
+      operationId: revokeAssetGrant
+      tags: [library]
+      summary: Revoke a grant (MANAGER role or above required). Takes effect on the next query.
+      responses:
+        "204":
+          description: Grant revoked
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 components:
   schemas:
     HealthResponse:
@@ -1537,6 +1620,72 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    AssetRole:
+      type: string
+      description: >
+        The graded asset role a grant carries - a ranking deliberately separate from SpaceRole; no
+        role name occurs in both. USER uses the asset without seeing its configuration, VIEWER
+        additionally sees it, EDITOR additionally changes it, MANAGER additionally shares/grants
+        and sets visibility, OWNER additionally deletes and transfers ownership. See
+        docs/features/spaces-and-assets.md#asset-rollen.
+      enum: [USER, VIEWER, EDITOR, MANAGER, OWNER]
+      example: VIEWER
+
+    PermissionSubjectType:
+      type: string
+      description: Whether a grant targets a single user or a group.
+      enum: [USER, GROUP]
+      example: USER
+
+    AssetGrantRequest:
+      type: object
+      required: [subjectType, subjectId, role]
+      properties:
+        subjectType:
+          $ref: "#/components/schemas/PermissionSubjectType"
+        subjectId:
+          type: string
+          format: uuid
+          description: The user or group id, depending on subjectType.
+        role:
+          $ref: "#/components/schemas/AssetRole"
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >
+            Null means the grant never expires. Present from the start even though
+            recertification only arrives with #241.
+
+    AssetGrantResponse:
+      type: object
+      required: [id, subjectType, subjectId, role, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        subjectType:
+          $ref: "#/components/schemas/PermissionSubjectType"
+        subjectId:
+          type: string
+          format: uuid
+        role:
+          $ref: "#/components/schemas/AssetRole"
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        grantedByUserId:
+          type: string
+          format: uuid
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
     DirectorySyncOutcome:
       type: string

--- a/backend/src/test/java/io/opaa/api/QueryControllerTest.java
+++ b/backend/src/test/java/io/opaa/api/QueryControllerTest.java
@@ -3,6 +3,7 @@ package io.opaa.api;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,10 +11,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.opaa.api.dto.QueryMetadata;
 import io.opaa.api.dto.QueryResponse;
 import io.opaa.api.dto.SourceReference;
+import io.opaa.auth.SystemRole;
 import io.opaa.auth.TestSecurityConfig;
+import io.opaa.auth.User;
+import io.opaa.auth.UserService;
 import io.opaa.query.QueryService;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.ai.retry.TransientAiException;
@@ -24,14 +30,31 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @WebMvcTest(QueryController.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "basic"})
 @Import(TestSecurityConfig.class)
 class QueryControllerTest {
 
+  private static final String TEST_ISSUER = "test-issuer";
+  private static final String TEST_SUBJECT = "test-subject";
+
   @Autowired private MockMvc mockMvc;
   @MockitoBean private QueryService queryService;
+  @MockitoBean private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    User user = new User(TEST_SUBJECT, TEST_ISSUER, "test@example.com", "Test User");
+    user.setSystemRole(SystemRole.USER);
+    when(userService.findBySubjectAndIssuer(TEST_SUBJECT, TEST_ISSUER))
+        .thenReturn(Optional.of(user));
+  }
+
+  private RequestPostProcessor asTestUser() {
+    return jwt().jwt(builder -> builder.subject(TEST_SUBJECT).claim("iss", TEST_ISSUER));
+  }
 
   @Test
   void queryReturnsAnswerWithSources() throws Exception {
@@ -41,11 +64,12 @@ class QueryControllerTest {
             List.of(sourceReference("doc.md", 0.9, 2, Instant.parse("2025-01-15T10:30:00Z"), true)),
             new QueryMetadata("gpt-4o", 500, 1200L),
             "conv-123");
-    when(queryService.query(anyString(), any())).thenReturn(response);
+    when(queryService.query(anyString(), any(), any())).thenReturn(response);
 
     mockMvc
         .perform(
             post("/api/v1/query")
+                .with(asTestUser())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"What is OPAA?\"}"))
         .andExpect(status().isOk())
@@ -66,11 +90,12 @@ class QueryControllerTest {
     var response =
         new QueryResponse(
             "Answer", List.of(), new QueryMetadata("gpt-4o", 100, 500L), "existing-conv");
-    when(queryService.query(anyString(), any())).thenReturn(response);
+    when(queryService.query(anyString(), any(), any())).thenReturn(response);
 
     mockMvc
         .perform(
             post("/api/v1/query")
+                .with(asTestUser())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"Follow-up?\", \"conversationId\": \"existing-conv\"}"))
         .andExpect(status().isOk())
@@ -82,6 +107,7 @@ class QueryControllerTest {
     mockMvc
         .perform(
             post("/api/v1/query")
+                .with(asTestUser())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"  \"}"))
         .andExpect(status().isBadRequest())
@@ -91,18 +117,26 @@ class QueryControllerTest {
   @Test
   void queryWithMissingBodyReturns400() throws Exception {
     mockMvc
-        .perform(post("/api/v1/query").contentType(MediaType.APPLICATION_JSON))
+        .perform(post("/api/v1/query").with(asTestUser()).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
 
+  // No test for the "unknown user" 401 path here: GlobalExceptionHandler has no
+  // @ExceptionHandler(ResponseStatusException.class), so a ResponseStatusException thrown from
+  // currentUser() (the same pattern LibraryController, GroupController and SpaceController
+  // already use) falls through to the generic Exception.class handler and surfaces as 500, not
+  // its actual status - a pre-existing gap this PR does not fix (out of scope for #202, see the
+  // PR description's follow-up note).
+
   @Test
   void queryWithTransientAiExceptionReturns503() throws Exception {
-    when(queryService.query(anyString(), any()))
+    when(queryService.query(anyString(), any(), any()))
         .thenThrow(new TransientAiException("Service unavailable"));
 
     mockMvc
         .perform(
             post("/api/v1/query")
+                .with(asTestUser())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"What?\"}"))
         .andExpect(status().isServiceUnavailable())
@@ -112,12 +146,13 @@ class QueryControllerTest {
 
   @Test
   void queryWithNonTransientAiExceptionReturns502() throws Exception {
-    when(queryService.query(anyString(), any()))
+    when(queryService.query(anyString(), any(), any()))
         .thenThrow(new NonTransientAiException("Invalid API key"));
 
     mockMvc
         .perform(
             post("/api/v1/query")
+                .with(asTestUser())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"question\": \"What?\"}"))
         .andExpect(status().isBadGateway())

--- a/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/GroupServiceIntegrationTest.java
@@ -9,6 +9,9 @@ import io.opaa.api.dto.GroupResponse;
 import io.opaa.api.dto.GroupUpdateRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
+import io.opaa.library.AssetGrant;
+import io.opaa.library.AssetGrantRepository;
+import io.opaa.library.AssetRole;
 import io.opaa.library.KnowledgeLibrary;
 import io.opaa.library.KnowledgeLibraryRepository;
 import io.opaa.library.LibraryVisibility;
@@ -70,6 +73,7 @@ class GroupServiceIntegrationTest {
   @Autowired private GroupMembershipResolver membershipResolver;
   @Autowired private UserRepository userRepository;
   @Autowired private KnowledgeLibraryRepository libraryRepository;
+  @Autowired private AssetGrantRepository grantRepository;
   @Autowired private PlatformTransactionManager transactionManager;
 
   private UUID organizationA;
@@ -77,6 +81,7 @@ class GroupServiceIntegrationTest {
 
   @BeforeEach
   void cleanUp() {
+    grantRepository.deleteAll();
     libraryRepository.deleteAll();
     membershipRepository.deleteAll();
     groupRepository.deleteAll();
@@ -173,6 +178,42 @@ class GroupServiceIntegrationTest {
     // Once the library no longer references the group, deletion succeeds - the check is a live
     // guard, not a one-time flag on the group.
     libraryRepository.delete(library);
+    groupService.deleteGroup(saved.getId(), admin);
+    assertThat(groupRepository.findById(saved.getId())).isEmpty();
+  }
+
+  @Test
+  void cannotDeleteAGroupThatStillHoldsAGrantOnALibraryItDoesNotOwn() {
+    // #202 code review (blocker 2): "an Abteilung 5 freigeben" (feature spec's
+    // "Freigabestufen und Auffindbarkeit") is a grant TO the group, not ownership BY it - the
+    // everyday case, not the edge case. fk_asset_grants_subject_group_organization (migration
+    // 013) is RESTRICT exactly like fk_knowledge_libraries_owner_group_organization, so without
+    // GroupService#deleteGroup's second, independent check, this must fail with an unhandled
+    // DataIntegrityViolationException (500) instead of a clean 409.
+    UUID admin = createUser(organizationA);
+    UUID owner = createUser(organizationA);
+    Group group = new Group(organizationA, GroupKind.AD_HOC, "Abteilung 5", null, null, null);
+    Group saved = groupRepository.save(group);
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByUser(
+            organizationA, "Rechtsquellen", null, owner, LibraryVisibility.PRIVATE, false, false);
+    KnowledgeLibrary savedLibrary = libraryRepository.save(library);
+    AssetGrant grant =
+        AssetGrant.forGroup(
+            savedLibrary.getId(), organizationA, saved.getId(), AssetRole.VIEWER, null, owner);
+    grantRepository.save(grant);
+
+    assertThatThrownBy(() -> groupService.deleteGroup(saved.getId(), admin))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    assertThat(groupRepository.findById(saved.getId())).isPresent();
+
+    // Once the grant is revoked, deletion succeeds - the check is a live guard, not a one-time
+    // flag on the group.
+    grantRepository.delete(grant);
     groupService.deleteGroup(saved.getId(), admin);
     assertThat(groupRepository.findById(saved.getId())).isEmpty();
   }

--- a/backend/src/test/java/io/opaa/integration/OpenAiIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/integration/OpenAiIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opaa.api.dto.QueryResponse;
 import io.opaa.indexing.*;
+import io.opaa.library.KnowledgeLibrary;
+import io.opaa.organization.Organization;
 import io.opaa.query.QueryService;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -50,8 +52,16 @@ class OpenAiIntegrationTest {
     registry.add("opaa.indexing.retry-attempts", () -> 1);
   }
 
-  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
-  private static final String SYSTEM_LIBRARY_ID = "00000000-0000-0000-0000-000000000002";
+  // The real seeded ids (Organization.DEFAULT_ID, KnowledgeLibrary.SYSTEM_LIBRARY_ID), not
+  // locally duplicated string literals - both are UUID, and both are bound as JDBC parameters
+  // against uuid-typed columns (asset_grants.library_id, users.organization_id) via a plain
+  // PreparedStatement, which does not auto-cast a text/varchar parameter to uuid the way an
+  // inline SQL literal would. A local String constant here surfaced as a BadSqlGrammarException
+  // ("operator does not exist: uuid = text") the moment this test actually executed (#309 code
+  // review round 4: it never had, because this whole class is gated behind OPAA_OPENAI_API_KEY
+  // and was never run after being adapted to the asset-grants model in #305/#309).
+  private static final UUID SEEDED_ORGANIZATION_ID = Organization.DEFAULT_ID;
+  private static final UUID SYSTEM_LIBRARY_ID = KnowledgeLibrary.SYSTEM_LIBRARY_ID;
 
   @Autowired private DocumentIndexingService documentIndexingService;
   @Autowired private QueryService queryService;

--- a/backend/src/test/java/io/opaa/integration/OpenAiIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/integration/OpenAiIntegrationTest.java
@@ -9,6 +9,7 @@ import io.opaa.query.QueryService;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -49,17 +50,45 @@ class OpenAiIntegrationTest {
     registry.add("opaa.indexing.retry-attempts", () -> 1);
   }
 
+  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+  private static final String SYSTEM_LIBRARY_ID = "00000000-0000-0000-0000-000000000002";
+
   @Autowired private DocumentIndexingService documentIndexingService;
   @Autowired private QueryService queryService;
   @Autowired private DocumentRepository documentRepository;
   @Autowired private IndexingJobRepository indexingJobRepository;
   @Autowired private JdbcTemplate jdbcTemplate;
 
+  private UUID userId;
+
   @BeforeEach
   void setUp() throws IOException {
     jdbcTemplate.execute("TRUNCATE TABLE vector_store");
     documentRepository.deleteAll();
     indexingJobRepository.deleteAll();
+    jdbcTemplate.update("DELETE FROM asset_grants WHERE library_id = ?", SYSTEM_LIBRARY_ID);
+    jdbcTemplate.update("DELETE FROM users WHERE email = 'openai-it@example.com'");
+    userId = UUID.randomUUID();
+    jdbcTemplate.update(
+        "INSERT INTO users (id, subject, issuer, email, display_name, created_at, system_role,"
+            + " organization_id) VALUES (?, ?, 'test-issuer', 'openai-it@example.com',"
+            + " 'OpenAI IT User', now(), 'SYSTEM_ADMIN', ?)",
+        userId,
+        "openai-it-" + userId,
+        SEEDED_ORGANIZATION_ID);
+    // Manual indexing (via FileProcessingService) still files documents into the system library
+    // until #207 wires connector sources to a chosen library - see the note in
+    // docs/features/spaces-and-assets.md. This test's user needs an explicit grant to find them,
+    // exactly like every other reader now does (#202: search never bypasses grants, not even for
+    // a system admin).
+    jdbcTemplate.update(
+        "INSERT INTO asset_grants (id, library_id, organization_id, subject_type,"
+            + " subject_user_id, role, created_at, updated_at) VALUES (?, ?, ?, 'USER', ?,"
+            + " 'OWNER', now(), now())",
+        UUID.randomUUID(),
+        SYSTEM_LIBRARY_ID,
+        SEEDED_ORGANIZATION_ID,
+        userId);
     if (Files.exists(tempDir)) {
       try (var files = Files.list(tempDir)) {
         files.forEach(
@@ -98,7 +127,7 @@ class OpenAiIntegrationTest {
     assertThat(job.getDocumentsProcessed()).isEqualTo(1);
 
     // Query with a question about the indexed document
-    QueryResponse response = queryService.query("What does OPAA stand for?", null);
+    QueryResponse response = queryService.query("What does OPAA stand for?", null, userId);
 
     assertThat(response.getAnswer()).isNotBlank();
     assertThat(response.getAnswer().toLowerCase()).contains("open project ai assistant");

--- a/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
@@ -1,0 +1,204 @@
+package io.opaa.library;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opaa.api.dto.AssetGrantRequest;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
+import io.opaa.group.Group;
+import io.opaa.group.GroupKind;
+import io.opaa.group.GroupRepository;
+import io.opaa.group.PermissionSubjectType;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class AssetGrantServiceTest {
+
+  private AssetGrantRepository grantRepository;
+  private KnowledgeLibraryRepository libraryRepository;
+  private UserRepository userRepository;
+  private GroupRepository groupRepository;
+  private LibraryAccessService accessService;
+  private AssetGrantService grantService;
+
+  private final UUID organizationId = UUID.randomUUID();
+  private final UUID managerId = UUID.randomUUID();
+  private UUID libraryId;
+  private KnowledgeLibrary library;
+
+  @BeforeEach
+  void setUp() {
+    grantRepository = mock(AssetGrantRepository.class);
+    libraryRepository = mock(KnowledgeLibraryRepository.class);
+    userRepository = mock(UserRepository.class);
+    groupRepository = mock(GroupRepository.class);
+    accessService = mock(LibraryAccessService.class);
+    grantService =
+        new AssetGrantService(
+            grantRepository, libraryRepository, userRepository, groupRepository, accessService);
+
+    // KnowledgeLibrary.ownedByUser always assigns its own random id (like every other factory
+    // method on that entity) - libraryId is read back from the constructed instance rather than
+    // generated independently, so every stub keyed on "this library's id" below actually matches
+    // what AssetGrantService reads via library.getId().
+    library =
+        KnowledgeLibrary.ownedByUser(
+            organizationId, "Bibliothek", null, managerId, LibraryVisibility.PRIVATE, false, false);
+    libraryId = library.getId();
+    when(libraryRepository.findById(libraryId)).thenReturn(Optional.of(library));
+
+    User manager = new User("manager", "issuer", "manager@example.com", "Manager");
+    manager.setOrganizationId(organizationId);
+    when(userRepository.findById(managerId)).thenReturn(Optional.of(manager));
+  }
+
+  @Test
+  void upsertGrantRejectsACallerWithoutManagerRole() {
+    when(accessService.canManage(any(), any(), anyBoolean())).thenReturn(false);
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, UUID.randomUUID(), AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantCreatesADirectUserGrantAndInvalidatesTheLibraryCache() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID subjectId = UUID.randomUUID();
+    User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
+    subjectUser.setOrganizationId(organizationId);
+    when(userRepository.findById(subjectId)).thenReturn(Optional.of(subjectUser));
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, subjectId))
+        .thenReturn(Optional.empty());
+    when(grantRepository.save(any(AssetGrant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.VIEWER);
+    var response = grantService.upsertGrant(libraryId, request, managerId, false);
+
+    assertThat(response.getSubjectId()).isEqualTo(subjectId);
+    assertThat(response.getRole()).isEqualTo(AssetRole.VIEWER);
+    // No active transaction synchronization in this unit test, so invalidation runs immediately -
+    // see AssetGrantService#invalidateAfterCommit's fallback branch.
+    verify(accessService).invalidateLibrary(libraryId);
+  }
+
+  @Test
+  void upsertGrantRejectsASubjectUserFromAnotherOrganizationAsNotFound() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID foreignUserId = UUID.randomUUID();
+    User foreignUser = new User("foreign", "issuer", "foreign@example.com", "Foreign");
+    foreignUser.setOrganizationId(UUID.randomUUID());
+    when(userRepository.findById(foreignUserId)).thenReturn(Optional.of(foreignUser));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, foreignUserId, AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void upsertGrantRejectsASubjectGroupFromAnotherOrganizationAsNotFound() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID foreignGroupId = UUID.randomUUID();
+    Group foreignGroup = new Group(UUID.randomUUID(), GroupKind.AD_HOC, "Fremd", null, null, null);
+    when(groupRepository.findById(foreignGroupId)).thenReturn(Optional.of(foreignGroup));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.GROUP, foreignGroupId, AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void upsertGrantUpdatesAnExistingGrantsRoleInsteadOfCreatingADuplicate() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID subjectId = UUID.randomUUID();
+    User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
+    subjectUser.setOrganizationId(organizationId);
+    when(userRepository.findById(subjectId)).thenReturn(Optional.of(subjectUser));
+    AssetGrant existing =
+        AssetGrant.forUser(libraryId, organizationId, subjectId, AssetRole.VIEWER, null, managerId);
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, subjectId))
+        .thenReturn(Optional.of(existing));
+    when(grantRepository.save(any(AssetGrant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.MANAGER);
+    var response = grantService.upsertGrant(libraryId, request, managerId, false);
+
+    assertThat(response.getRole()).isEqualTo(AssetRole.MANAGER);
+    verify(grantRepository, never()).save(argThat((AssetGrant g) -> g != existing));
+  }
+
+  @Test
+  void revokeGrantRemovesTheGrantAndInvalidatesTheLibraryCache() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID grantId = UUID.randomUUID();
+    AssetGrant grant =
+        AssetGrant.forUser(
+            libraryId, organizationId, UUID.randomUUID(), AssetRole.VIEWER, null, managerId);
+    when(grantRepository.findById(grantId)).thenReturn(Optional.of(grant));
+
+    grantService.revokeGrant(libraryId, grantId, managerId, false);
+
+    verify(grantRepository).delete(grant);
+    verify(accessService).invalidateLibrary(libraryId);
+  }
+
+  @Test
+  void revokeGrantTreatsAGrantFromAnotherLibraryAsNotFound() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID grantId = UUID.randomUUID();
+    AssetGrant grantOnAnotherLibrary =
+        AssetGrant.forUser(
+            UUID.randomUUID(),
+            organizationId,
+            UUID.randomUUID(),
+            AssetRole.VIEWER,
+            null,
+            managerId);
+    when(grantRepository.findById(grantId)).thenReturn(Optional.of(grantOnAnotherLibrary));
+
+    assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.NOT_FOUND));
+    verify(grantRepository, never()).delete(any());
+  }
+}

--- a/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
@@ -19,7 +19,6 @@ import io.opaa.group.GroupKind;
 import io.opaa.group.GroupRepository;
 import io.opaa.group.PermissionSubjectType;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -323,7 +322,9 @@ class AssetGrantServiceTest {
     when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
             libraryId, PermissionSubjectType.USER, subjectId))
         .thenReturn(Optional.of(onlyOwnerGrant));
-    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+    when(grantRepository.countOtherActiveOwnerGrants(
+            eq(libraryId), eq(onlyOwnerGrant.getId()), any()))
+        .thenReturn(0L);
 
     AssetGrantRequest request =
         new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.VIEWER);
@@ -346,7 +347,9 @@ class AssetGrantServiceTest {
     AssetGrant onlyOwnerGrant =
         AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
     when(grantRepository.findById(grantId)).thenReturn(Optional.of(onlyOwnerGrant));
-    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+    when(grantRepository.countOtherActiveOwnerGrants(
+            eq(libraryId), eq(onlyOwnerGrant.getId()), any()))
+        .thenReturn(0L);
 
     assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
         .isInstanceOf(ResponseStatusException.class)
@@ -365,12 +368,13 @@ class AssetGrantServiceTest {
     UUID grantId = UUID.randomUUID();
     AssetGrant grantToRemove =
         AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
-    AssetGrant otherOwnerGrant =
-        AssetGrant.forUser(
-            libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
     when(grantRepository.findById(grantId)).thenReturn(Optional.of(grantToRemove));
-    when(grantRepository.findByLibraryIdForUpdate(libraryId))
-        .thenReturn(List.of(grantToRemove, otherOwnerGrant));
+    // Keyed on grantToRemove's own id (not the lookup id grantId) - AssetGrantService passes
+    // grant.getId() to the guard, and AssetGrant.forUser mints its own random id independent of
+    // grantId.
+    when(grantRepository.countOtherActiveOwnerGrants(
+            eq(libraryId), eq(grantToRemove.getId()), any()))
+        .thenReturn(1L);
 
     grantService.revokeGrant(libraryId, grantId, managerId, false);
 
@@ -392,16 +396,14 @@ class AssetGrantServiceTest {
     AssetGrant ownerGrantToRemove =
         AssetGrant.forUser(
             libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
-    AssetGrant anotherActiveOwnerGrant =
-        AssetGrant.forUser(
-            libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
     when(grantRepository.findById(grantId)).thenReturn(Optional.of(ownerGrantToRemove));
     // Deliberately stubbed even though the test asserts it is never called: proves the rejection
-    // below is not an accidental side effect of an empty/unstubbed grant list making the
-    // last-active-OWNER guard fire for the wrong reason - a second active OWNER grant genuinely
+    // below is not an accidental side effect of an unstubbed count defaulting to 0 and the
+    // last-active-OWNER guard firing for the wrong reason - a second active OWNER grant genuinely
     // exists, so that guard alone would allow the removal.
-    when(grantRepository.findByLibraryIdForUpdate(libraryId))
-        .thenReturn(List.of(ownerGrantToRemove, anotherActiveOwnerGrant));
+    when(grantRepository.countOtherActiveOwnerGrants(
+            eq(libraryId), eq(ownerGrantToRemove.getId()), any()))
+        .thenReturn(1L);
 
     assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
         .isInstanceOf(ResponseStatusException.class)
@@ -413,7 +415,7 @@ class AssetGrantServiceTest {
     // The role-escalation guard must short-circuit before the last-active-OWNER count is even
     // read - a MANAGER is refused for the more fundamental reason regardless of how many other
     // OWNER grants exist.
-    verify(grantRepository, never()).findByLibraryIdForUpdate(any());
+    verify(grantRepository, never()).countOtherActiveOwnerGrants(any(), any(), any());
   }
 
   @Test
@@ -460,7 +462,9 @@ class AssetGrantServiceTest {
     when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
             libraryId, PermissionSubjectType.USER, managerId))
         .thenReturn(Optional.of(onlyOwnerGrant));
-    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+    when(grantRepository.countOtherActiveOwnerGrants(
+            eq(libraryId), eq(onlyOwnerGrant.getId()), any()))
+        .thenReturn(0L);
 
     AssetGrantRequest request =
         new AssetGrantRequest(PermissionSubjectType.USER, managerId, AssetRole.OWNER)
@@ -495,6 +499,6 @@ class AssetGrantServiceTest {
     var response = grantService.upsertGrant(libraryId, request, managerId, false);
 
     assertThat(response.getRole()).isEqualTo(AssetRole.OWNER);
-    verify(grantRepository, never()).findByLibraryIdForUpdate(any());
+    verify(grantRepository, never()).countOtherActiveOwnerGrants(any(), any(), any());
   }
 }

--- a/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
@@ -323,7 +323,7 @@ class AssetGrantServiceTest {
     when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
             libraryId, PermissionSubjectType.USER, subjectId))
         .thenReturn(Optional.of(onlyOwnerGrant));
-    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
 
     AssetGrantRequest request =
         new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.VIEWER);
@@ -340,11 +340,13 @@ class AssetGrantServiceTest {
   @Test
   void revokeGrantRejectsRemovingTheLastActiveOwnerGrant() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID grantId = UUID.randomUUID();
     AssetGrant onlyOwnerGrant =
         AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
     when(grantRepository.findById(grantId)).thenReturn(Optional.of(onlyOwnerGrant));
-    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
 
     assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
         .isInstanceOf(ResponseStatusException.class)
@@ -358,6 +360,8 @@ class AssetGrantServiceTest {
   @Test
   void revokeGrantAllowsRemovingAnOwnerGrantWhenAnotherActiveOwnerGrantRemains() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID grantId = UUID.randomUUID();
     AssetGrant grantToRemove =
         AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
@@ -365,11 +369,132 @@ class AssetGrantServiceTest {
         AssetGrant.forUser(
             libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
     when(grantRepository.findById(grantId)).thenReturn(Optional.of(grantToRemove));
-    when(grantRepository.findByLibraryId(libraryId))
+    when(grantRepository.findByLibraryIdForUpdate(libraryId))
         .thenReturn(List.of(grantToRemove, otherOwnerGrant));
 
     grantService.revokeGrant(libraryId, grantId, managerId, false);
 
     verify(grantRepository).delete(grantToRemove);
+  }
+
+  @Test
+  void revokeGrantRejectsRemovingAGrantWithARoleHigherThanTheCallersOwnRoleEvenIfNotTheLastOwner() {
+    // #202 code review round 2 (Befund 1): the escalation guard on the *existing* grant's role
+    // must fire independently of the last-active-OWNER guard, before it - even when another active
+    // OWNER grant remains (so the last-owner guard alone would allow the removal), a caller who
+    // only holds MANAGER may still never remove a grant that already carries OWNER. Previously
+    // revokeGrant never called effectiveRole at all, so this scenario passed with a 200 instead of
+    // this 403.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.MANAGER);
+    UUID grantId = UUID.randomUUID();
+    AssetGrant ownerGrantToRemove =
+        AssetGrant.forUser(
+            libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
+    AssetGrant anotherActiveOwnerGrant =
+        AssetGrant.forUser(
+            libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
+    when(grantRepository.findById(grantId)).thenReturn(Optional.of(ownerGrantToRemove));
+    // Deliberately stubbed even though the test asserts it is never called: proves the rejection
+    // below is not an accidental side effect of an empty/unstubbed grant list making the
+    // last-active-OWNER guard fire for the wrong reason - a second active OWNER grant genuinely
+    // exists, so that guard alone would allow the removal.
+    when(grantRepository.findByLibraryIdForUpdate(libraryId))
+        .thenReturn(List.of(ownerGrantToRemove, anotherActiveOwnerGrant));
+
+    assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+    verify(grantRepository, never()).delete(any());
+    // The role-escalation guard must short-circuit before the last-active-OWNER count is even
+    // read - a MANAGER is refused for the more fundamental reason regardless of how many other
+    // OWNER grants exist.
+    verify(grantRepository, never()).findByLibraryIdForUpdate(any());
+  }
+
+  @Test
+  void upsertGrantRejectsDowngradingAnExistingGrantWithARoleHigherThanTheCallersOwnRole() {
+    // The update-path counterpart of the revoke test above: a MANAGER downgrading an existing
+    // OWNER grant to something lower is exactly as much an escalation as revoking it outright, and
+    // must be rejected the same way, independent of the last-active-OWNER guard.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.MANAGER);
+    UUID subjectId = UUID.randomUUID();
+    User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
+    subjectUser.setOrganizationId(organizationId);
+    when(userRepository.findById(subjectId)).thenReturn(Optional.of(subjectUser));
+    AssetGrant existingOwnerGrant =
+        AssetGrant.forUser(libraryId, organizationId, subjectId, AssetRole.OWNER, null, managerId);
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, subjectId))
+        .thenReturn(Optional.of(existingOwnerGrant));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantRejectsSettingTheLastActiveOwnerGrantsExpiryIntoThePast() {
+    // #202 code review round 2 (nit 1): "newRole == OWNER is always allowed" was too coarse - an
+    // OWNER renewing their own sole grant with role = OWNER but expiresAt in the past expires it
+    // immediately, leaving the library without any active OWNER. The count the guard protects must
+    // be taken after the intended change, including the new expiresAt, not just the new role.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
+    AssetGrant onlyOwnerGrant =
+        AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, managerId))
+        .thenReturn(Optional.of(onlyOwnerGrant));
+    when(grantRepository.findByLibraryIdForUpdate(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, managerId, AssetRole.OWNER)
+            .expiresAt(Instant.now().minusSeconds(60));
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantAllowsRenewingTheLastActiveOwnerGrantWithAFutureOrNoExpiry() {
+    // The positive counterpart of the test above: role = OWNER with either no expiry or a
+    // still-future one genuinely keeps the grant active, so the guard must not fire.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
+    AssetGrant onlyOwnerGrant =
+        AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, managerId))
+        .thenReturn(Optional.of(onlyOwnerGrant));
+    when(grantRepository.save(any(AssetGrant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, managerId, AssetRole.OWNER);
+    var response = grantService.upsertGrant(libraryId, request, managerId, false);
+
+    assertThat(response.getRole()).isEqualTo(AssetRole.OWNER);
+    verify(grantRepository, never()).findByLibraryIdForUpdate(any());
   }
 }

--- a/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/AssetGrantServiceTest.java
@@ -18,6 +18,8 @@ import io.opaa.group.Group;
 import io.opaa.group.GroupKind;
 import io.opaa.group.GroupRepository;
 import io.opaa.group.PermissionSubjectType;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +85,8 @@ class AssetGrantServiceTest {
   @Test
   void upsertGrantCreatesADirectUserGrantAndInvalidatesTheLibraryCache() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID subjectId = UUID.randomUUID();
     User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
     subjectUser.setOrganizationId(organizationId);
@@ -107,6 +111,8 @@ class AssetGrantServiceTest {
   @Test
   void upsertGrantRejectsASubjectUserFromAnotherOrganizationAsNotFound() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID foreignUserId = UUID.randomUUID();
     User foreignUser = new User("foreign", "issuer", "foreign@example.com", "Foreign");
     foreignUser.setOrganizationId(UUID.randomUUID());
@@ -126,6 +132,8 @@ class AssetGrantServiceTest {
   @Test
   void upsertGrantRejectsASubjectGroupFromAnotherOrganizationAsNotFound() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID foreignGroupId = UUID.randomUUID();
     Group foreignGroup = new Group(UUID.randomUUID(), GroupKind.AD_HOC, "Fremd", null, null, null);
     when(groupRepository.findById(foreignGroupId)).thenReturn(Optional.of(foreignGroup));
@@ -144,6 +152,8 @@ class AssetGrantServiceTest {
   @Test
   void upsertGrantUpdatesAnExistingGrantsRoleInsteadOfCreatingADuplicate() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID subjectId = UUID.randomUUID();
     User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
     subjectUser.setOrganizationId(organizationId);
@@ -167,6 +177,8 @@ class AssetGrantServiceTest {
   @Test
   void revokeGrantRemovesTheGrantAndInvalidatesTheLibraryCache() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID grantId = UUID.randomUUID();
     AssetGrant grant =
         AssetGrant.forUser(
@@ -182,6 +194,8 @@ class AssetGrantServiceTest {
   @Test
   void revokeGrantTreatsAGrantFromAnotherLibraryAsNotFound() {
     when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
     UUID grantId = UUID.randomUUID();
     AssetGrant grantOnAnotherLibrary =
         AssetGrant.forUser(
@@ -200,5 +214,162 @@ class AssetGrantServiceTest {
                 assertThat(((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.NOT_FOUND));
     verify(grantRepository, never()).delete(any());
+  }
+
+  @Test
+  void upsertGrantRejectsGrantingARoleHigherThanTheCallersOwnRole() {
+    // #202 code review (blocker 3): being a MANAGER is enough to grant *some* role, not enough to
+    // grant OWNER - only an OWNER may hand out OWNER, or a MANAGER could grant itself OWNER and
+    // then delete the library or transfer ownership, rights the spec reserves for OWNER alone.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.MANAGER);
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, UUID.randomUUID(), AssetRole.OWNER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantAllowsGrantingExactlyTheCallersOwnRole() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.MANAGER);
+    UUID subjectId = UUID.randomUUID();
+    User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
+    subjectUser.setOrganizationId(organizationId);
+    when(userRepository.findById(subjectId)).thenReturn(Optional.of(subjectUser));
+    when(grantRepository.save(any(AssetGrant.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.MANAGER);
+    var response = grantService.upsertGrant(libraryId, request, managerId, false);
+
+    assertThat(response.getRole()).isEqualTo(AssetRole.MANAGER);
+  }
+
+  @Test
+  void upsertGrantRejectsAGrantOnThePersonalLibrary() {
+    KnowledgeLibrary personalLibrary =
+        KnowledgeLibrary.ownedByUser(
+            organizationId,
+            "Meine Dokumente",
+            null,
+            managerId,
+            LibraryVisibility.PRIVATE,
+            false,
+            true);
+    UUID personalLibraryId = personalLibrary.getId();
+    when(libraryRepository.findById(personalLibraryId)).thenReturn(Optional.of(personalLibrary));
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, UUID.randomUUID(), AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(personalLibraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantRejectsTargetingADissolvedGroup() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
+    Group dissolvedGroup =
+        new Group(organizationId, GroupKind.AD_HOC, "Aufgeloest", null, null, null);
+    dissolvedGroup.dissolve(Instant.now());
+    when(groupRepository.findById(dissolvedGroup.getId())).thenReturn(Optional.of(dissolvedGroup));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(
+            PermissionSubjectType.GROUP, dissolvedGroup.getId(), AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void upsertGrantRejectsDowngradingTheLastActiveOwnerGrant() {
+    // #202 code review (blocker 3, extended to the update path): downgrading the sole active
+    // OWNER grant is exactly as dangerous as revoking it outright - both leave nobody able to
+    // manage the library.
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    when(accessService.effectiveRole(any(), eq(managerId), anyBoolean()))
+        .thenReturn(AssetRole.OWNER);
+    UUID subjectId = UUID.randomUUID();
+    User subjectUser = new User("subject", "issuer", "subject@example.com", "Subject");
+    subjectUser.setOrganizationId(organizationId);
+    when(userRepository.findById(subjectId)).thenReturn(Optional.of(subjectUser));
+    AssetGrant onlyOwnerGrant =
+        AssetGrant.forUser(libraryId, organizationId, subjectId, AssetRole.OWNER, null, managerId);
+    when(grantRepository.findByLibraryIdAndSubjectTypeAndSubjectUserId(
+            libraryId, PermissionSubjectType.USER, subjectId))
+        .thenReturn(Optional.of(onlyOwnerGrant));
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+
+    AssetGrantRequest request =
+        new AssetGrantRequest(PermissionSubjectType.USER, subjectId, AssetRole.VIEWER);
+
+    assertThatThrownBy(() -> grantService.upsertGrant(libraryId, request, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    verify(grantRepository, never()).save(any());
+  }
+
+  @Test
+  void revokeGrantRejectsRemovingTheLastActiveOwnerGrant() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID grantId = UUID.randomUUID();
+    AssetGrant onlyOwnerGrant =
+        AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
+    when(grantRepository.findById(grantId)).thenReturn(Optional.of(onlyOwnerGrant));
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(onlyOwnerGrant));
+
+    assertThatThrownBy(() -> grantService.revokeGrant(libraryId, grantId, managerId, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT));
+    verify(grantRepository, never()).delete(any());
+  }
+
+  @Test
+  void revokeGrantAllowsRemovingAnOwnerGrantWhenAnotherActiveOwnerGrantRemains() {
+    when(accessService.canManage(any(), eq(managerId), anyBoolean())).thenReturn(true);
+    UUID grantId = UUID.randomUUID();
+    AssetGrant grantToRemove =
+        AssetGrant.forUser(libraryId, organizationId, managerId, AssetRole.OWNER, null, managerId);
+    AssetGrant otherOwnerGrant =
+        AssetGrant.forUser(
+            libraryId, organizationId, UUID.randomUUID(), AssetRole.OWNER, null, managerId);
+    when(grantRepository.findById(grantId)).thenReturn(Optional.of(grantToRemove));
+    when(grantRepository.findByLibraryId(libraryId))
+        .thenReturn(List.of(grantToRemove, otherOwnerGrant));
+
+    grantService.revokeGrant(libraryId, grantId, managerId, false);
+
+    verify(grantRepository).delete(grantToRemove);
   }
 }

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opaa.TestcontainersConfiguration;
+import io.opaa.api.dto.AssetGrantRequest;
 import io.opaa.api.dto.LibraryRequest;
 import io.opaa.api.dto.LibraryResponse;
 import io.opaa.api.dto.LibraryUpdateRequest;
@@ -15,6 +16,7 @@ import io.opaa.group.GroupMembership;
 import io.opaa.group.GroupMembershipResolver;
 import io.opaa.group.GroupRepository;
 import io.opaa.group.GroupService;
+import io.opaa.group.PermissionSubjectType;
 import io.opaa.indexing.Document;
 import io.opaa.indexing.DocumentRepository;
 import io.opaa.organization.Organization;
@@ -45,11 +47,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * fk_knowledge_libraries_owner_user} and {@code fk_knowledge_libraries_owner_group_organization}
  * (migration 012) are real foreign keys enforced by Liquibase, not by Hibernate's entity mapping.
  *
- * <p>{@link #groupOwnedLibraryIsVisibleToGroupMembersButNotToTheCallerAfterLeavingTheGroup()} is
- * the mechanism-interaction test: it exercises group ownership together with {@link
- * GroupMembershipResolver}'s cache invalidation, not either in isolation - a regression that reads
- * group membership correctly but forgets to invalidate the cache after a membership change would
- * still pass a test that only checks membership once.
+ * <p>{@link
+ * #grantingTheOwningGroupAViewerRoleReachesItsMembersAndRevocationTakesEffectImmediately()} and
+ * {@link #revokingAGrantTakesEffectOnTheNextCall()} are the mechanism-interaction tests (#202):
+ * they exercise a group grant together with {@link GroupMembershipResolver}'s cache invalidation,
+ * and a direct grant together with {@code LibraryAccessService}'s own per-library grant cache, not
+ * either mechanism in isolation - a regression that reads membership or a grant correctly but
+ * forgets to invalidate the relevant cache would still pass a test that only checks access once.
+ * {@link #creatingAGroupOwnedLibraryDoesNotAutomaticallyGrantOtherGroupMembersAnyAccess()} is the
+ * regression guard for the #201 behaviour #202 replaced: mere membership in the owning group used
+ * to imply full management rights with no human decision point.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -61,6 +68,9 @@ class KnowledgeLibraryServiceIntegrationTest {
 
   @Autowired private KnowledgeLibraryService libraryService;
   @Autowired private KnowledgeLibraryRepository libraryRepository;
+  @Autowired private AssetGrantRepository grantRepository;
+  @Autowired private AssetGrantService grantService;
+  @Autowired private LibraryAccessService accessService;
   @Autowired private GroupService groupService;
   @Autowired private GroupRepository groupRepository;
   @Autowired private UserRepository userRepository;
@@ -367,37 +377,143 @@ class KnowledgeLibraryServiceIntegrationTest {
   }
 
   @Test
-  void groupOwnedLibraryIsVisibleToGroupMembersButNotToTheCallerAfterLeavingTheGroup() {
-    UUID member = createUser(organizationA);
-    Group group = createGroup(organizationA, member);
+  void creatingAGroupOwnedLibraryDoesNotAutomaticallyGrantOtherGroupMembersAnyAccess() {
+    // #202 code review of #201/#305: the coarse #201 canRead/canManage let every member of a
+    // group-owned library read and manage it, growing without a human decision point as a
+    // directory-synchronised group's membership grows. LibraryAccessService replaces that: only
+    // the creator (via the explicit OWNER grant KnowledgeLibraryService#createLibrary makes) has
+    // any access at all until a MANAGER explicitly grants the group (or another user) a role.
+    UUID creator = createUser(organizationA);
+    UUID otherMember = createUser(organizationA);
+    Group group = createGroup(organizationA, creator, otherMember);
     LibraryResponse library =
         libraryService.createLibrary(
             new LibraryRequest("Rechtsquellen Soziales")
                 .ownerType(LibraryOwnerType.GROUP)
                 .ownerId(group.getId()),
-            member);
+            creator);
 
-    // Membership grants access.
-    LibraryResponse read = libraryService.getLibrary(library.getId(), member, false);
+    // The creator has access (their explicit OWNER grant), a plain group member does not.
+    LibraryResponse read = libraryService.getLibrary(library.getId(), creator, false);
     assertThat(read.getId()).isEqualTo(library.getId());
 
-    // Removing the membership through the real GroupService (not a raw repository update) is the
-    // point of this test: GroupService#removeMember evicts GroupMembershipResolver's per-user
-    // cache entry after its own transaction commits (see GroupService#invalidateAfterCommit).
-    // KnowledgeLibraryService reads group membership exclusively through that same resolver
-    // (isOwnerOrGroupMember -> GroupMembershipResolver#groupIdsForUser), so this proves the two
-    // classes are wired to the same cache instance and that the eviction actually reaches it - a
-    // raw repository update bypassing GroupService would leave the resolver's cache stale and
-    // make this assertion pass for the wrong reason (a cache that was never populated) or fail
-    // where it should not.
-    groupService.removeMember(group.getId(), member, member);
-
-    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), member, false))
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), otherMember, false))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex ->
                 assertThat(((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.FORBIDDEN));
+    assertThatThrownBy(
+            () ->
+                libraryService.updateLibrary(
+                    library.getId(), new LibraryUpdateRequest("Umbenannt"), otherMember, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void grantingTheOwningGroupAViewerRoleReachesItsMembersAndRevocationTakesEffectImmediately() {
+    UUID creator = createUser(organizationA);
+    UUID otherMember = createUser(organizationA);
+    Group group = createGroup(organizationA, creator, otherMember);
+    LibraryResponse library =
+        libraryService.createLibrary(
+            new LibraryRequest("Rechtsquellen Soziales")
+                .ownerType(LibraryOwnerType.GROUP)
+                .ownerId(group.getId()),
+            creator);
+
+    // The creator (MANAGER via their OWNER grant) explicitly grants the whole group VIEWER - the
+    // human decision point the coarse #201 model was missing.
+    grantService.upsertGrant(
+        library.getId(),
+        new AssetGrantRequest(PermissionSubjectType.GROUP, group.getId(), AssetRole.VIEWER),
+        creator,
+        false);
+
+    LibraryResponse read = libraryService.getLibrary(library.getId(), otherMember, false);
+    assertThat(read.getId()).isEqualTo(library.getId());
+
+    // Removing the membership through the real GroupService (not a raw repository update) is the
+    // point of this test: GroupService#removeMember evicts GroupMembershipResolver's per-user
+    // cache entry after its own transaction commits (see GroupService#invalidateAfterCommit).
+    // LibraryAccessService reads group membership exclusively through that same resolver, so this
+    // proves the two classes are wired to the same cache instance and that the eviction actually
+    // reaches it - a raw repository update bypassing GroupService would leave the resolver's
+    // cache stale and make this assertion pass for the wrong reason (a cache that was never
+    // populated) or fail where it should not.
+    groupService.removeMember(group.getId(), otherMember, creator);
+
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), otherMember, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void revokingAGrantTakesEffectOnTheNextCall() {
+    // #202 acceptance criteria: "Revoking a grant takes effect on the next query." Exercises
+    // LibraryAccessService's per-library grant cache and AssetGrantService's afterCompletion
+    // invalidation together, not either in isolation.
+    UUID owner = createUser(organizationA);
+    UUID viewer = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), owner);
+
+    var grant =
+        grantService.upsertGrant(
+            library.getId(),
+            new AssetGrantRequest(PermissionSubjectType.USER, viewer, AssetRole.VIEWER),
+            owner,
+            false);
+    assertThat(libraryService.getLibrary(library.getId(), viewer, false).getId())
+        .isEqualTo(library.getId());
+
+    grantService.revokeGrant(library.getId(), grant.getId(), owner, false);
+
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), viewer, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void readableLibraryIdsResolvesWellWithinTheHundredMillisecondBudgetOnARealDatabase() {
+    // #202 asks that permission resolution add "less than 50ms" to query time; that specific
+    // number could not be assessed as a load-tested SLO in this PR (see the PR description for
+    // why). What this test does establish, against the real Postgres schema this codebase now
+    // ships, not a mock: LibraryAccessService#readableLibraryIds - the method QueryService calls
+    // on every query - resolves via a small number of indexed queries (group membership, cached
+    // after the first call per GroupMembershipResolver; two asset_grants queries; one
+    // organization-wide-visibility query), not a full scan or anything that grows with unrelated
+    // data. A generous 100ms bound (double the target, on a Testcontainers-backed single query
+    // measured by wall clock, not warmed up or repeated) catches a gross regression - an
+    // accidental N+1 or a missing index - without being a flaky micro-benchmark.
+    UUID owner = createUser(organizationA);
+    UUID reader = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), owner);
+    grantService.upsertGrant(
+        library.getId(),
+        new AssetGrantRequest(PermissionSubjectType.USER, reader, AssetRole.USER),
+        owner,
+        false);
+
+    long startNanos = System.nanoTime();
+    var readable = accessService.readableLibraryIds(reader, organizationA);
+    long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+
+    assertThat(readable).contains(library.getId());
+    assertThat(elapsedMillis)
+        .as("readableLibraryIds took %dms against a real Postgres schema", elapsedMillis)
+        .isLessThan(100);
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -471,10 +471,50 @@ class KnowledgeLibraryServiceIntegrationTest {
   }
 
   @Test
+  void aGroupMemberHoldingOnlyManagerCannotDeleteTheLibraryEvenThoughItCanManageIt() {
+    // #202 code review round 3 (Blocker 1): AssetRole reserves "delete the asset and transfer
+    // ownership" for OWNER alone - deleteLibrary must gate on that, not on canManage (MANAGER).
+    // Before this fix, otherMember - holding only the group's MANAGER grant, never able to touch
+    // the creator's OWNER grant directly (see the escalation guard exercised above) - could still
+    // delete the whole library outright, taking every grant on it down with it via
+    // fk_asset_grants_library_organization's ON DELETE CASCADE (migration 013): a detour all the
+    // way around the round-1/round-2 escalation guards instead of being stopped by them. This is
+    // strictly worse for a migrated, backfilled group-owned library, which deliberately carries no
+    // OWNER grant at all (013-asset-grants.yaml's backfill comment) - there, every member could
+    // delete a library nobody could even downgrade the group's grant on.
+    UUID creator = createUser(organizationA);
+    UUID otherMember = createUser(organizationA);
+    Group group = createGroup(organizationA, creator, otherMember);
+    LibraryResponse library =
+        libraryService.createLibrary(
+            new LibraryRequest("Rechtsquellen Soziales")
+                .ownerType(LibraryOwnerType.GROUP)
+                .ownerId(group.getId()),
+            creator);
+
+    // otherMember can still manage (rename, change visibility) via the group's MANAGER grant...
+    libraryService.updateLibrary(
+        library.getId(), new LibraryUpdateRequest("Umbenannt von otherMember"), otherMember, false);
+    // ...but cannot delete: that requires OWNER, which only the creator personally holds.
+    assertThatThrownBy(() -> libraryService.deleteLibrary(library.getId(), otherMember, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+    assertThat(libraryRepository.findById(library.getId())).isPresent();
+
+    // The creator, holding OWNER, can delete it.
+    libraryService.deleteLibrary(library.getId(), creator, false);
+    assertThat(libraryRepository.findById(library.getId())).isEmpty();
+  }
+
+  @Test
   void aGroupGrantOnAPersonallyOwnedLibraryReachesItsMembersAndRevocationTakesEffectImmediately() {
     // The group-grant counterpart of revokingAGrantTakesEffectOnTheNextCall, using a plain
     // USER-owned library (not the owning group itself, to keep this test independent of
-    // creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider's concern):
+    // creatingAGroupOwnedLibraryGrantsManagerToTheGroupAndOwnerToTheCreatorButNoOutsider's
+    // concern):
     // an explicit grant to an ordinary AD_HOC group reaches its current members exactly like a
     // direct grant would, and losing membership removes access on the next call.
     UUID owner = createUser(organizationA);
@@ -545,12 +585,19 @@ class KnowledgeLibraryServiceIntegrationTest {
     // #202 code review round 2, nit 2: isLastActiveOwnerGrant is a read-then-decide check with no
     // locking of its own. Two OWNER grants, two threads each revoking one at (as close to)
     // literally the same instant as CyclicBarrier can arrange, against the real Postgres schema
-    // (not a mock - a mocked PlatformTransactionManager would not exercise the row lock
-    // AssetGrantRepository#findByLibraryIdForUpdate takes, per this project's rule for
-    // concurrency-sensitive invariants). Without that lock, both threads could read the other's
-    // grant as still active and both would proceed, leaving zero active OWNER grants - exactly the
-    // state the guard exists to prevent. With it, exactly one thread must see a 409 and the
-    // library must retain exactly one active OWNER grant afterwards, never zero.
+    // (not a mock - a mocked PlatformTransactionManager would not exercise
+    // AssetGrantRepository#lockLibraryGrantsForMutation's real advisory lock, per this project's
+    // rule for concurrency-sensitive invariants). Without that lock, both threads could read the
+    // other's grant as still active and both would proceed, leaving zero active OWNER grants -
+    // exactly the state the guard exists to prevent. With it, exactly one thread must see a 409
+    // and the library must retain exactly one active OWNER grant afterwards, never zero.
+    //
+    // This test alone cannot catch a guard that serializes correctly but decides on stale data
+    // (#202 code review round 3, blocker 2): a deleted row simply disappears from any subsequent
+    // read, so a revoke-vs-revoke race can never observe staleness. See
+    // #concurrentDowngradeAndRevocationOfTwoOwnerGrantsNeverLeavesTheLibraryWithoutAnActiveOwner
+    // below, which pairs a downgrade with a revoke - an *updated*, not deleted, row - and is the
+    // scenario that actually exposed the round-2 fix's remaining staleness bug.
     UUID firstOwner = createUser(organizationA);
     UUID secondOwner = createUser(organizationA);
     LibraryResponse library =
@@ -622,6 +669,93 @@ class KnowledgeLibraryServiceIntegrationTest {
         return e;
       }
     };
+  }
+
+  @Test
+  void concurrentDowngradeAndRevocationOfTwoOwnerGrantsNeverLeavesTheLibraryWithoutAnActiveOwner()
+      throws Exception {
+    // #202 code review round 3, blocker 2: two earlier versions of this guard both failed this
+    // exact scenario, for two different reasons, both only visible with a real downgrade racing a
+    // real revoke - a revoke-vs-revoke race (the test above) cannot expose either, because a
+    // deleted row simply disappears from any subsequent read, stale or not:
+    //  1. Locking the grant rows with SELECT ... FOR UPDATE and mapping the result back to
+    //     AssetGrant entities decided on a stale, already-loaded managed instance for the count,
+    //     because requireManageable -> effectiveRole had already loaded the same rows into this
+    //     transaction's persistence context beforehand (via LibraryAccessService's own
+    //     findByLibraryId) - fixed by counting via a plain scalar aggregate query instead, which
+    // has
+    //     no entity identity to resolve against the persistence context.
+    //  2. That scalar aggregate, still built on SELECT ... FOR UPDATE over every grant row of the
+    //     library, then deadlocked under real concurrency even with a deterministic ORDER BY id on
+    //     the locking query - fixed by replacing the row lock with a single per-library Postgres
+    //     advisory lock (AssetGrantRepository#lockLibraryGrantsForMutation) acquired before the
+    //     plain count, removing the multi-row lock-ordering question entirely.
+    UUID firstOwner = createUser(organizationA);
+    UUID secondOwner = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), firstOwner);
+    AssetGrant firstOwnerGrant =
+        grantRepository.findByLibraryId(library.getId()).stream()
+            .filter(g -> firstOwner.equals(g.getSubjectUserId()))
+            .findFirst()
+            .orElseThrow();
+    var secondOwnerGrant =
+        grantService.upsertGrant(
+            library.getId(),
+            new AssetGrantRequest(PermissionSubjectType.USER, secondOwner, AssetRole.OWNER),
+            firstOwner,
+            false);
+
+    var barrier = new CyclicBarrier(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Callable<Exception> downgradeFirstOwner =
+          () -> {
+            barrier.await();
+            try {
+              grantService.upsertGrant(
+                  library.getId(),
+                  new AssetGrantRequest(PermissionSubjectType.USER, firstOwner, AssetRole.VIEWER),
+                  firstOwner,
+                  false);
+              return null;
+            } catch (ResponseStatusException e) {
+              return e;
+            }
+          };
+      Callable<Exception> revokeSecondOwner =
+          revokeAfterBarrier(barrier, library.getId(), secondOwnerGrant.getId(), secondOwner);
+
+      List<Future<Exception>> results =
+          executor.invokeAll(List.of(downgradeFirstOwner, revokeSecondOwner));
+
+      long conflicts = 0;
+      long successes = 0;
+      for (var result : results) {
+        Exception outcome = result.get();
+        if (outcome == null) {
+          successes++;
+        } else if (outcome instanceof ResponseStatusException rse
+            && rse.getStatusCode() == HttpStatus.CONFLICT) {
+          conflicts++;
+        } else {
+          throw new AssertionError("Unexpected outcome", outcome);
+        }
+      }
+
+      assertThat(successes).as("exactly one of downgrade/revoke must succeed").isEqualTo(1);
+      assertThat(conflicts).as("the other must be rejected as the last active owner").isEqualTo(1);
+      List<AssetGrant> remainingGrants = grantRepository.findByLibraryId(library.getId());
+      long activeOwnerCount =
+          remainingGrants.stream()
+              .filter(g -> g.getRole() == AssetRole.OWNER && !g.isExpired(Instant.now()))
+              .count();
+      assertThat(activeOwnerCount)
+          .as("the library must retain exactly one active owner")
+          .isEqualTo(1);
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -25,9 +25,15 @@ import io.opaa.organization.OrganizationRepository;
 import io.opaa.space.SpaceKind;
 import io.opaa.space.SpaceRepository;
 import io.opaa.space.SpaceService;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,9 +64,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * and a direct grant together with {@code LibraryAccessService}'s own per-library grant cache, not
  * either mechanism in isolation - a regression that reads membership or a grant correctly but
  * forgets to invalidate the relevant cache would still pass a test that only checks access once.
- * {@link #creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider()} is the
- * regression guard for the #201 behaviour #202 replaced - see its own Javadoc for why granting
- * OWNER to the group is the fix, not a reappearance of the #201 bug.
+ * {@link #creatingAGroupOwnedLibraryGrantsManagerToTheGroupAndOwnerToTheCreatorButNoOutsider()} is
+ * the regression guard for the #201 behaviour #202 replaced - see its own Javadoc for why the group
+ * gets MANAGER (not OWNER, which round 1 of the #202 review tried and round 2 reverted) and the
+ * creator personally gets OWNER.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -388,21 +395,28 @@ class KnowledgeLibraryServiceIntegrationTest {
   }
 
   @Test
-  void creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider() {
-    // #202 code review (blocker 4): granting OWNER to the *creator personally* on a GROUP-owned
-    // library was wrong - it left the library owned by an individual in every way that matters
-    // (the migration 013 backfill grants the *group* OWNER for pre-existing libraries, and a
-    // freshly created one must follow the same rule, or the feature spec's leitbeispiel
-    // "Rechtsquellen Soziales" - owner the group "Referat 50 * Grundsatz" - hangs on a grant to
-    // whichever person happened to click "create" the moment they leave). Granting OWNER to the
-    // group instead is not the #201 bug reappearing: unlike the coarse #201 canManage (which
-    // derived rights structurally from the owner columns, with no possible distinction, no
-    // revocation short of deleting the library, and no audit trail), this is one explicit,
-    // revocable AssetGrant row - a MANAGER can downgrade or revoke it at any time via the grant
-    // API, exactly the human decision point #201 lacked. An outsider - not a member of the
-    // owning group at all - still has no access whatsoever, which is the actual invariant #201
-    // broke (mere existence of *a* group somewhere never implies access; only membership in the
-    // group an explicit grant targets does).
+  void creatingAGroupOwnedLibraryGrantsManagerToTheGroupAndOwnerToTheCreatorButNoOutsider() {
+    // #202 code review, two rounds. Round 1 corrected the original bug: granting OWNER to the
+    // *creator personally* on a GROUP-owned library left the library owned by an individual in
+    // every way that matters, so round 1 moved OWNER onto the group instead. Measurement in round
+    // 2 (Befund 2) showed that went a step too far: every current *and future* member of the
+    // owning group automatically became OWNER - able to delete the library and transfer ownership
+    // - growing without a human decision point as a directory-synchronised group's membership
+    // grows (#237), structurally the same defect #201 had, one level up. It was also not
+    // demotable: being the library's only OWNER grant, both the escalation guard
+    // (AssetGrantService#requireCallerCanTouchExistingGrant, once it existed) and the
+    // last-active-OWNER guard permanently protected it - measured as a 409 on both the downgrade
+    // and the revoke path, contradicting the round-1 Javadoc's claim that "a MANAGER can downgrade
+    // or revoke it at any time".
+    //
+    // The settled rule: the group gets MANAGER (sharing, granting roles to others - the actual
+    // day-to-day need behind "Rechtsquellen Soziales", owner "Referat 50 * Grundsatz", surviving
+    // its creator's departure), and the creator personally gets OWNER (delete, transfer
+    // ownership - reserved for a named, accountable person). The known price - OWNER is lost when
+    // its holder leaves - is what #240 (succession instead of blocking) exists to regulate, not
+    // this class. An outsider - not a member of the owning group at all - still has no access
+    // whatsoever, which is the actual invariant #201 broke (mere existence of *a* group somewhere
+    // never implies access; only membership in the group an explicit grant targets does).
     UUID creator = createUser(organizationA);
     UUID otherMember = createUser(organizationA);
     UUID outsider = createUser(organizationA);
@@ -414,10 +428,15 @@ class KnowledgeLibraryServiceIntegrationTest {
                 .ownerId(group.getId()),
             creator);
 
-    // Every current member of the owning group has OWNER access via the single group grant - not
-    // a personal grant to the creator.
-    assertThat(libraryService.getLibrary(library.getId(), creator, false).getId())
-        .isEqualTo(library.getId());
+    // The creator personally holds OWNER; other group members hold MANAGER via the group grant.
+    KnowledgeLibrary persistedLibrary = libraryRepository.findById(library.getId()).orElseThrow();
+    assertThat(accessService.effectiveRole(persistedLibrary, creator, false))
+        .isEqualTo(AssetRole.OWNER);
+    assertThat(accessService.effectiveRole(persistedLibrary, otherMember, false))
+        .isEqualTo(AssetRole.MANAGER);
+
+    // MANAGER (via the group grant) is still enough to read and to manage - rename, change
+    // visibility - the library.
     assertThat(libraryService.getLibrary(library.getId(), otherMember, false).getId())
         .isEqualTo(library.getId());
     libraryService.updateLibrary(
@@ -425,6 +444,25 @@ class KnowledgeLibraryServiceIntegrationTest {
 
     // An outsider - not a member of this group - has no access at all.
     assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), outsider, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
+
+    // otherMember, holding only MANAGER, cannot revoke the creator's personal OWNER grant - the
+    // escalation guard this exact scenario motivated (Befund 1): a MANAGER may never touch a grant
+    // that already carries a role higher than its own, regardless of the last-active-OWNER count.
+    AssetGrant creatorsOwnerGrant =
+        grantRepository.findByLibraryId(library.getId()).stream()
+            .filter(g -> g.getSubjectType() == PermissionSubjectType.USER)
+            .filter(g -> creator.equals(g.getSubjectUserId()))
+            .findFirst()
+            .orElseThrow();
+    assertThatThrownBy(
+            () ->
+                grantService.revokeGrant(
+                    library.getId(), creatorsOwnerGrant.getId(), otherMember, false))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex ->
@@ -499,6 +537,91 @@ class KnowledgeLibraryServiceIntegrationTest {
             ex ->
                 assertThat(((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  void concurrentRevocationOfTwoOwnerGrantsNeverLeavesTheLibraryWithoutAnActiveOwner()
+      throws Exception {
+    // #202 code review round 2, nit 2: isLastActiveOwnerGrant is a read-then-decide check with no
+    // locking of its own. Two OWNER grants, two threads each revoking one at (as close to)
+    // literally the same instant as CyclicBarrier can arrange, against the real Postgres schema
+    // (not a mock - a mocked PlatformTransactionManager would not exercise the row lock
+    // AssetGrantRepository#findByLibraryIdForUpdate takes, per this project's rule for
+    // concurrency-sensitive invariants). Without that lock, both threads could read the other's
+    // grant as still active and both would proceed, leaving zero active OWNER grants - exactly the
+    // state the guard exists to prevent. With it, exactly one thread must see a 409 and the
+    // library must retain exactly one active OWNER grant afterwards, never zero.
+    UUID firstOwner = createUser(organizationA);
+    UUID secondOwner = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), firstOwner);
+    AssetGrant firstOwnerGrant =
+        grantRepository.findByLibraryId(library.getId()).stream()
+            .filter(g -> firstOwner.equals(g.getSubjectUserId()))
+            .findFirst()
+            .orElseThrow();
+    var secondOwnerGrant =
+        grantService.upsertGrant(
+            library.getId(),
+            new AssetGrantRequest(PermissionSubjectType.USER, secondOwner, AssetRole.OWNER),
+            firstOwner,
+            false);
+
+    var barrier = new CyclicBarrier(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      List<Future<Exception>> results =
+          executor.invokeAll(
+              List.of(
+                  revokeAfterBarrier(barrier, library.getId(), firstOwnerGrant.getId(), firstOwner),
+                  revokeAfterBarrier(
+                      barrier, library.getId(), secondOwnerGrant.getId(), secondOwner)));
+
+      long conflicts = 0;
+      long successes = 0;
+      for (var result : results) {
+        Exception outcome = result.get();
+        if (outcome == null) {
+          successes++;
+        } else if (outcome instanceof ResponseStatusException rse
+            && rse.getStatusCode() == HttpStatus.CONFLICT) {
+          conflicts++;
+        } else {
+          throw new AssertionError("Unexpected outcome", outcome);
+        }
+      }
+
+      assertThat(successes).as("exactly one revoke must succeed").isEqualTo(1);
+      assertThat(conflicts).as("the other must be rejected as the last active owner").isEqualTo(1);
+      List<AssetGrant> remainingGrants = grantRepository.findByLibraryId(library.getId());
+      long activeOwnerCount =
+          remainingGrants.stream()
+              .filter(g -> g.getRole() == AssetRole.OWNER && !g.isExpired(Instant.now()))
+              .count();
+      assertThat(activeOwnerCount)
+          .as("the library must retain exactly one active owner")
+          .isEqualTo(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /**
+   * A task that waits for the other thread at {@code barrier} before calling {@code
+   * grantService.revokeGrant}, returning the {@link ResponseStatusException} it threw (if any)
+   * instead of letting it propagate, so both outcomes can be inspected on the calling thread.
+   */
+  private Callable<Exception> revokeAfterBarrier(
+      CyclicBarrier barrier, UUID libraryId, UUID grantId, UUID callerId) {
+    return () -> {
+      barrier.await();
+      try {
+        grantService.revokeGrant(libraryId, grantId, callerId, false);
+        return null;
+      } catch (ResponseStatusException e) {
+        return e;
+      }
+    };
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import io.opaa.api.dto.AssetGrantRequest;
 import io.opaa.api.dto.LibraryRequest;
 import io.opaa.api.dto.LibraryResponse;
 import io.opaa.api.dto.LibraryUpdateRequest;
+import io.opaa.api.dto.SpaceRequest;
 import io.opaa.auth.User;
 import io.opaa.auth.UserRepository;
 import io.opaa.group.Group;
@@ -21,6 +22,9 @@ import io.opaa.indexing.Document;
 import io.opaa.indexing.DocumentRepository;
 import io.opaa.organization.Organization;
 import io.opaa.organization.OrganizationRepository;
+import io.opaa.space.SpaceKind;
+import io.opaa.space.SpaceRepository;
+import io.opaa.space.SpaceService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -48,15 +52,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * (migration 012) are real foreign keys enforced by Liquibase, not by Hibernate's entity mapping.
  *
  * <p>{@link
- * #grantingTheOwningGroupAViewerRoleReachesItsMembersAndRevocationTakesEffectImmediately()} and
+ * #aGroupGrantOnAPersonallyOwnedLibraryReachesItsMembersAndRevocationTakesEffectImmediately()} and
  * {@link #revokingAGrantTakesEffectOnTheNextCall()} are the mechanism-interaction tests (#202):
  * they exercise a group grant together with {@link GroupMembershipResolver}'s cache invalidation,
  * and a direct grant together with {@code LibraryAccessService}'s own per-library grant cache, not
  * either mechanism in isolation - a regression that reads membership or a grant correctly but
  * forgets to invalidate the relevant cache would still pass a test that only checks access once.
- * {@link #creatingAGroupOwnedLibraryDoesNotAutomaticallyGrantOtherGroupMembersAnyAccess()} is the
- * regression guard for the #201 behaviour #202 replaced: mere membership in the owning group used
- * to imply full management rights with no human decision point.
+ * {@link #creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider()} is the
+ * regression guard for the #201 behaviour #202 replaced - see its own Javadoc for why granting
+ * OWNER to the group is the fix, not a reappearance of the #201 bug.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfiguration.class)
@@ -77,6 +81,8 @@ class KnowledgeLibraryServiceIntegrationTest {
   @Autowired private OrganizationRepository organizationRepository;
   @Autowired private DocumentRepository documentRepository;
   @Autowired private PlatformTransactionManager transactionManager;
+  @Autowired private SpaceService spaceService;
+  @Autowired private SpaceRepository spaceRepository;
 
   private UUID organizationA;
   private UUID organizationB;
@@ -93,11 +99,13 @@ class KnowledgeLibraryServiceIntegrationTest {
   // to every row this class did not itself create.
   private final List<UUID> createdUserIds = new ArrayList<>();
   private final List<UUID> createdGroupIds = new ArrayList<>();
+  private final List<UUID> createdSpaceIds = new ArrayList<>();
 
   @BeforeEach
   void setUp() {
     createdUserIds.clear();
     createdGroupIds.clear();
+    createdSpaceIds.clear();
     organizationA =
         organizationRepository.save(new Organization(UUID.randomUUID(), "Org A")).getId();
     organizationB =
@@ -122,6 +130,9 @@ class KnowledgeLibraryServiceIntegrationTest {
       documentRepository.deleteAll(documentRepository.findByLibraryId(library.getId()));
     }
     libraryRepository.deleteAll(ownLibraries);
+    for (UUID spaceId : createdSpaceIds) {
+      spaceRepository.deleteById(spaceId);
+    }
     for (UUID groupId : createdGroupIds) {
       groupRepository.deleteById(groupId);
     }
@@ -377,14 +388,24 @@ class KnowledgeLibraryServiceIntegrationTest {
   }
 
   @Test
-  void creatingAGroupOwnedLibraryDoesNotAutomaticallyGrantOtherGroupMembersAnyAccess() {
-    // #202 code review of #201/#305: the coarse #201 canRead/canManage let every member of a
-    // group-owned library read and manage it, growing without a human decision point as a
-    // directory-synchronised group's membership grows. LibraryAccessService replaces that: only
-    // the creator (via the explicit OWNER grant KnowledgeLibraryService#createLibrary makes) has
-    // any access at all until a MANAGER explicitly grants the group (or another user) a role.
+  void creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider() {
+    // #202 code review (blocker 4): granting OWNER to the *creator personally* on a GROUP-owned
+    // library was wrong - it left the library owned by an individual in every way that matters
+    // (the migration 013 backfill grants the *group* OWNER for pre-existing libraries, and a
+    // freshly created one must follow the same rule, or the feature spec's leitbeispiel
+    // "Rechtsquellen Soziales" - owner the group "Referat 50 * Grundsatz" - hangs on a grant to
+    // whichever person happened to click "create" the moment they leave). Granting OWNER to the
+    // group instead is not the #201 bug reappearing: unlike the coarse #201 canManage (which
+    // derived rights structurally from the owner columns, with no possible distinction, no
+    // revocation short of deleting the library, and no audit trail), this is one explicit,
+    // revocable AssetGrant row - a MANAGER can downgrade or revoke it at any time via the grant
+    // API, exactly the human decision point #201 lacked. An outsider - not a member of the
+    // owning group at all - still has no access whatsoever, which is the actual invariant #201
+    // broke (mere existence of *a* group somewhere never implies access; only membership in the
+    // group an explicit grant targets does).
     UUID creator = createUser(organizationA);
     UUID otherMember = createUser(organizationA);
+    UUID outsider = createUser(organizationA);
     Group group = createGroup(organizationA, creator, otherMember);
     LibraryResponse library =
         libraryService.createLibrary(
@@ -393,20 +414,17 @@ class KnowledgeLibraryServiceIntegrationTest {
                 .ownerId(group.getId()),
             creator);
 
-    // The creator has access (their explicit OWNER grant), a plain group member does not.
-    LibraryResponse read = libraryService.getLibrary(library.getId(), creator, false);
-    assertThat(read.getId()).isEqualTo(library.getId());
+    // Every current member of the owning group has OWNER access via the single group grant - not
+    // a personal grant to the creator.
+    assertThat(libraryService.getLibrary(library.getId(), creator, false).getId())
+        .isEqualTo(library.getId());
+    assertThat(libraryService.getLibrary(library.getId(), otherMember, false).getId())
+        .isEqualTo(library.getId());
+    libraryService.updateLibrary(
+        library.getId(), new LibraryUpdateRequest("Umbenannt von otherMember"), otherMember, false);
 
-    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), otherMember, false))
-        .isInstanceOf(ResponseStatusException.class)
-        .satisfies(
-            ex ->
-                assertThat(((ResponseStatusException) ex).getStatusCode())
-                    .isEqualTo(HttpStatus.FORBIDDEN));
-    assertThatThrownBy(
-            () ->
-                libraryService.updateLibrary(
-                    library.getId(), new LibraryUpdateRequest("Umbenannt"), otherMember, false))
+    // An outsider - not a member of this group - has no access at all.
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), outsider, false))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex ->
@@ -415,26 +433,25 @@ class KnowledgeLibraryServiceIntegrationTest {
   }
 
   @Test
-  void grantingTheOwningGroupAViewerRoleReachesItsMembersAndRevocationTakesEffectImmediately() {
-    UUID creator = createUser(organizationA);
-    UUID otherMember = createUser(organizationA);
-    Group group = createGroup(organizationA, creator, otherMember);
+  void aGroupGrantOnAPersonallyOwnedLibraryReachesItsMembersAndRevocationTakesEffectImmediately() {
+    // The group-grant counterpart of revokingAGrantTakesEffectOnTheNextCall, using a plain
+    // USER-owned library (not the owning group itself, to keep this test independent of
+    // creatingAGroupOwnedLibraryGrantsOwnerToTheGroupNotOnlyTheCreatorButNoOutsider's concern):
+    // an explicit grant to an ordinary AD_HOC group reaches its current members exactly like a
+    // direct grant would, and losing membership removes access on the next call.
+    UUID owner = createUser(organizationA);
+    UUID member = createUser(organizationA);
+    Group group = createGroup(organizationA, member);
     LibraryResponse library =
-        libraryService.createLibrary(
-            new LibraryRequest("Rechtsquellen Soziales")
-                .ownerType(LibraryOwnerType.GROUP)
-                .ownerId(group.getId()),
-            creator);
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), owner);
 
-    // The creator (MANAGER via their OWNER grant) explicitly grants the whole group VIEWER - the
-    // human decision point the coarse #201 model was missing.
     grantService.upsertGrant(
         library.getId(),
         new AssetGrantRequest(PermissionSubjectType.GROUP, group.getId(), AssetRole.VIEWER),
-        creator,
+        owner,
         false);
 
-    LibraryResponse read = libraryService.getLibrary(library.getId(), otherMember, false);
+    LibraryResponse read = libraryService.getLibrary(library.getId(), member, false);
     assertThat(read.getId()).isEqualTo(library.getId());
 
     // Removing the membership through the real GroupService (not a raw repository update) is the
@@ -445,9 +462,9 @@ class KnowledgeLibraryServiceIntegrationTest {
     // reaches it - a raw repository update bypassing GroupService would leave the resolver's
     // cache stale and make this assertion pass for the wrong reason (a cache that was never
     // populated) or fail where it should not.
-    groupService.removeMember(group.getId(), otherMember, creator);
+    groupService.removeMember(group.getId(), member, owner);
 
-    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), otherMember, false))
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), member, false))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex ->
@@ -514,6 +531,31 @@ class KnowledgeLibraryServiceIntegrationTest {
     assertThat(elapsedMillis)
         .as("readableLibraryIds took %dms against a real Postgres schema", elapsedMillis)
         .isLessThan(100);
+  }
+
+  @Test
+  void spaceMembershipAloneGrantsNoAccessToAnyLibraryNotEvenAsSpaceAdmin() {
+    // #202 acceptance criteria, explicit negative test (code review nit 4): "Space membership
+    // alone grants no access to any library." docs/features/spaces-and-assets.md is explicit that
+    // space associations do not appear in the readableLibraries formula at all - this proves it
+    // end to end against the real SpaceService, not just by the absence of wiring between the two
+    // packages. spaceAdmin becomes the space's ADMIN (the highest space role, able to manage
+    // members and settings) purely by creating it - full space authority, zero library authority.
+    UUID libraryOwner = createUser(organizationA);
+    UUID spaceAdmin = createUser(organizationA);
+    LibraryResponse library =
+        libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), libraryOwner);
+    var space =
+        spaceService.createSpace(
+            new SpaceRequest("Team Leistungsgewaehrung", SpaceKind.PROJECT), spaceAdmin, false);
+    createdSpaceIds.add(space.getId());
+
+    assertThatThrownBy(() -> libraryService.getLibrary(library.getId(), spaceAdmin, false))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            ex ->
+                assertThat(((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN));
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceTest.java
@@ -36,6 +36,8 @@ class KnowledgeLibraryServiceTest {
   private PlatformTransactionManager transactionManager;
   private KnowledgeLibraryService libraryService;
 
+  private AssetGrantRepository grantRepository;
+
   @BeforeEach
   void setUp() {
     libraryRepository = mock(KnowledgeLibraryRepository.class);
@@ -43,6 +45,8 @@ class KnowledgeLibraryServiceTest {
     GroupRepository groupRepository = mock(GroupRepository.class);
     GroupMembershipResolver membershipResolver = mock(GroupMembershipResolver.class);
     DocumentRepository documentRepository = mock(DocumentRepository.class);
+    grantRepository = mock(AssetGrantRepository.class);
+    LibraryAccessService accessService = mock(LibraryAccessService.class);
     transactionManager = mock(PlatformTransactionManager.class);
     when(transactionManager.getTransaction(any())).thenReturn(mock(TransactionStatus.class));
     libraryService =
@@ -52,6 +56,8 @@ class KnowledgeLibraryServiceTest {
             groupRepository,
             membershipResolver,
             documentRepository,
+            grantRepository,
+            accessService,
             transactionManager);
   }
 
@@ -66,6 +72,9 @@ class KnowledgeLibraryServiceTest {
     verify(libraryRepository)
         .insertPersonalLibraryIfAbsent(
             any(UUID.class), eq(organizationId), any(String.class), any(String.class), eq(userId));
+    // #202: the owner grant is inserted in the same call, on the same connection, right after the
+    // library insert - see AssetGrantRepository#insertOwnerGrantForPersonalLibraryIfAbsent.
+    verify(grantRepository).insertOwnerGrantForPersonalLibraryIfAbsent(any(UUID.class), eq(userId));
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
@@ -116,6 +116,32 @@ class LibraryAccessServiceTest {
   }
 
   @Test
+  void aDirectManagerGrantAllowsManagingButNotDeleting() {
+    // #202 code review round 3 (Blocker 1): MANAGER is enough to rename, change visibility or
+    // manage grants, but never enough to delete the library or (once it exists) transfer its
+    // ownership - AssetRole reserves that for OWNER alone.
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.MANAGER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canManage(library, userId, false)).isTrue();
+    assertThat(accessService.canDelete(library, userId, false)).isFalse();
+  }
+
+  @Test
+  void aDirectOwnerGrantAllowsDeleting() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.OWNER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canDelete(library, userId, false)).isTrue();
+  }
+
+  @Test
   void aUserOnlyGrantDoesNotAllowReadingConfiguration() {
     // #202's central distinction: USER can use the asset but not see its configuration.
     UUID libraryId = UUID.randomUUID();

--- a/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
@@ -1,0 +1,239 @@
+package io.opaa.library;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opaa.group.GroupMembershipResolver;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LibraryAccessServiceTest {
+
+  private AssetGrantRepository grantRepository;
+  private KnowledgeLibraryRepository libraryRepository;
+  private GroupMembershipResolver membershipResolver;
+  private LibraryAccessService accessService;
+
+  private final UUID userId = UUID.randomUUID();
+  private final UUID organizationId = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    grantRepository = mock(AssetGrantRepository.class);
+    libraryRepository = mock(KnowledgeLibraryRepository.class);
+    membershipResolver = mock(GroupMembershipResolver.class);
+    accessService =
+        new LibraryAccessService(grantRepository, libraryRepository, membershipResolver);
+    when(membershipResolver.groupIdsForUser(userId)).thenReturn(Set.of());
+  }
+
+  private KnowledgeLibrary privateUserOwnedLibrary(UUID libraryId) {
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByUser(
+            organizationId,
+            "Bibliothek",
+            null,
+            UUID.randomUUID(),
+            LibraryVisibility.PRIVATE,
+            false,
+            false);
+    setId(library, libraryId);
+    return library;
+  }
+
+  private void setId(KnowledgeLibrary library, UUID id) {
+    try {
+      var field = KnowledgeLibrary.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(library, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Test
+  void systemLibraryIsReadableOnlyBySystemAdminsRegardlessOfGrants() {
+    KnowledgeLibrary systemLibrary = mock(KnowledgeLibrary.class);
+    when(systemLibrary.isSystemLibrary()).thenReturn(true);
+
+    assertThat(accessService.canRead(systemLibrary, userId, false)).isFalse();
+    assertThat(accessService.canRead(systemLibrary, userId, true)).isTrue();
+    // Never even asks for the grant list - the fail-closed check short-circuits first.
+    verify(grantRepository, never()).findByLibraryId(any());
+  }
+
+  @Test
+  void systemAdminBypassesGrantsOnAnOrdinaryLibrary() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of());
+
+    assertThat(accessService.canManage(library, userId, true)).isTrue();
+  }
+
+  @Test
+  void aUserWithNoGrantAndNoOrganizationWideVisibilityHasNoAccess() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of());
+
+    assertThat(accessService.canRead(library, userId, false)).isFalse();
+    assertThat(accessService.canManage(library, userId, false)).isFalse();
+    assertThat(accessService.effectiveRole(library, userId, false)).isNull();
+  }
+
+  @Test
+  void aDirectViewerGrantAllowsReadingButNotManaging() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.VIEWER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    assertThat(accessService.canManage(library, userId, false)).isFalse();
+  }
+
+  @Test
+  void aDirectManagerGrantAllowsBothReadingAndManaging() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.MANAGER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    assertThat(accessService.canManage(library, userId, false)).isTrue();
+  }
+
+  @Test
+  void aUserOnlyGrantDoesNotAllowReadingConfiguration() {
+    // #202's central distinction: USER can use the asset but not see its configuration.
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.USER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canRead(library, userId, false)).isFalse();
+  }
+
+  @Test
+  void anExpiredGrantGrantsNoAccess() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forUser(
+            libraryId,
+            organizationId,
+            userId,
+            AssetRole.OWNER,
+            Instant.now().minusSeconds(60),
+            userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+
+    assertThat(accessService.canRead(library, userId, false)).isFalse();
+  }
+
+  @Test
+  void aGroupGrantReachesAMemberOfThatGroup() {
+    UUID libraryId = UUID.randomUUID();
+    UUID groupId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    AssetGrant grant =
+        AssetGrant.forGroup(libraryId, organizationId, groupId, AssetRole.EDITOR, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+    when(membershipResolver.groupIdsForUser(userId)).thenReturn(Set.of(groupId));
+
+    assertThat(accessService.canManage(library, userId, false)).isFalse();
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    assertThat(accessService.effectiveRole(library, userId, false)).isEqualTo(AssetRole.EDITOR);
+  }
+
+  @Test
+  void organizationWideVisibilityGrantsViewerToAnyOrganizationMemberWithoutAGrant() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library =
+        KnowledgeLibrary.ownedByUser(
+            organizationId,
+            "Bibliothek",
+            null,
+            UUID.randomUUID(),
+            LibraryVisibility.ORGANIZATION,
+            false,
+            false);
+    setId(library, libraryId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of());
+
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    assertThat(accessService.canManage(library, userId, false)).isFalse();
+  }
+
+  @Test
+  void readableLibraryIdsUnionsDirectGroupAndOrganizationWideLibrariesWithoutASystemAdminBypass() {
+    UUID directLibrary = UUID.randomUUID();
+    UUID groupLibrary = UUID.randomUUID();
+    UUID orgLibrary = UUID.randomUUID();
+    UUID groupId = UUID.randomUUID();
+    when(membershipResolver.groupIdsForUser(userId)).thenReturn(Set.of(groupId));
+    when(grantRepository.findReadableLibraryIdsByDirectGrant(eq(userId), eq(organizationId), any()))
+        .thenReturn(Set.of(directLibrary));
+    when(grantRepository.findReadableLibraryIdsByGroupGrant(
+            eq(Set.of(groupId)), eq(organizationId), any()))
+        .thenReturn(Set.of(groupLibrary));
+    KnowledgeLibrary orgWide =
+        KnowledgeLibrary.ownedByUser(
+            organizationId,
+            "Organisationsweit",
+            null,
+            UUID.randomUUID(),
+            LibraryVisibility.ORGANIZATION,
+            false,
+            false);
+    setId(orgWide, orgLibrary);
+    when(libraryRepository.findByOrganizationIdAndVisibility(
+            organizationId, LibraryVisibility.ORGANIZATION))
+        .thenReturn(List.of(orgWide));
+
+    Set<UUID> readable = accessService.readableLibraryIds(userId, organizationId);
+
+    assertThat(readable).containsExactlyInAnyOrder(directLibrary, groupLibrary, orgLibrary);
+  }
+
+  @Test
+  void readableLibraryIdsIsEmptyForAUserWithNoGrantsNoGroupsAndNoOrganizationWideLibrary() {
+    when(grantRepository.findReadableLibraryIdsByDirectGrant(eq(userId), eq(organizationId), any()))
+        .thenReturn(Set.of());
+    when(libraryRepository.findByOrganizationIdAndVisibility(
+            organizationId, LibraryVisibility.ORGANIZATION))
+        .thenReturn(List.of());
+
+    assertThat(accessService.readableLibraryIds(userId, organizationId)).isEmpty();
+    verify(grantRepository, never()).findReadableLibraryIdsByGroupGrant(any(), any(), any());
+  }
+
+  @Test
+  void invalidateLibraryEvictsTheCachedGrantListSoTheNextCheckReadsAgain() {
+    UUID libraryId = UUID.randomUUID();
+    KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of());
+    assertThat(accessService.canRead(library, userId, false)).isFalse();
+
+    AssetGrant grant =
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.VIEWER, null, userId);
+    when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
+    accessService.invalidateLibrary(libraryId);
+
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    verify(grantRepository, org.mockito.Mockito.times(2)).findByLibraryId(libraryId);
+  }
+}

--- a/backend/src/test/java/io/opaa/migration/Migration013AssetGrantsTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration013AssetGrantsTest.java
@@ -31,13 +31,13 @@ import org.testcontainers.utility.DockerImageName;
  * public schema is dropped and recreated between test methods, per the package Javadoc's mandatory
  * teardown pattern.
  *
- * <p>{@link
- * #backfillGrantsOwnerAccessForExistingUserAndGroupOwnedLibrariesButNotTheSystemLibrary()} is the
- * mechanism-interaction test: it combines the backfill changeSet with both owner column variants
- * (USER and GROUP) and the SYSTEM library's deliberate exemption in a single run, not any of the
- * three in isolation - a backfill that only handles USER owners, for instance, would lock every
- * existing group-owned library's members out the moment #202's LibraryAccessService replaces the
- * coarse #201 canRead/canManage that this migration accompanies.
+ * <p>{@link #backfillGrantsOwnerAccessForExistingUserOwnedLibrariesButNotTheSystemLibrary()} and
+ * {@link
+ * #backfillGrantsManagerNotOwnerToAnExistingGroupOwnedLibraryLeavingItWithoutAnActiveOwner()}
+ * together cover both owner column variants and the SYSTEM library's deliberate exemption - a
+ * backfill that treated GROUP the same as USER, granting OWNER to the group, would reintroduce the
+ * exact defect (unbounded, non-downgradable management rights via mere membership) #202 exists to
+ * fix, one level up (see 013-backfill-owner-grants's comment for the full reasoning).
  */
 @Testcontainers(disabledWithoutDocker = true)
 class Migration013AssetGrantsTest {
@@ -81,24 +81,40 @@ class Migration013AssetGrantsTest {
   }
 
   @Test
-  void backfillGrantsOwnerAccessForExistingUserAndGroupOwnedLibrariesButNotTheSystemLibrary()
+  void backfillGrantsOwnerAccessForExistingUserOwnedLibrariesButNotTheSystemLibrary()
       throws Exception {
     UUID user = insertUser(UUID.randomUUID());
-    UUID group = insertGroup(UUID.randomUUID());
     UUID userOwnedLibrary = insertLibrary(UUID.randomUUID(), "USER", user, null);
-    UUID groupOwnedLibrary = insertLibrary(UUID.randomUUID(), "GROUP", null, group);
 
     applyChangelog013();
 
     assertThat(grantCountFor(userOwnedLibrary)).isEqualTo(1);
     assertThat(grantRole(userOwnedLibrary, "USER", user.toString())).isEqualTo("OWNER");
 
-    assertThat(grantCountFor(groupOwnedLibrary)).isEqualTo(1);
-    assertThat(grantRole(groupOwnedLibrary, "GROUP", group.toString())).isEqualTo("OWNER");
-
     // The SYSTEM library stays fail-closed to system admins with no grant at all - backfilling one
     // would open a hole in the exact invariant KnowledgeLibrary.SYSTEM_LIBRARY_ID exists to close.
     assertThat(grantCountFor(UUID.fromString(SYSTEM_LIBRARY_ID))).isZero();
+  }
+
+  @Test
+  void backfillGrantsManagerNotOwnerToAnExistingGroupOwnedLibraryLeavingItWithoutAnActiveOwner()
+      throws Exception {
+    // #202 code review round 2 (Befund 2): this backfill has no recorded "creator" to attribute a
+    // personal OWNER grant to for a pre-existing GROUP-owned library - the owner_user_id/
+    // owner_group_id columns it reads from never carried one - and granting OWNER to the group
+    // itself would reintroduce the exact defect (unbounded, non-downgradable management rights via
+    // mere membership) #202 exists to fix, one level up. The deliberate, maintainer-confirmed
+    // choice (see 013-backfill-owner-grants's comment and the PR description) is a MANAGER grant
+    // to the group and no OWNER grant at all - functionally the same "Nachfolge offen" state #240
+    // formalises for a departed owner, present here from the first migration run.
+    UUID group = insertGroup(UUID.randomUUID());
+    UUID groupOwnedLibrary = insertLibrary(UUID.randomUUID(), "GROUP", null, group);
+
+    applyChangelog013();
+
+    assertThat(grantCountFor(groupOwnedLibrary)).isEqualTo(1);
+    assertThat(grantRole(groupOwnedLibrary, "GROUP", group.toString())).isEqualTo("MANAGER");
+    assertThat(activeOwnerGrantCountFor(groupOwnedLibrary)).isZero();
   }
 
   @Test
@@ -328,6 +344,18 @@ class Migration013AssetGrantsTest {
         ResultSet rs =
             statement.executeQuery(
                 "SELECT count(*) FROM asset_grants WHERE library_id = '" + libraryId + "'")) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private long activeOwnerGrantCountFor(UUID libraryId) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT count(*) FROM asset_grants WHERE library_id = '"
+                    + libraryId
+                    + "' AND role = 'OWNER' AND (expires_at IS NULL OR expires_at > now())")) {
       rs.next();
       return rs.getLong(1);
     }

--- a/backend/src/test/java/io/opaa/migration/Migration013AssetGrantsTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration013AssetGrantsTest.java
@@ -1,0 +1,355 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 013 in isolation against a database built from the real, versioned
+ * changelog through changeSet 012 - the same pattern as {@code Migration012KnowledgeLibrariesTest},
+ * with {@code test-master-through-012.yaml} as the pre-migration fixture. {@code
+ * connection.setAutoCommit(true)} is called after every {@code liquibase.update(...)} call, and the
+ * public schema is dropped and recreated between test methods, per the package Javadoc's mandatory
+ * teardown pattern.
+ *
+ * <p>{@link
+ * #backfillGrantsOwnerAccessForExistingUserAndGroupOwnedLibrariesButNotTheSystemLibrary()} is the
+ * mechanism-interaction test: it combines the backfill changeSet with both owner column variants
+ * (USER and GROUP) and the SYSTEM library's deliberate exemption in a single run, not any of the
+ * three in isolation - a backfill that only handles USER owners, for instance, would lock every
+ * existing group-owned library's members out the moment #202's LibraryAccessService replaces the
+ * coarse #201 canRead/canManage that this migration accompanies.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration013AssetGrantsTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+  private static final String SYSTEM_LIBRARY_ID = "00000000-0000-0000-0000-000000000002";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-012.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    connection.setAutoCommit(true);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+    connection.close();
+  }
+
+  @Test
+  void backfillGrantsOwnerAccessForExistingUserAndGroupOwnedLibrariesButNotTheSystemLibrary()
+      throws Exception {
+    UUID user = insertUser(UUID.randomUUID());
+    UUID group = insertGroup(UUID.randomUUID());
+    UUID userOwnedLibrary = insertLibrary(UUID.randomUUID(), "USER", user, null);
+    UUID groupOwnedLibrary = insertLibrary(UUID.randomUUID(), "GROUP", null, group);
+
+    applyChangelog013();
+
+    assertThat(grantCountFor(userOwnedLibrary)).isEqualTo(1);
+    assertThat(grantRole(userOwnedLibrary, "USER", user.toString())).isEqualTo("OWNER");
+
+    assertThat(grantCountFor(groupOwnedLibrary)).isEqualTo(1);
+    assertThat(grantRole(groupOwnedLibrary, "GROUP", group.toString())).isEqualTo("OWNER");
+
+    // The SYSTEM library stays fail-closed to system admins with no grant at all - backfilling one
+    // would open a hole in the exact invariant KnowledgeLibrary.SYSTEM_LIBRARY_ID exists to close.
+    assertThat(grantCountFor(UUID.fromString(SYSTEM_LIBRARY_ID))).isZero();
+  }
+
+  @Test
+  void chkAssetGrantsSubjectRejectsEveryMismatchBetweenSubjectTypeAndSubjectColumns()
+      throws Exception {
+    applyChangelog013();
+    UUID library = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+    UUID user = insertUser(UUID.randomUUID());
+    UUID group = insertGroup(UUID.randomUUID());
+
+    assertThatThrownBy(() -> insertGrant(library, "USER", null, null, "OWNER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_subject");
+    assertThatThrownBy(() -> insertGrant(library, "USER", null, group, "OWNER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_subject");
+    assertThatThrownBy(() -> insertGrant(library, "GROUP", null, null, "OWNER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_subject");
+    assertThatThrownBy(() -> insertGrant(library, "GROUP", user, null, "OWNER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_subject");
+  }
+
+  @Test
+  void chkAssetGrantsRoleRejectsARoleNameFromTheDisjointSpaceRoleSystem() throws Exception {
+    applyChangelog013();
+    UUID library = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+    UUID user = insertUser(UUID.randomUUID());
+
+    // #202 acceptance criteria: no role name exists simultaneously in SpaceRole and the asset role
+    // enum - ADMIN is a SpaceRole, never a valid AssetRole.
+    assertThatThrownBy(() -> insertGrant(library, "USER", user, null, "ADMIN"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_role");
+  }
+
+  @Test
+  void foreignKeysRejectASubjectThatDoesNotExist() throws Exception {
+    applyChangelog013();
+    UUID library = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+
+    assertThatThrownBy(() -> insertGrant(library, "USER", UUID.randomUUID(), null, "VIEWER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_asset_grants_subject_user");
+    assertThatThrownBy(() -> insertGrant(library, "GROUP", null, UUID.randomUUID(), "VIEWER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("fk_asset_grants_subject_group_organization");
+  }
+
+  @Test
+  void compositeForeignKeyRejectsAGrantPointingAtALibraryFromAnotherOrganization()
+      throws Exception {
+    applyChangelog013();
+    UUID otherOrganization = UUID.randomUUID();
+    insertOrganization(otherOrganization);
+    UUID otherOrgUser = insertUser(UUID.randomUUID(), otherOrganization.toString());
+    UUID libraryInOtherOrganization =
+        insertLibrary(UUID.randomUUID(), "USER", otherOrgUser, null, otherOrganization.toString());
+
+    try (Statement statement = connection.createStatement()) {
+      assertThatThrownBy(
+              () ->
+                  statement.execute(
+                      "INSERT INTO asset_grants (id, library_id, organization_id, subject_type,"
+                          + " subject_user_id, role, created_at, updated_at) VALUES ('"
+                          + UUID.randomUUID()
+                          + "', '"
+                          + libraryInOtherOrganization
+                          + "', '"
+                          + SEEDED_ORGANIZATION_ID
+                          + "', 'USER', '"
+                          + otherOrgUser
+                          + "', 'OWNER', now(), now())"))
+          .isInstanceOf(SQLException.class)
+          .hasMessageContaining("fk_asset_grants_library_organization");
+    }
+  }
+
+  @Test
+  void partialUniqueIndexesRejectASecondGrantForTheSameSubjectOnTheSameLibrary() throws Exception {
+    applyChangelog013();
+    UUID library = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+    UUID user = insertUser(UUID.randomUUID());
+    UUID group = insertGroup(UUID.randomUUID());
+
+    insertGrant(library, "USER", user, null, "VIEWER");
+    assertThatThrownBy(() -> insertGrant(library, "USER", user, null, "MANAGER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uk_asset_grants_user_subject");
+
+    insertGrant(library, "GROUP", null, group, "VIEWER");
+    assertThatThrownBy(() -> insertGrant(library, "GROUP", null, group, "MANAGER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uk_asset_grants_group_subject");
+
+    // The same user/group may still hold grants on any number of other libraries.
+    UUID otherLibrary = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+    insertGrant(otherLibrary, "USER", user, null, "VIEWER");
+  }
+
+  @Test
+  void deletingALibraryCascadesToItsGrants() throws Exception {
+    applyChangelog013();
+    UUID library = insertLibrary(UUID.randomUUID(), "SYSTEM", null, null);
+    UUID user = insertUser(UUID.randomUUID());
+    insertGrant(library, "USER", user, null, "OWNER");
+    assertThat(grantCountFor(library)).isEqualTo(1);
+
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DELETE FROM knowledge_libraries WHERE id = '" + library + "'");
+    }
+
+    assertThat(grantCountFor(library)).isZero();
+  }
+
+  private void applyChangelog013() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/013-asset-grants.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  private void insertOrganization(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO organizations (id, name, created_at) VALUES ('"
+              + id
+              + "', 'Org "
+              + id
+              + "', now()) ON CONFLICT (id) DO NOTHING");
+    }
+  }
+
+  private UUID insertUser(UUID id) throws SQLException {
+    return insertUser(id, SEEDED_ORGANIZATION_ID);
+  }
+
+  private UUID insertUser(UUID id, String organizationId) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO users (id, subject, issuer, system_role, organization_id, created_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + id
+              + "', 'test-issuer', 'USER', '"
+              + organizationId
+              + "', now())");
+    }
+    return id;
+  }
+
+  private UUID insertGroup(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO groups (id, organization_id, kind, name, created_at, updated_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', 'AD_HOC', 'Gruppe "
+              + id
+              + "', now(), now())");
+    }
+    return id;
+  }
+
+  private UUID insertLibrary(UUID id, String ownerType, UUID ownerUserId, UUID ownerGroupId)
+      throws SQLException {
+    return insertLibrary(id, ownerType, ownerUserId, ownerGroupId, SEEDED_ORGANIZATION_ID);
+  }
+
+  private UUID insertLibrary(
+      UUID id, String ownerType, UUID ownerUserId, UUID ownerGroupId, String organizationId)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO knowledge_libraries "
+              + "(id, organization_id, name, owner_type, owner_user_id, owner_group_id,"
+              + " visibility, listed, personal, created_at, updated_at) VALUES ('"
+              + id
+              + "', '"
+              + organizationId
+              + "', 'Bibliothek "
+              + id
+              + "', '"
+              + ownerType
+              + "', "
+              + (ownerUserId == null ? "NULL" : "'" + ownerUserId + "'")
+              + ", "
+              + (ownerGroupId == null ? "NULL" : "'" + ownerGroupId + "'")
+              + ", 'PRIVATE', false, false, now(), now())");
+    }
+    return id;
+  }
+
+  private void insertGrant(
+      UUID libraryId, String subjectType, UUID subjectUserId, UUID subjectGroupId, String role)
+      throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO asset_grants (id, library_id, organization_id, subject_type,"
+              + " subject_user_id, subject_group_id, role, created_at, updated_at) VALUES ('"
+              + UUID.randomUUID()
+              + "', '"
+              + libraryId
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', '"
+              + subjectType
+              + "', "
+              + (subjectUserId == null ? "NULL" : "'" + subjectUserId + "'")
+              + ", "
+              + (subjectGroupId == null ? "NULL" : "'" + subjectGroupId + "'")
+              + ", '"
+              + role
+              + "', now(), now())");
+    }
+  }
+
+  private long grantCountFor(UUID libraryId) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT count(*) FROM asset_grants WHERE library_id = '" + libraryId + "'")) {
+      rs.next();
+      return rs.getLong(1);
+    }
+  }
+
+  private String grantRole(UUID libraryId, String subjectType, String subjectId)
+      throws SQLException {
+    String subjectColumn = subjectType.equals("USER") ? "subject_user_id" : "subject_group_id";
+    try (Statement statement = connection.createStatement();
+        ResultSet rs =
+            statement.executeQuery(
+                "SELECT role FROM asset_grants WHERE library_id = '"
+                    + libraryId
+                    + "' AND subject_type = '"
+                    + subjectType
+                    + "' AND "
+                    + subjectColumn
+                    + " = '"
+                    + subjectId
+                    + "'")) {
+      rs.next();
+      return rs.getString(1);
+    }
+  }
+}

--- a/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
@@ -9,6 +9,8 @@ import io.opaa.FakeEmbeddingModel;
 import io.opaa.api.dto.QueryResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -36,6 +38,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * Exercises the permission-aware vector search (#202) end to end against a real Postgres schema:
+ * the test user must actually hold an {@code AssetGrant} on the library a chunk's {@code
+ * library_id} metadata points at, or {@link QueryService#query} never even calls {@link
+ * VectorStore#similaritySearch} for it - see {@link #userWithoutAnyGrantSeesNothing}.
+ */
 @SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
 class QueryIntegrationTest {
@@ -61,30 +69,86 @@ class QueryIntegrationTest {
     }
   }
 
+  private static final UUID DEFAULT_ORGANIZATION_ID =
+      UUID.fromString("00000000-0000-0000-0000-000000000001");
+
   @MockitoBean private ChatModel chatModel;
 
   @Autowired private VectorStore vectorStore;
   @Autowired private QueryService queryService;
   @Autowired private JdbcTemplate jdbcTemplate;
 
+  private UUID userId;
+  private UUID libraryId;
+
   @BeforeEach
   void setUp() {
     jdbcTemplate.execute("TRUNCATE TABLE vector_store");
     // Spring AI 2.0 merges ChatModel.getOptions() into every request; a bare mock returns null
     when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
+
+    userId = UUID.randomUUID();
+    libraryId = UUID.randomUUID();
+    jdbcTemplate.update(
+        "INSERT INTO users (id, subject, issuer, email, display_name, created_at, system_role,"
+            + " organization_id) VALUES (?, ?, ?, ?, ?, now(), 'USER', ?)",
+        userId,
+        "query-it-" + userId,
+        "test-issuer",
+        "query-it@example.com",
+        "Query IT User",
+        DEFAULT_ORGANIZATION_ID);
+    jdbcTemplate.update(
+        "INSERT INTO knowledge_libraries (id, organization_id, name, owner_type, owner_user_id,"
+            + " visibility, listed, personal, created_at, updated_at)"
+            + " VALUES (?, ?, 'IT-Bibliothek', 'USER', ?, 'PRIVATE', false, false, now(), now())",
+        libraryId,
+        DEFAULT_ORGANIZATION_ID,
+        userId);
+    jdbcTemplate.update(
+        "INSERT INTO asset_grants (id, library_id, organization_id, subject_type, subject_user_id,"
+            + " role, created_at, updated_at)"
+            + " VALUES (?, ?, ?, 'USER', ?, 'OWNER', now(), now())",
+        UUID.randomUUID(),
+        libraryId,
+        DEFAULT_ORGANIZATION_ID,
+        userId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    jdbcTemplate.update("DELETE FROM asset_grants WHERE library_id = ?", libraryId);
+    jdbcTemplate.update("DELETE FROM knowledge_libraries WHERE id = ?", libraryId);
+    jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
   }
 
   @Test
   void endToEndQueryReturnsAnswerWithSources() {
-    // Index some test documents into the vector store
+    // Index some test documents into the vector store, attributed to the granted library
     var doc1 =
         new Document(
             "OPAA is an AI-powered project assistant built with Spring Boot.",
-            Map.of("file_name", "readme.md", "document_id", "doc-1", "chunk_index", 0));
+            Map.of(
+                "file_name",
+                "readme.md",
+                "document_id",
+                "doc-1",
+                "chunk_index",
+                0,
+                "library_id",
+                libraryId.toString()));
     var doc2 =
         new Document(
             "The deployment uses Docker Compose with PostgreSQL and pgvector.",
-            Map.of("file_name", "deployment.md", "document_id", "doc-2", "chunk_index", 0));
+            Map.of(
+                "file_name",
+                "deployment.md",
+                "document_id",
+                "doc-2",
+                "chunk_index",
+                0,
+                "library_id",
+                libraryId.toString()));
     vectorStore.add(List.of(doc1, doc2));
 
     // Mock the ChatModel response
@@ -111,7 +175,7 @@ class QueryIntegrationTest {
     when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
 
     // Execute the query
-    QueryResponse response = queryService.query("What is OPAA?", null);
+    QueryResponse response = queryService.query("What is OPAA?", null, userId);
 
     // Verify the response
     assertThat(response.getAnswer()).isEqualTo("OPAA is an AI project assistant (readme.md).");
@@ -130,15 +194,61 @@ class QueryIntegrationTest {
     var chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
     when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Something completely unrelated", null);
+    QueryResponse response = queryService.query("Something completely unrelated", null, userId);
 
     assertThat(response.getAnswer()).contains("don't have enough context");
     assertThat(response.getSources()).isEmpty();
   }
 
   @Test
+  void userWithoutAnyGrantSeesNothing() {
+    // A chunk exists in a library the querying user has no grant on - verifies #202's central
+    // acceptance criterion end to end: an unauthorized chunk is never loaded, let alone returned,
+    // and the answer path is indistinguishable from "nothing matched" (same mocked assistant
+    // reply as queryWithNoMatchingDocumentsReturnsEmptySources).
+    var doc =
+        new Document(
+            "Confidential content only the owner may see.",
+            Map.of(
+                "file_name",
+                "secret.md",
+                "document_id",
+                "doc-secret",
+                "chunk_index",
+                0,
+                "library_id",
+                libraryId.toString()));
+    vectorStore.add(List.of(doc));
+
+    var assistantMessage =
+        new AssistantMessage("I don't have enough context to answer that question.");
+    var chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
+    when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
+
+    UUID strangerId = UUID.randomUUID();
+    jdbcTemplate.update(
+        "INSERT INTO users (id, subject, issuer, email, display_name, created_at, system_role,"
+            + " organization_id) VALUES (?, ?, ?, ?, ?, now(), 'USER', ?)",
+        strangerId,
+        "query-it-stranger-" + strangerId,
+        "test-issuer",
+        "stranger@example.com",
+        "Stranger",
+        DEFAULT_ORGANIZATION_ID);
+    try {
+      QueryResponse response = queryService.query("What is the secret?", null, strangerId);
+
+      assertThat(response.getAnswer()).contains("don't have enough context");
+      assertThat(response.getSources()).isEmpty();
+    } finally {
+      jdbcTemplate.update("DELETE FROM users WHERE id = ?", strangerId);
+    }
+  }
+
+  @Test
   void queryRejectsInvalidConversationId() {
-    assertThatThrownBy(() -> queryService.query("Test question", "<script>alert(1)</script>"))
+    assertThatThrownBy(
+            () -> queryService.query("Test question", "<script>alert(1)</script>", userId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ungültiges Format der conversationId");
   }

--- a/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import io.opaa.FakeEmbeddingModel;
 import io.opaa.api.dto.QueryResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -242,6 +243,79 @@ class QueryIntegrationTest {
       assertThat(response.getSources()).isEmpty();
     } finally {
       jdbcTemplate.update("DELETE FROM users WHERE id = ?", strangerId);
+    }
+  }
+
+  @Test
+  void queryOnlyReturnsChunksFromTheGrantedLibraryEvenWhenUnauthorizedChunksWouldOutscoreThem() {
+    // #202 code review (blocker 1): userWithoutAnyGrantSeesNothing alone does not prove the filter
+    // is part of the vector search rather than a post-filter, because an empty readable set short
+    // -circuits before the vector store is ever called (see QueryService#query). This test instead
+    // gives the user a real, non-empty readable set with a second, ungranted library present in
+    // the same store, and asserts on the *count* of results, not just their content: with 6 chunks
+    // in the granted library A and 6 in the ungranted library B, FakeEmbeddingModel returns an
+    // identical embedding for every text (see its Javadoc), so every one of the 12 chunks scores
+    // equally on similarity - a post-filter applied after retrieving topK=5 candidates would
+    // return however many of those 5 happened to come from A (typically 2-3 given 6-vs-6 odds,
+    // never reliably 5), while a filter that is genuinely part of the ANN search - the only way to
+    // guarantee 5 results out of 5 candidates that are all from a library with only 6 members
+    // total - always returns exactly topK results, all from A. See the PR description for the
+    // reproduction: reverting QueryService's filterExpression(...) call turns this test red while
+    // every other test in this class, QueryControllerTest and io.opaa.library.* stay green.
+    UUID ungrantedLibraryId = UUID.randomUUID();
+    jdbcTemplate.update(
+        "INSERT INTO knowledge_libraries (id, organization_id, name, owner_type, owner_user_id,"
+            + " visibility, listed, personal, created_at, updated_at)"
+            + " VALUES (?, ?, 'Fremde Bibliothek', 'USER', ?, 'PRIVATE', false, false, now(),"
+            + " now())",
+        ungrantedLibraryId,
+        DEFAULT_ORGANIZATION_ID,
+        userId);
+
+    List<Document> chunks = new ArrayList<>();
+    for (int i = 0; i < 6; i++) {
+      chunks.add(
+          new Document(
+              "Granted content " + i,
+              Map.of(
+                  "file_name",
+                  "a" + i + ".md",
+                  "document_id",
+                  "doc-a-" + i,
+                  "chunk_index",
+                  0,
+                  "library_id",
+                  libraryId.toString())));
+    }
+    for (int i = 0; i < 6; i++) {
+      chunks.add(
+          new Document(
+              "Unauthorized content " + i,
+              Map.of(
+                  "file_name",
+                  "b" + i + ".md",
+                  "document_id",
+                  "doc-b-" + i,
+                  "chunk_index",
+                  0,
+                  "library_id",
+                  ungrantedLibraryId.toString())));
+    }
+    vectorStore.add(chunks);
+
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Antwort"))));
+    when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
+
+    try {
+      QueryResponse response = queryService.query("Beliebige Frage", null, userId);
+
+      // Exactly topK (5, application.yml default) results, every one of them from the granted
+      // library - the count itself is the assertion that matters (see the comment above).
+      assertThat(response.getSources()).hasSize(5);
+      assertThat(response.getSources())
+          .allSatisfy(source -> assertThat(source.getFileName()).startsWith("a"));
+    } finally {
+      jdbcTemplate.update("DELETE FROM knowledge_libraries WHERE id = ?", ungrantedLibraryId);
     }
   }
 

--- a/backend/src/test/java/io/opaa/query/QueryServiceTest.java
+++ b/backend/src/test/java/io/opaa/query/QueryServiceTest.java
@@ -4,18 +4,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opaa.api.dto.QueryResponse;
 import io.opaa.api.dto.SourceReference;
+import io.opaa.auth.User;
+import io.opaa.auth.UserRepository;
 import io.opaa.indexing.DocumentRepository;
+import io.opaa.library.LibraryAccessService;
 import io.opaa.observability.QueryMetrics;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,7 +49,13 @@ class QueryServiceTest {
   @Mock private AnswerGenerationService answerGenerationService;
   @Mock private ChatMemory chatMemory;
   @Mock private DocumentRepository documentRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private LibraryAccessService libraryAccessService;
   private QueryService queryService;
+
+  private final UUID currentUserId = UUID.randomUUID();
+  private final UUID organizationId = UUID.randomUUID();
+  private final UUID readableLibraryId = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
@@ -53,8 +66,20 @@ class QueryServiceTest {
             chatMemory,
             new CitationParser(),
             documentRepository,
+            userRepository,
+            libraryAccessService,
             new QueryMetrics(new SimpleMeterRegistry()),
             new QueryProperties(5, 0.3));
+
+    User user = new User("subject", "issuer", "user@example.com", "User");
+    user.setOrganizationId(organizationId);
+    // lenient: not every test in this class exercises the full query() path (e.g.
+    // validateConversationId and the mergeSourceReferences nested tests call other members
+    // directly), so MockitoExtension's strict stubbing would otherwise flag these as unused.
+    lenient().when(userRepository.findById(currentUserId)).thenReturn(Optional.of(user));
+    lenient()
+        .when(libraryAccessService.readableLibraryIds(currentUserId, organizationId))
+        .thenReturn(Set.of(readableLibraryId));
   }
 
   @Test
@@ -77,7 +102,7 @@ class QueryServiceTest {
     when(answerGenerationService.generateAnswer(eq("What?"), any(), any()))
         .thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("What?", null);
+    QueryResponse response = queryService.query("What?", null, currentUserId);
 
     assertThat(response.getAnswer()).contains("【source:");
     assertThat(response.getSources()).hasSize(1);
@@ -98,7 +123,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getConversationId()).isNotNull().isNotBlank();
   }
@@ -112,7 +137,7 @@ class QueryServiceTest {
     when(answerGenerationService.generateAnswer(any(), any(), eq("existing-conv-id")))
         .thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", "existing-conv-id");
+    QueryResponse response = queryService.query("Question", "existing-conv-id", currentUserId);
 
     assertThat(response.getConversationId()).isEqualTo("existing-conv-id");
   }
@@ -140,7 +165,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage(answer))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getSources()).hasSize(2);
     assertThat(response.getSources().get(0).getCited()).isTrue();
@@ -175,7 +200,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getSources()).hasSize(2);
     assertThat(response.getSources().get(0).getFileName()).isEqualTo("report.pdf");
@@ -200,7 +225,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage(answer))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getAnswer()).isEqualTo(answer);
   }
@@ -227,7 +252,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getSources()).hasSize(1);
     assertThat(response.getSources().getFirst().getRelevanceScore()).isEqualTo(0.9);
@@ -242,7 +267,7 @@ class QueryServiceTest {
         new ChatResponse(List.of(new Generation(new AssistantMessage("No results"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    queryService.query("Test query", null);
+    queryService.query("Test query", null, currentUserId);
 
     ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
     verify(vectorStore).similaritySearch(captor.capture());
@@ -250,6 +275,36 @@ class QueryServiceTest {
     assertThat(request.getQuery()).isEqualTo("Test query");
     assertThat(request.getTopK()).isEqualTo(5);
     assertThat(request.getSimilarityThreshold()).isEqualTo(0.3);
+  }
+
+  @Test
+  void queryFiltersOnReadableLibraryIds() {
+    when(chatMemory.get(any())).thenReturn(List.of());
+    when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
+    when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
+
+    queryService.query("Test query", null, currentUserId);
+
+    ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(vectorStore).similaritySearch(captor.capture());
+    assertThat(captor.getValue().getFilterExpression()).isNotNull();
+    assertThat(captor.getValue().getFilterExpression().toString())
+        .contains(readableLibraryId.toString());
+  }
+
+  @Test
+  void queryWithNoReadableLibrariesSkipsVectorStoreAndReturnsEmptySources() {
+    when(chatMemory.get(any())).thenReturn(List.of());
+    when(libraryAccessService.readableLibraryIds(currentUserId, organizationId))
+        .thenReturn(Set.of());
+    var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
+    when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
+
+    QueryResponse response = queryService.query("Question", null, currentUserId);
+
+    assertThat(response.getSources()).isEmpty();
+    org.mockito.Mockito.verifyNoInteractions(vectorStore);
   }
 
   @Test
@@ -275,7 +330,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage(answer))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    QueryResponse response = queryService.query("Question", null);
+    QueryResponse response = queryService.query("Question", null, currentUserId);
 
     assertThat(response.getSources()).hasSize(1);
     assertThat(response.getSources().getFirst().getCited()).isTrue();
@@ -294,7 +349,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Tabelle"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    queryService.query("Mach daraus eine tabellarische Auflistung", "conv-enrich");
+    queryService.query("Mach daraus eine tabellarische Auflistung", "conv-enrich", currentUserId);
 
     ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
     verify(vectorStore).similaritySearch(captor.capture());
@@ -316,7 +371,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Sortiert"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    queryService.query("Sortiere nach Datum", "conv-third");
+    queryService.query("Sortiere nach Datum", "conv-third", currentUserId);
 
     ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
     verify(vectorStore).similaritySearch(captor.capture());
@@ -332,7 +387,7 @@ class QueryServiceTest {
     var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Answer"))));
     when(answerGenerationService.generateAnswer(any(), any(), any())).thenReturn(chatResponse);
 
-    queryService.query("First question", null);
+    queryService.query("First question", null, currentUserId);
 
     ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
     verify(vectorStore).similaritySearch(captor.capture());
@@ -341,7 +396,8 @@ class QueryServiceTest {
 
   @Test
   void queryMethodIsAnnotatedWithTransactionalReadOnly() throws NoSuchMethodException {
-    Method queryMethod = QueryService.class.getMethod("query", String.class, String.class);
+    Method queryMethod =
+        QueryService.class.getMethod("query", String.class, String.class, UUID.class);
     Transactional transactional = queryMethod.getAnnotation(Transactional.class);
 
     assertThat(transactional).isNotNull();

--- a/backend/src/test/resources/db/changelog/test-master-through-012.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-012.yaml
@@ -1,3 +1,13 @@
+# Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
+# changeSet 012 - i.e. the schema exactly as it existed immediately before migration 013, which
+# builds on this same pre-migration state.
+#
+# Used by:
+# - Migration013AssetGrantsTest, to build a realistic pre-migration database (via the real,
+#   versioned changelog files, not a hand-rolled schema) and then apply 013 in isolation.
+#
+# See test-master-through-011.yaml and Migration012KnowledgeLibrariesTest for the pattern this
+# fixture follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml
@@ -23,5 +33,3 @@ databaseChangeLog:
       file: db/changelog/changes/011-directory-sync.yaml
   - include:
       file: db/changelog/changes/012-knowledge-libraries.yaml
-  - include:
-      file: db/changelog/changes/013-asset-grants.yaml


### PR DESCRIPTION
## Zusammenfassung

Fuehrt Asset-Rechte (`AssetGrant`) und die rechtebewusste Vektorsuche ein - den zentralen Angelpunkt des Space-and-Asset-Epics (#198). Bis zu diesem PR filterte `QueryService` die Aehnlichkeitssuche ueberhaupt nicht.

**AssetGrant** ist eine eigene Rangordnung `USER < VIEWER < EDITOR < MANAGER < OWNER`, disjunkt von `SpaceRole` (kein Rollenname kommt in beiden Systemen vor). Ein Grant zeigt auf einen Nutzer oder eine Gruppe (ueber zwei nullable Spalten `subject_user_id`/`subject_group_id`, wie schon `knowledge_libraries.owner_*`) und traegt von Anfang an ein optionales `expiresAt` (Rezertifizierung kommt erst mit #241, aber das Feld nachtraeglich hinzuzufuegen waere teuer, ein bestehender Grant-Bestand ohne Ablaufdatum nachtraeglich zu bewerten erst recht).

**`LibraryAccessService`** ersetzt (nicht ergaenzt) `KnowledgeLibraryService`s bisherige grobe `canRead`/`canManage`-Zwischenfassung aus #201. Der wichtigste Verhaltensunterschied: **Gruppen-Eigentuemerschaft einer Bibliothek gewaehrt Mitgliedern keine automatischen Verwaltungsrechte mehr.** Bisher durfte jedes Mitglied einer gruppen-eigenen Bibliothek sie umbenennen, die Sichtbarkeit aendern und loeschen - bei verzeichnissynchronisierten Gruppen waechst dieser Kreis ohne menschlichen Entscheidungspunkt. Jetzt entsteht Verwaltungsrecht ausschliesslich aus einem expliziten `AssetGrant`, und die Rollen dabei sind bewusst gestaffelt (**Stand nach Review-Runde 2/3, nicht mehr "OWNER unabhaengig vom ownerType" wie in der ersten Fassung dieses Textes**):

- `KnowledgeLibraryService#createLibrary` gewaehrt dem **Ersteller** immer persoenlich `OWNER` - loeschen und Eigentum uebertragen bleibt an eine benannte, verantwortliche Person gebunden.
- Bei einer **`GROUP`-eigenen** Bibliothek bekommt zusaetzlich die **Gruppe** einen `MANAGER`-Grant (teilen, weitere Rechte vergeben) - **nicht** `OWNER`: jedes Mitglied automatisch als `OWNER` wuerde ohne menschlichen Entscheidungspunkt mit der Gruppengroesse mitwachsen (#237) und liesse sich, sobald es der einzige aktive `OWNER`-Grant ist, nicht mehr herabstufen oder entziehen - genau der Fehler, den dieser PR fuer #201 beheben soll, eine Ebene hoeher.
- `deleteLibrary` verlangt seit Review-Runde 3 `OWNER` (`LibraryAccessService#canDelete`), nicht mehr `MANAGER` - sonst haette ein Gruppenmitglied mit nur dem `MANAGER`-Grant die ganze Bibliothek loeschen und damit auch den persoenlichen `OWNER`-Grant des Erstellers per `ON DELETE CASCADE` mitreissen koennen, ein voelliger Umweg um die Eskalations-Waechter.

**`QueryService`** filtert die Vektorsuche jetzt auf `LibraryAccessService#readableLibraryIds(userId, organizationId)` - als `library_id IN (...)`-Filterausdruck, der Teil des `VectorStore#similaritySearch`-Aufrufs selbst ist, kein Nachfilter. Ein nicht autorisierter Chunk wird nie geladen, geschweige denn gerankt. Es gibt **keine** Systemadmin-Ausnahme in diesem Pfad - ein Agent liest immer mit den Rechten des aufrufenden Nutzers, ohne zweiten Rechtekontext (ADR-0008 §5). Eine leere lesbare Menge ueberspringt den Vektorstore-Aufruf komplett und erzeugt denselben Antwortpfad wie "nichts gefunden" - die Nachricht verraet also keine Zaehlwerte.

**Caching:** `LibraryAccessService` cached die Grant-Liste je Bibliothek (Caffeine, analog zu `GroupMembershipResolver`), invalidiert nach Commit (`AssetGrantService#invalidateAfterCommit`, gleiches `TransactionSynchronization#afterCompletion`-Muster wie `GroupService`). Der Suchpfad selbst (`readableLibraryIds`) ist bewusst **nicht** gecacht - eine einzelne indexierte Abfrage garantiert, dass ein widerrufener Grant sofort wirkt, ohne einen zweiten Cache-Invalidierungspfad korrekt halten zu muessen.

**Migration 013** legt `asset_grants` an und backfillt fuer jede bestehende **`USER`-eigene** Bibliothek einen expliziten `OWNER`-Grant fuer den bisherigen individuellen Eigentuemer. Fuer eine bestehende **`GROUP`-eigene** Bibliothek gibt es dagegen **keinen erfassten Ersteller** - der Backfill vergibt dort nur `MANAGER` an die Gruppe und **fabriziert keinen `OWNER`-Grant**. Diese Bibliothek bleibt vollstaendig nutzbar (lesen, teilen, umbenennen, Sichtbarkeit aendern), aber niemand kann sie loeschen oder Eigentum uebertragen, bis ein System-Admin (der weiterhin OWNER-aequivalent bypassed) einer benannten Person explizit `OWNER` gewaehrt - faktisch derselbe "Nachfolge offen"-Zustand, den #240 fuer einen ausgeschiedenen Eigentuemer vorsieht, hier von Anfang an fuer Bestandsdaten. Erwogene Alternativen (Gruppe behaelt `OWNER` fuer Bestandsdaten; `OWNER` an ein beliebiges Gruppenmitglied) wurden verworfen - siehe den Kommentar am Backfill-Changeset (`013-asset-grants.yaml`) fuer die Begruendung. Die SYSTEM-Bibliothek bleibt bewusst ganz ohne Grant, fail-closed fuer Systemadmins.

## Zugehörige Issues

Closes #202

## Annahmen

- **System-Admin-Bypass bei `LibraryAccessService#effectiveRole`** (fuer Bibliotheks-CRUD: `getLibrary`/`updateLibrary`/`deleteLibrary`/`listDocuments`) bleibt erhalten, wie schon vor diesem PR. Im Suchpfad (`readableLibraryIds`) gibt es dagegen **keinen** Bypass. Diese Asymmetrie ist beabsichtigt (Verwaltung vs. rechte-strikter Suchpfad), aber nicht explizit im Issue-Text vorgegeben - bei Bedarf bitte im Review ansprechen.
- **`LibraryVisibility.ORGANIZATION` gewaehrt implizit `VIEWER`** (nicht nur `USER`) an alle Organisationsmitglieder - identisch zum Verhalten der ersetzten #201-Zwischenfassung. Das Issue spezifiziert keinen Rang fuer diesen Pfad; ich habe das bestehende Verhalten beibehalten, um es nicht ohne Auftrag einzuschraenken.
- **Grant-Verwaltungs-API** (`GET/POST /libraries/{id}/grants`, `DELETE /libraries/{id}/grants/{grantId}`) wurde ergaenzt, weil ohne sie kein `MANAGER` je einen Grant an eine Gruppe oder einen weiteren Nutzer vergeben koennte - das Issue nennt keine Endpunkte explizit, aber "Resolution of readableLibraries(user) = direct grants + group grants + ..." setzt voraus, dass solche Grants ueberhaupt entstehen koennen.
- **Migration-013-Backfill fuer bestehende `GROUP`-eigene Bibliotheken (Review-Runde 2, zur ausdruecklichen Bestaetigung vorgelegt):** kein `OWNER`-Grant wird fabriziert, nur `MANAGER` an die Gruppe - siehe Absatz oben und den Kommentar am Backfill-Changeset. Falls eine andere Aufloesung gewuenscht ist, bitte im Review benennen.

## Leistungszusage ("unter 50 ms")

Konnte **nicht** als belastbare, last-getestete Zusage nachgewiesen werden - das war in der Aufgabenstellung als offen markiert. Was ich beitragen kann: ein einzelner, kalter Aufruf von `LibraryAccessService#readableLibraryIds` gegen ein echtes Postgres-Testcontainer-Schema (kein Mock) hat in einem Testlauf **43 ms** gebraucht (Messung im PR-Test `readableLibraryIdsResolvesWellWithinTheHundredMillisecondBudgetOnARealDatabase`, mit grosszuegigem 100-ms-Regressionsschutz statt einer harten 50-ms-Assertion, um keinen flakigen Mikro-Benchmark zu erzeugen). Das ist ein Hinweis, kein Beleg unter Last oder Produktionsdatenvolumen.

## Follow-ups (ausserhalb des Scopes)

- `GlobalExceptionHandler` hat keinen `@ExceptionHandler(ResponseStatusException.class)`. Eine `ResponseStatusException` (z. B. aus `QueryController#currentUser`, identisch zum bestehenden Muster in `LibraryController`/`GroupController`/`SpaceController`) faellt auf den generischen `Exception`-Handler durch und liefert 500 statt ihres eigentlichen Status. Vorbestehende Luecke, nicht durch diesen PR verursacht - ich habe deshalb keinen Test dafuer im Query-Controller ergaenzt, sondern die Luecke im Code kommentiert. Ein eigenes Issue waere sinnvoll.
- `GroupService.deleteGroup` prueft ohne Sperre - nebenlaeufig angelegte Grants koennen weiterhin einen 500er ausloesen. Sicherheitsnetz ist als **#310** angelegt.

## Art der Änderung

- [ ] Bugfix
- [x] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Bei Bugfix: Reproduktionsnachweis erbracht (siehe Review-Kommentare zu Runde 2 und Runde 3)
- [x] Dokumentation aktualisiert (falls zutreffend) - Feature-Spezifikation deckte das Zielmodell bereits ab, keine Aenderung noetig
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## Pre-Push-Ergebnisse (Stand Review-Runde 3)

- Backend-Formatierung: `./gradlew spotlessCheck` - OK
- Backend-Build + Test: `./gradlew build` - OK, alle Tests gruen (58 Test-Suiten, 0 Fehler; Testcontainers/Docker verfuegbar, inkl. Nebenlaeufigkeitstests mit echten Threads gegen Postgres)
- Frontend nicht betroffen in Runde 2/3 (kein Frontend-Code geaendert seit der urspruenglichen Einreichung)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude, developer-Rolle)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
