### PR TITLE
fix(ci): Report früher planen und Zeitfenster nachvollziehbar machen

### DIFF
--- a/.github/scripts/daily_report.py
+++ b/.github/scripts/daily_report.py
@@ -53,6 +53,9 @@ def _local_timezone() -> ZoneInfo | timezone:
 
 
 TIMEZONE = _local_timezone()
+# Beim Rückfall auf UTC verschieben sich die Tagesgrenzen. Das wird im Report
+# ausgewiesen, damit ein solcher Lauf nicht unbemerkt bleibt.
+TIMEZONE_FALLBACK = str(TIMEZONE) != "Europe/Berlin"
 UTC = timezone.utc
 SEARCH_PAGE_SIZE = 100
 SEARCH_MAX_PAGES = 10
@@ -107,15 +110,27 @@ def gh_api(path: str, *, paginate: bool = False) -> object:
 
 
 def day_bounds(day: Date) -> tuple[str, str]:
-    """Liefert Beginn und Ende eines Tages als ISO-Zeitstempel mit Zeitzone.
+    """Liefert das halboffene Zeitfenster eines Tages mit Zeitzone.
 
     Die Suche der GitHub-API rechnet ohne Offset in UTC. Für einen Report, der
     sich an der lokalen Arbeitszeit orientiert, muss der Offset mitgegeben
     werden, sonst wandern Abendereignisse in den Folgetag.
+
+    Beide Grenzen gehören zum Fenster. Ein halboffenes Fenster wäre sauberer,
+    ist über die Suche aber nicht ausdrückbar: Zwei Bereichsangaben zum selben
+    Feld verknüpft GitHub nicht, die zweite verdrängt die erste. Eine Abfrage
+    `merged:>=A merged:<B` liefert daher alles vor B statt des Tages. Nur der
+    Bereichsoperator `A..B` grenzt korrekt ein. Da die Zeitstempel der API
+    sekundengenau sind, entsteht zum Folgetag dennoch keine Lücke.
     """
     start = datetime.combine(day, datetime.min.time(), tzinfo=TIMEZONE)
-    end = start + timedelta(days=1) - timedelta(seconds=1)
-    return start.isoformat(), end.isoformat()
+    ende = start + timedelta(days=1) - timedelta(seconds=1)
+    return start.isoformat(), ende.isoformat()
+
+
+def zeitraum_qualifier(feld: str, start: str, ende: str) -> str:
+    """Baut den Suchausdruck für das Zeitfenster eines Tages."""
+    return f"{feld}:{start}..{ende}"
 
 
 def search_issues(repo: str, qualifier: str) -> list[dict]:
@@ -352,19 +367,24 @@ def assign_to_epics(data: dict, epics: list[dict]) -> dict:
 def collect(repo: str, day: Date) -> dict:
     """Trägt alle Daten für einen Tag zusammen."""
     start, end = day_bounds(day)
-    window = f"{start}..{end}"
 
     closed_issues = [
         simplify_issue(item)
-        for item in search_issues(repo, f"is:issue is:closed closed:{window}")
+        for item in search_issues(
+            repo, "is:issue is:closed " + zeitraum_qualifier("closed", start, end)
+        )
     ]
     opened_issues = [
         simplify_issue(item)
-        for item in search_issues(repo, f"is:issue created:{window}")
+        for item in search_issues(
+            repo, "is:issue " + zeitraum_qualifier("created", start, end)
+        )
     ]
     merged = [
         simplify_issue(item)
-        for item in search_issues(repo, f"is:pr is:merged merged:{window}")
+        for item in search_issues(
+            repo, "is:pr is:merged " + zeitraum_qualifier("merged", start, end)
+        )
     ]
     for pull_request in merged:
         pull_request.update(pull_request_stats(repo, pull_request["number"]))
@@ -380,6 +400,12 @@ def collect(repo: str, day: Date) -> dict:
         "repo": repo,
         "date": day.isoformat(),
         "generated_at": datetime.now(tz=TIMEZONE).isoformat(),
+        # Macht nachprüfbar, gegen welche Grenzen abgefragt wurde — besonders
+        # für Vorgänge kurz vor Mitternacht.
+        "timezone": str(TIMEZONE),
+        "timezone_fallback": TIMEZONE_FALLBACK,
+        "window_start": start,
+        "window_end": end,
         "closed_issues": closed_issues,
         "opened_issues": opened_issues,
         "merged_pull_requests": merged,
@@ -744,6 +770,27 @@ def render_ci(ci: dict | None) -> str:
     )
 
 
+def render_zeitraum(data: dict) -> str:
+    """Weist das abgefragte Zeitfenster aus.
+
+    Ältere Reports kennen die Felder nicht; dann entfällt der Hinweis.
+    """
+    start, ende = data.get("window_start"), data.get("window_end")
+    if not start or not ende:
+        return ""
+    zone = html.escape(str(data.get("timezone", "")))
+    hinweis = (
+        f'<br><span class="empty">Berichtszeitraum: {html.escape(start[:19])} '
+        f"bis {html.escape(ende[:19])} ({zone})</span>"
+    )
+    if data.get("timezone_fallback"):
+        hinweis += (
+            '<br><span class="status bad">Ohne Zeitzonendatenbank erzeugt — '
+            "die Tagesgrenzen können abweichen.</span>"
+        )
+    return hinweis
+
+
 def render_report(data: dict) -> str:
     day = Date.fromisoformat(data["date"])
     body = f"""<header>
@@ -773,6 +820,7 @@ def render_report(data: dict) -> str:
 <footer>
 Erzeugt am {html.escape(data["generated_at"][:16].replace("T", " um "))} Uhr ·
 <a href="../feed.xml">Feed abonnieren</a>
+{render_zeitraum(data)}
 </footer>"""
     return page(f"Tagesreport {day.isoformat()}", body, feed_href="../feed.xml")
 

--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -2,9 +2,11 @@ name: Daily Report
 
 on:
   schedule:
-    # 04:30 UTC entspricht 06:30 MESZ beziehungsweise 05:30 MEZ. Der Vortag ist
-    # damit in jedem Fall abgeschlossen.
-    - cron: "30 4 * * *"
+    # 00:30 UTC entspricht 02:30 MESZ beziehungsweise 01:30 MEZ. Der Vortag ist
+    # nach mitteleuropäischer Zeit damit abgeschlossen, siehe TIMEZONE im Skript.
+    # Die Uhrzeit ist ein Wunsch, keine Zusage: GitHub führt geplante Läufe bei
+    # Last auch mehrere Stunden später aus.
+    - cron: "30 0 * * *"
   workflow_dispatch:
     inputs:
       date:

--- a/docs/tagesreport.md
+++ b/docs/tagesreport.md
@@ -23,6 +23,42 @@ Modellaufruf und ist optional — siehe [Zusammenfassung aktivieren](#zusammenfa
 
 Tage ohne Issue- oder PR-Bewegung erzeugen keinen Report.
 
+### Welcher Tag ein Vorgang ist
+
+Maßgeblich ist der Zeitpunkt des **Ereignisses**, nicht der Anlage. Ein im
+Januar erstelltes Issue, das am 3. August geschlossen wird, erscheint im Report
+vom 3. August.
+
+| Gruppe | Zeitstempel |
+| --- | --- |
+| Neu angelegte Issues | `created_at` |
+| Abgeschlossene Issues | `closed_at` |
+| Gemergte Pull Requests | `merged_at` |
+
+Der Tag wird nach **Europe/Berlin** abgegrenzt, nicht nach UTC. Das Fenster
+reicht von `00:00:00` bis `23:59:59` desselben Tages, jeweils mit Offset, etwa
+`2026-08-03T00:00:00+02:00..2026-08-03T23:59:59+02:00`. Beide Grenzen gehören
+dazu; da die Zeitstempel der API sekundengenau sind, entsteht zum Folgetag
+keine Lücke.
+
+Ein halboffenes Fenster wäre sauberer, ist über die Suche aber nicht
+ausdrückbar: Zwei Bereichsangaben zum selben Feld verknüpft GitHub nicht, die
+zweite verdrängt die erste. `merged:>=A merged:<B` liefert deshalb alles vor
+`B` statt des Tages.
+
+**Nachprüfbarkeit.** Jeder Report weist im Fußbereich das tatsächlich
+verwendete Fenster samt Zeitzone aus, die Rohdaten führen es als
+`window_start`, `window_end` und `timezone`. Wer wissen will, in welchem Report
+ein Vorgang von kurz vor Mitternacht gelandet ist, vergleicht dessen
+Zeitstempel mit diesen Grenzen.
+
+**Wenn die Zeitzonendatenbank fehlt**, weicht das Skript auf UTC aus; die
+Grenzen verschieben sich dann um ein bis zwei Stunden. Der Workflow installiert
+`tzdata` deshalb ausdrücklich. Sollte das einmal fehlschlagen, weist der Report
+sichtbar darauf hin, statt stillschweigend andere Grenzen zu verwenden. Die
+Auswirkung ist real: Für den 3. August 2026 liefert das UTC-Fenster sieben
+abgeschlossene Issues, das Berliner Fenster neun.
+
 ### Gliederung nach Epics
 
 Die Zusammenfassung folgt den Epics, weil diese die thematisch
@@ -77,8 +113,13 @@ Die Rohdaten jedes Tages liegen als JSON unter `data/` im Branch `gh-pages`.
 
 ## Bedienung
 
-Der Workflow läuft täglich um 04:30 UTC. Ein Lauf lässt sich jederzeit von Hand
-auslösen, wahlweise für einen bestimmten Tag:
+Der Workflow läuft täglich um 00:30 UTC. Die Uhrzeit ist ein Wunsch, keine
+Zusage: GitHub führt geplante Läufe bei Last auch mehrere Stunden später aus,
+beobachtet wurden bis zu dreieinhalb Stunden. Ein ausgefallener Tag holt sich
+nicht von selbst nach und muss von Hand nachgezogen werden.
+
+Ein Lauf lässt sich jederzeit von Hand auslösen, wahlweise für einen bestimmten
+Tag:
 
 ```bash
 # Vortag


### PR DESCRIPTION
## Zusammenfassung

Der geplante Lauf liegt jetzt auf **00:30 UTC** statt 04:30 UTC. Zusätzlich wird das verwendete Zeitfenster ausgewiesen, damit nachprüfbar ist, in welchem Report ein Vorgang von kurz vor Mitternacht gelandet ist.

## Wie der Berichtstag abgegrenzt wird

Maßgeblich ist der Zeitpunkt des **Ereignisses**, nicht der Anlage:

| Gruppe | Zeitstempel |
| --- | --- |
| Neu angelegte Issues | `created_at` |
| Abgeschlossene Issues | `closed_at` |
| Gemergte Pull Requests | `merged_at` |

Abgegrenzt wird nach `Europe/Berlin`, etwa `2026-08-03T00:00:00+02:00..2026-08-03T23:59:59+02:00`.

## Die Änderungen

**Nachprüfbarkeit.** Die Rohdaten führen `timezone`, `window_start` und `window_end`; der Fußbereich der Seite nennt Zeitraum und Zeitzone. Wer wissen will, wo ein Vorgang von 23:50 gelandet ist, vergleicht dessen Zeitstempel mit diesen Grenzen.

**Der UTC-Rückfall wird sichtbar.** Fehlt `tzdata`, weicht das Skript auf UTC aus — bisher nur auf der Fehlerausgabe vermerkt. Der Report weist jetzt sichtbar darauf hin. Die Auswirkung ist real: Für den 3. August liefert das UTC-Fenster **sieben** abgeschlossene Issues, das Berliner Fenster **neun**. Zwei Vorgänge lagen zwischen 00:00 und 02:00 Berliner Zeit.

## Was ich verworfen habe

Geplant war ein halboffenes Fenster (`>= Tagesbeginn`, `< Folgetag`), weil das eindeutiger ist als eine Grenze auf `23:59:59`. **Das funktioniert bei GitHub nicht.** Zwei Bereichsangaben zum selben Feld werden nicht verknüpft — die zweite verdrängt die erste:

```
merged:<2026-08-04T00:00:00+02:00                                    -> 118
merged:>=2026-08-03T00:00:00+02:00 merged:<2026-08-04T00:00:00+02:00 -> 118
korrekt (Bereichsoperator)                                           ->   9
```

Der Bereichsoperator bleibt daher unverändert; der Grund steht jetzt als Kommentar im Code, damit es niemand erneut versucht. Da die Zeitstempel der API sekundengenau sind, entsteht zum Folgetag ohnehin keine Lücke.

## Prüfung

- Alte und neue Suchsyntax gegen die echten Daten des 3. August verglichen — dabei fiel die Abweichung auf
- Zeitfenster, Zeitzone und Warnhinweis erscheinen korrekt im Fußbereich
- Reports im alten Format ohne die neuen Felder rendern weiterhin, der Hinweis entfällt dann
- YAML validiert, Cron steht auf `30 0 * * *`

## Hinweis zur Pünktlichkeit

Die Uhrzeit ist ein Wunsch, keine Zusage — beide bisherigen Läufe kamen rund drei Stunden später. Ein ausgefallener Tag holt sich nicht von selbst nach. Beides ist jetzt in `docs/tagesreport.md` vermerkt.

## Zugehörige Issues

Closes #312

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [x] Tests bestehen lokal (keine Anwendungsänderung; gegen die echten Daten geprüft, YAML validiert)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [ ] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _______)
- [x] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF