### PR TITLE
fix(api): ResponseStatusException und DataIntegrityViolationException im GlobalExceptionHandler abbilden

### DIFF
--- a/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/opaa/api/GlobalExceptionHandler.java
@@ -1,23 +1,33 @@
 package io.opaa.api;
 
 import io.opaa.api.dto.ErrorResponse;
+import java.sql.SQLException;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.ai.retry.TransientAiException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  // SQLSTATE codes of class 23 (integrity constraint violation), see SQL standard / PostgreSQL.
+  private static final String SQLSTATE_NOT_NULL_VIOLATION = "23502";
+  private static final String SQLSTATE_FOREIGN_KEY_VIOLATION = "23503";
+  private static final String SQLSTATE_UNIQUE_VIOLATION = "23505";
+  private static final String SQLSTATE_CHECK_VIOLATION = "23514";
 
   // Instantiated directly to keep it out of the Spring context and avoid
   // forcing every @WebMvcTest to import the bean.
@@ -76,6 +86,61 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
     return ResponseEntity.status(HttpStatus.FORBIDDEN)
         .body(new ErrorResponse("Zugriff verweigert", HttpStatus.FORBIDDEN.value(), Instant.now()));
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
+    HttpStatusCode status = ex.getStatusCode();
+    if (status.is5xxServerError()) {
+      log.error("Server error raised by application", ex);
+    }
+    String message = ex.getReason() != null ? ex.getReason() : defaultMessageFor(status);
+    return ResponseEntity.status(status)
+        .body(new ErrorResponse(message, status.value(), Instant.now()));
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+      DataIntegrityViolationException ex) {
+    // The constraint name belongs in the log, never in the response.
+    log.warn("Data integrity violation", ex);
+
+    String sqlState = findSqlState(ex);
+    HttpStatus status = HttpStatus.CONFLICT;
+    String message;
+    switch (sqlState == null ? "" : sqlState) {
+      case SQLSTATE_UNIQUE_VIOLATION -> message = "Ein Eintrag mit diesen Werten existiert bereits";
+      case SQLSTATE_FOREIGN_KEY_VIOLATION ->
+          message =
+              "Der Datensatz wird noch verwendet und kann nicht geändert oder gelöscht werden";
+      case SQLSTATE_NOT_NULL_VIOLATION, SQLSTATE_CHECK_VIOLATION -> {
+        // Malformed input rather than a conflict with existing data.
+        status = HttpStatus.BAD_REQUEST;
+        message = "Die übergebenen Daten sind unvollständig oder ungültig";
+      }
+      default -> message = "Die Aktion widerspricht bestehenden Daten und wurde nicht ausgeführt";
+    }
+    return ResponseEntity.status(status)
+        .body(new ErrorResponse(message, status.value(), Instant.now()));
+  }
+
+  private String defaultMessageFor(HttpStatusCode status) {
+    if (status.is5xxServerError()) {
+      return "Interner Serverfehler";
+    }
+    return "Die Anfrage konnte nicht verarbeitet werden";
+  }
+
+  private String findSqlState(Throwable ex) {
+    for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+      if (cause instanceof SQLException sqlException && sqlException.getSQLState() != null) {
+        return sqlException.getSQLState();
+      }
+      if (cause.getCause() == cause) {
+        break;
+      }
+    }
+    return null;
   }
 
   @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/io/opaa/api/GlobalExceptionHandlerTest.java
@@ -1,12 +1,17 @@
 package io.opaa.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opaa.api.dto.ErrorResponse;
+import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.ai.retry.TransientAiException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 class GlobalExceptionHandlerTest {
 
@@ -62,5 +67,100 @@ class GlobalExceptionHandlerTest {
     ErrorResponse body = response.getBody();
     assertNotNull(body);
     assertEquals("bad input", body.getError());
+  }
+
+  @Test
+  void handleResponseStatusExceptionKeepsStatusAndReason() {
+    var response =
+        handler.handleResponseStatusException(
+            new ResponseStatusException(HttpStatus.NOT_FOUND, "Space nicht gefunden"));
+    assertEquals(404, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals(404, body.getStatus());
+    assertEquals("Space nicht gefunden", body.getError());
+    assertNotNull(body.getTimestamp());
+  }
+
+  @Test
+  void handleResponseStatusExceptionWithoutReasonUsesFallbackMessage() {
+    var response =
+        handler.handleResponseStatusException(new ResponseStatusException(HttpStatus.CONFLICT));
+    assertEquals(409, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals("Die Anfrage konnte nicht verarbeitet werden", body.getError());
+  }
+
+  @Test
+  void handleResponseStatusExceptionWithServerErrorUsesGenericMessage() {
+    var response =
+        handler.handleResponseStatusException(
+            new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
+    assertEquals(500, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals("Interner Serverfehler", body.getError());
+  }
+
+  @Test
+  void handleDataIntegrityViolationExceptionReturnsConflictForForeignKeyViolation() {
+    var response =
+        handler.handleDataIntegrityViolationException(
+            dataIntegrityViolation(
+                "23503",
+                "update or delete on table \"groups\" violates foreign key constraint"
+                    + " \"fk_library_grant_group\""));
+    assertEquals(409, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals(409, body.getStatus());
+    assertEquals(
+        "Der Datensatz wird noch verwendet und kann nicht geändert oder gelöscht werden",
+        body.getError());
+    assertFalse(body.getError().contains("fk_library_grant_group"));
+  }
+
+  @Test
+  void handleDataIntegrityViolationExceptionReturnsConflictForUniqueViolation() {
+    var response =
+        handler.handleDataIntegrityViolationException(
+            dataIntegrityViolation(
+                "23505", "duplicate key value violates unique constraint \"uk_group_name\""));
+    assertEquals(409, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals("Ein Eintrag mit diesen Werten existiert bereits", body.getError());
+    assertFalse(body.getError().contains("uk_group_name"));
+  }
+
+  @Test
+  void handleDataIntegrityViolationExceptionReturnsBadRequestForNotNullViolation() {
+    var response =
+        handler.handleDataIntegrityViolationException(
+            dataIntegrityViolation(
+                "23502", "null value in column \"name\" violates not-null constraint"));
+    assertEquals(400, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals("Die übergebenen Daten sind unvollständig oder ungültig", body.getError());
+  }
+
+  @Test
+  void handleDataIntegrityViolationExceptionWithoutSqlStateReturnsConflict() {
+    var response =
+        handler.handleDataIntegrityViolationException(
+            new DataIntegrityViolationException("could not execute statement"));
+    assertEquals(409, response.getStatusCode().value());
+    ErrorResponse body = response.getBody();
+    assertNotNull(body);
+    assertEquals(
+        "Die Aktion widerspricht bestehenden Daten und wurde nicht ausgeführt", body.getError());
+  }
+
+  private DataIntegrityViolationException dataIntegrityViolation(String sqlState, String message) {
+    return new DataIntegrityViolationException(
+        "could not execute statement",
+        new RuntimeException(message, new SQLException(message, sqlState)));
   }
 }


### PR DESCRIPTION
## Zusammenfassung

`GlobalExceptionHandler` ließ zwei häufige Ausnahmen auf den Catch-all-Handler fallen, sodass sie als HTTP 500 „Interner Serverfehler" beim Aufrufer ankamen:

- **`ResponseStatusException`** — wird jetzt mit ihrem gesetzten Status und ihrer Meldung durchgereicht. Fehlt der Reason, greift eine verständliche Ersatzmeldung; 5xx-Fälle werden weiterhin geloggt.
- **`DataIntegrityViolationException`** — wird anhand des SQLSTATE der zugrundeliegenden `SQLException` unterschieden, statt pauschal alles als Konflikt zu behandeln:
  - `23505` (Unique) und `23503` (Fremdschlüssel) → **409 Conflict**
  - `23502` (Not-Null) und `23514` (Check) → **400 Bad Request**, da das fehlerhafte Eingabedaten sind und kein Konflikt mit Bestandsdaten
  - unbekannt/kein SQLSTATE → 409 mit allgemeiner Meldung

Der Constraint-Name erscheint ausschließlich im Log, nie in der Antwort. Die bestehenden gezielten Guards an den Aufrufstellen bleiben unverändert — diese Änderung ist das Sicherheitsnetz darunter für künftige `RESTRICT`-Fremdschlüssel.

## Zugehörige Issues

Closes #310

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Opus 5 / Claude Code)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzEd5z6cNCgQkUV8Y61zaF
