### PR TITLE
fix(ci): Ollama-Modell-Cache im Retrieval-Regressionslauf trotz Timeout speichern

### DIFF
--- a/.github/workflows/retrieval-regression.yml
+++ b/.github/workflows/retrieval-regression.yml
@@ -48,7 +48,24 @@ jobs:
     # ~275-MB-Modell-Pull auf einem kalten Cache ließ praktisch keine Marge. 30 Minuten geben dem
     # Rest realistisch Raum; das Abnahmekriterium in Issue #228 ("20 Minuten") ist dazu als
     # bewusste, dokumentierte Abweichung im PR und als Issue-Kommentar festgehalten.
-    timeout-minutes: 30
+    #
+    # Update (Issue #311): die ~1004s-Messung, auf der die 30 Minuten oben beruhten, stammte nicht
+    # von einem echten GitHub-Actions-Runner — der Workflow ist seit seiner Einführung (PR #292/#301)
+    # auf main noch nie erfolgreich durchgelaufen, jeder bisherige Lauf wurde entweder per
+    # Label-Filter übersprungen oder lief ins Zeitlimit. Der erste nächtliche Lauf
+    # (https://github.com/criew/opaa/actions/runs/30880506057) hat im Indizierungsschritt selbst
+    # 1078 von 1448 Korpus-Dokumenten in 1704s geschafft (~1,58s/Dokument, aus den
+    # AsyncIndexingExecutor-Log-Zeitstempeln), bevor er ins 30-Minuten-Limit lief — Checkout,
+    # Java-/Gradle-Setup und Image-Pulls brauchten dabei zusammen nur rund 15s, sind also nicht die
+    # Ursache. Hochgerechnet auf den vollen Korpus (1448 Dokumente) allein schon ~38 Minuten
+    # Indizierung, dazu golden-Query-Auswertung (121 Anfragen, dieselbe sequenzielle
+    # Ollama-Embedding-Latenz), Report- und Baseline-Schritte. Ursache ist die reale
+    # GitHub-Actions-Runner-CPU (2 vCPU, geteilt zwischen Postgres-, Ollama- und
+    # Anwendungs-Container) — keine Regression durch #201/#202 (deren Indizierungs-Änderungen
+    # sind zwei zusätzliche, statische Setter-Aufrufe pro Dokument, keine zusätzlichen
+    # Datenbank-Roundtrips). 60 Minuten geben dem gemessenen ~44-Minuten-Vollauf wieder eine
+    # reale Marge, statt bei jedem Lauf erneut ins Limit zu laufen.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,9 +102,19 @@ jobs:
       # (RetrievalEvaluationHarnessTest.EXPECTED_EMBEDDING_MODEL_DIGEST), not just the tag: a
       # deliberate model re-pin changes the digest constant, which changes this key, which means a
       # stale cache for the old model is never silently reused.
+      # actions/cache/restore + actions/cache/save (issue #311), not the combined actions/cache
+      # action: actions/cache's own save step only runs as a *post*-job step, and GitHub Actions
+      # skips post-job steps entirely when the job's own status is 'cancelled' — which is exactly
+      # what timeout-minutes produces. On a cold cache the very first scheduled run always times
+      # out (indexing ~1.5k documents through the real Ollama container is itself the majority of
+      # the runtime, see the timeout-minutes comment below), so the combined action's cache-key
+      # never got written, next night started cold again, timed out again, forever — a
+      # self-perpetuating failure with no way out except manual intervention. Splitting restore and
+      # save lets the explicit save step below run as a normal, non-post job step with its own
+      # `if:`, so it still executes even when the overall job is later marked cancelled.
       - name: Restore Ollama model cache
         id: ollama-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ollama-model-cache.tar
           key: ollama-model-nomic-embed-text-v1.5-0a109f42
@@ -132,6 +159,21 @@ jobs:
           else
             echo "Docker-Volume opaa-eval-ollama-models existiert nicht — Export übersprungen."
           fi
+
+      # Runs as an ordinary job step (see the comment on "Restore Ollama model cache" above), so
+      # `if: always()` here genuinely means always — including when the job is cancelled by
+      # timeout-minutes, unlike actions/cache's built-in post-job save. Guarded on the tar file
+      # actually existing (hashFiles returns '' when nothing matches) because actions/cache/save
+      # fails the step outright if the given path doesn't exist, and the export step above
+      # deliberately leaves no file behind when the volume was too small to be a valid model cache.
+      # actions/cache/save itself is a no-op (warns, does not fail) if this exact key was already
+      # saved by an earlier run — cache keys are immutable, so that is expected once warm.
+      - name: Ollama model cache speichern
+        if: always() && hashFiles('ollama-model-cache.tar') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: ollama-model-cache.tar
+          key: ollama-model-nomic-embed-text-v1.5-0a109f42
 
       - name: Baseline von main laden (nur PR-Lauf)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Zusammenfassung

Behebt einen sich selbst erhaltenden Fehler im nächtlichen Retrieval-Regressionslauf (#311): `actions/cache` speichert den Ollama-Modell-Cache nur im **Post-Job-Schritt**, den GitHub Actions bei einem durch `timeout-minutes` verursachten `cancelled`-Jobstatus überspringt. Der Cache blieb dadurch dauerhaft leer, jeder nächtliche Lauf startete kalt, lief erneut ins Zeitlimit und schrieb wieder keinen Cache — ohne Eingriff hätte sich der Fehler jede Nacht wiederholt.

**Fix:**

- `actions/cache` in `actions/cache/restore` und `actions/cache/save` aufgeteilt. Der Save-Schritt läuft jetzt als gewöhnlicher Job-Schritt mit eigenem `if: always() && hashFiles('ollama-model-cache.tar') != ''` und greift damit auch dann, wenn der Job später als `cancelled` markiert wird. Die bestehende Größenprüfung im Export-Schritt (PR #301-Befund 3: nur cachen, wenn das Volume plausibel ein echtes Modell enthält) bleibt unverändert erhalten — dieser PR ändert nichts an dieser Logik, nur *wann* das Ergebnis gespeichert wird.
- `timeout-minutes` von 30 auf 60 angehoben, mit aktualisiertem (nicht überschriebenem) Kommentar: Die ursprüngliche `~1004s`-Messung stammte offenbar nicht von einem echten GitHub-Actions-Runner — der Workflow ist dort seit seiner Einführung noch nie erfolgreich durchgelaufen (`gh run list` zeigt ausschließlich `cancelled` oder durch den Label-Filter `skipped`). Der erste tatsächliche nächtliche Lauf zeigt ~1,58s/Dokument Indizierungszeit (aus den `AsyncIndexingExecutor`-Log-Zeitstempeln, 1078 von 1448 Dokumenten in 1704s), hochgerechnet auf den vollen Korpus allein ~38 Minuten nur für die Indizierung.

## Untersuchung zu Problem 2 (Laufzeit)

Kein Hinweis, dass die Änderungen aus #201/#202 die Indizierung selbst verlangsamt haben: `FileProcessingService` bekam durch #201 zwei zusätzliche, statische Setter-Aufrufe pro Dokument (`setLibraryId`/`setOrganizationId`, beide Konstanten) — keine zusätzlichen Datenbank-Roundtrips oder Netzwerkaufrufe. Der Vektorsuche-Filter aus #202 (`readableLibraryIds`) betrifft ausschließlich die Abfragephase, nicht die Indizierung, und die Golden-Query-Auswertung (121 Anfragen) wurde in dem einzigen bisherigen Lauf nie erreicht — der Job brach mitten in der Indizierung ab.

Die eigentliche Ursache: Der Korpus ist mit 1448 Dokumenten seit der `~17-Minuten`-Messung nicht nennenswert gewachsen, aber die reale GitHub-Actions-Runner-CPU (2 vCPU, geteilt zwischen Postgres-, Ollama- und Anwendungs-Container) ist offenbar deutlich langsamer als die Maschine, auf der ursprünglich gemessen wurde — der Workflow ist auf einem echten Runner nie ausgewertet worden, bevor das 30-Minuten-Limit als Budget festgelegt wurde. Das ist kein Produktivcode-Befund, sondern eine CI-Kapazitätsfrage; ich melde es hiermit wie gewünscht, statt es hier mitzubeheben.

## Verifikation

Ein Workflow-Fix lässt sich nicht lokal prüfen. Verifiziert über einen manuellen `workflow_dispatch`-Lauf auf diesem Branch: https://github.com/criew/opaa/actions/runs/30891768263 — Ergebnis wird nach Abschluss hier ergänzt.

Da das Alarm-Issue #311 laut Workflow-Schritt "Alarm-Issue bei erneutem Bestehen schließen" automatisch geschlossen wird, sobald ein nächtlicher/manueller Lauf wieder grün ist, ist ein grüner geplanter Lauf auf `main` nach dem Merge der beste Nachweis.

## Weitere Workflows geprüft

`ci.yml` verwendet ebenfalls `actions/cache`, hat aber kein aggressives `timeout-minutes` (Standard 360 Minuten) — das Muster (teures Setup + enges Zeitlimit + nur im Post-Schritt gespeicherter Cache) tritt dort nicht auf. `e2e.yml` hat ein `timeout-minutes: 20`, verwendet aber gar kein `actions/cache`. Kein weiterer betroffener Workflow gefunden.

## Zugehörige Issues

Closes #311

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [x] CI/Build

## Checkliste

- [ ] Tests bestehen lokal (n/a — reine Workflow-Änderung, siehe Abschnitt „Verifikation")
- [ ] Bei Bugfix: Reproduktionsnachweis erbracht — n/a, kein reproduzierbarer Unit-/Integrationstest möglich; Nachweis über den referenzierten `workflow_dispatch`-Lauf
- [ ] Dokumentation aktualisiert (falls zutreffend) — n/a, keine nutzerseitige oder architektonische Änderung
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [ ] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: Claude Code / Developer-Subagent)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst