### PR TITLE
fix(group): Race auf uk_directory_sync_status_organization behandeln

### DIFF
--- a/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
+++ b/backend/src/main/java/io/opaa/group/sync/DirectorySyncStatusRecorder.java
@@ -1,9 +1,10 @@
 package io.opaa.group.sync;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Persists the outcome of a directory synchronisation run. Called only from {@link
@@ -26,17 +27,83 @@ public class DirectorySyncStatusRecorder {
     this.statusRepository = statusRepository;
   }
 
-  @Transactional
+  /**
+   * Deliberately <b>not</b> {@code @Transactional} (#300). Each {@link
+   * DirectorySyncStatusRepository} call below already runs in its own implicit transaction (Spring
+   * Data's {@code SimpleJpaRepository} methods are individually {@code @Transactional}), so no
+   * explicit demarcation is needed - and one here would actively break {@link
+   * #insertOrUpdateOnRaceLost}: inside a shared, still-open transaction the failed insert marks
+   * that transaction rollback-only, so the fallback read would run on a poisoned transaction and
+   * the caller would still see an exception instead of a recorded status. The same reasoning as
+   * {@code UserService#findOrCreateUser} (#293), which handles the identical race on {@code
+   * uq_users_subject_issuer}.
+   *
+   * <p>Note that the alternative of an inner {@code REQUIRES_NEW} transaction for the insert
+   * attempt is deliberately <em>not</em> used: that construction has caused a defect twice in this
+   * project already (#280's foreign-key violation against an uncommitted {@code users} row, #297's
+   * status write committing ahead of an apply that later rolled back), and it would additionally
+   * make each caller hold two connections at once - the pool-exhaustion mode found in the review of
+   * #299.
+   *
+   * <p>Two callers updating an <em>existing</em> row concurrently remain last-writer-wins. That is
+   * the intended semantics of a table holding "the outcome of the most recent run" and is unchanged
+   * by this fix; the unserialised concurrent runs behind it are the known gap documented in {@link
+   * DirectorySyncService}'s class javadoc.
+   */
   public void record(
       UUID organizationId,
       Instant runAt,
       DirectorySyncOutcome outcome,
       String message,
       double changedFraction) {
-    DirectorySyncStatus status =
-        statusRepository
-            .findByOrganizationId(organizationId)
-            .orElseGet(() -> new DirectorySyncStatus(organizationId));
+    Optional<DirectorySyncStatus> existing = statusRepository.findByOrganizationId(organizationId);
+    if (existing.isPresent()) {
+      updateExisting(existing.get(), runAt, outcome, message, changedFraction);
+      return;
+    }
+    insertOrUpdateOnRaceLost(organizationId, runAt, outcome, message, changedFraction);
+  }
+
+  /**
+   * Creates the organization's status row, tolerating the race of two concurrent <em>first</em>
+   * runs for the same organization getting past the {@code findByOrganizationId} check in {@link
+   * #record} together (#300). Only the first run of an organization can reach this method at all;
+   * every later run takes {@link #record}'s update branch.
+   *
+   * <p>Because {@link #record} is deliberately not {@code @Transactional} (see its javadoc), the
+   * {@code saveAndFlush} below runs in its own short-lived, implicit transaction. A {@link
+   * DataIntegrityViolationException} on {@code uk_directory_sync_status_organization} rolls back
+   * only that insert; nothing else is poisoned by it, so the loser of the race can simply update
+   * the row the winner has by now committed instead of surfacing the violation to {@code
+   * DirectorySyncService.recordStatusSafely}, where it would be logged and the run's outcome lost.
+   * Same fallback-read pattern as {@code UserService#createOrFetchUser} (#293).
+   */
+  private void insertOrUpdateOnRaceLost(
+      UUID organizationId,
+      Instant runAt,
+      DirectorySyncOutcome outcome,
+      String message,
+      double changedFraction) {
+    DirectorySyncStatus status = new DirectorySyncStatus(organizationId);
+    status.recordRun(runAt, outcome, message, changedFraction);
+    try {
+      // saveAndFlush forces the INSERT to execute (and thus to fail, if it must) here, instead of
+      // being deferred to a later flush point where the DataIntegrityViolationException could
+      // surface somewhere other than this try block.
+      statusRepository.saveAndFlush(status);
+    } catch (DataIntegrityViolationException raceLost) {
+      DirectorySyncStatus winner =
+          statusRepository.findByOrganizationId(organizationId).orElseThrow(() -> raceLost);
+      updateExisting(winner, runAt, outcome, message, changedFraction);
+    }
+  }
+
+  private void updateExisting(
+      DirectorySyncStatus status,
+      Instant runAt,
+      DirectorySyncOutcome outcome,
+      String message,
+      double changedFraction) {
     status.recordRun(runAt, outcome, message, changedFraction);
     statusRepository.save(status);
   }

--- a/backend/src/test/java/io/opaa/group/sync/DirectorySyncStatusRecorderRaceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/group/sync/DirectorySyncStatusRecorderRaceIntegrationTest.java
@@ -1,0 +1,148 @@
+package io.opaa.group.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opaa.TestcontainersConfiguration;
+import io.opaa.organization.Organization;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Exercises the race described in #300: two or more concurrent <em>first</em> synchronisation runs
+ * of the same organization reaching {@link DirectorySyncStatusRecorder#record} together, before
+ * either has committed the organization's single {@code directory_sync_status} row. Nothing
+ * serialises concurrent runs today (see {@link DirectorySyncService}'s class javadoc), so two
+ * administrators triggering a first run at the same time is constructible, if rare.
+ *
+ * <p>Runs against a real Postgres instance with the real, versioned Liquibase schema ({@code
+ * spring.liquibase.enabled=true}, {@code ddl-auto=none}) and real threads, following {@code
+ * UserServiceCreationRaceIntegrationTest}'s pattern - a mocked transaction manager would only
+ * exercise the catch block and not the propagation and visibility semantics the fix depends on,
+ * which is precisely where the two previous attempts at this class of fix went wrong (#280, #297).
+ *
+ * <p>Before the fix, {@link #concurrentFirstRunsOfTheSameOrganizationRecordExactlyOneStatusRow()}
+ * fails: the losers of the race throw {@link
+ * org.springframework.dao.DataIntegrityViolationException} with {@code duplicate key value violates
+ * unique constraint "uk_directory_sync_status_organization"}, because {@code record} checked for an
+ * existing row and inserted a new one without handling the unique-constraint race between the two.
+ *
+ * <p>The assertion is made on {@code record} directly rather than through {@link
+ * DirectorySyncService#run}: {@code recordStatusSafely} deliberately swallows and logs any failure
+ * here (see its javadoc), so a run driven end to end would report success while silently losing the
+ * status line - the exact outcome this test must be able to see.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles({"local", "basic"})
+@TestPropertySource(
+    properties = "OPAA_AUTH_BASIC_SECRET=test-only-secret-not-used-for-anything-sensitive-1234")
+@Testcontainers(disabledWithoutDocker = true)
+class DirectorySyncStatusRecorderRaceIntegrationTest {
+
+  /**
+   * Above 2 so the losing side of the race is hit reliably rather than only when the operating
+   * system happens to schedule two threads adversarially, and below Hikari's default {@code
+   * maximum-pool-size} of 10 is not required: {@code record} is deliberately not
+   * {@code @Transactional} (see its javadoc), so no caller ever holds more than one connection at a
+   * time and the threads cannot deadlock the pool the way #299's review found for the {@code
+   * REQUIRES_NEW} construction.
+   */
+  private static final int CONCURRENT_RUNS = 8;
+
+  @Autowired private DirectorySyncStatusRecorder statusRecorder;
+  @Autowired private DirectorySyncStatusRepository statusRepository;
+
+  @BeforeEach
+  void cleanUp() {
+    statusRepository.deleteAll();
+  }
+
+  @Test
+  void concurrentFirstRunsOfTheSameOrganizationRecordExactlyOneStatusRow() throws Exception {
+    UUID organizationId = Organization.DEFAULT_ID;
+    Instant runAt = Instant.now();
+
+    CountDownLatch ready = new CountDownLatch(CONCURRENT_RUNS);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_RUNS);
+    try {
+      List<Callable<Void>> runs =
+          Stream.generate(() -> recordTask(organizationId, runAt, ready, start))
+              .limit(CONCURRENT_RUNS)
+              .toList();
+
+      List<Future<Void>> futures = runs.stream().map(executor::submit).toList();
+      ready.await();
+      start.countDown();
+
+      for (Future<Void> future : futures) {
+        // Any DataIntegrityViolationException on uk_directory_sync_status_organization surfaces
+        // here as a reproduction of #300 (see the class javadoc) - none of the calls may fail.
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    List<DirectorySyncStatus> persisted = statusRepository.findAll();
+    assertThat(persisted).hasSize(1);
+    DirectorySyncStatus status = persisted.getFirst();
+    assertThat(status.getOrganizationId()).isEqualTo(organizationId);
+    assertThat(status.getLastOutcome()).isEqualTo(DirectorySyncOutcome.APPLIED);
+    assertThat(status.getLastRunAt()).isNotNull();
+    // recordRun advances lastAppliedAt only for APPLIED - the loser of the race must go through it
+    // too, not just write the row's insert-time state.
+    assertThat(status.getLastAppliedAt()).isNotNull();
+    assertThat(status.getLastMessage()).isEqualTo("Race");
+  }
+
+  @Test
+  void subsequentRunsUpdateTheExistingRowInsteadOfInsertingASecondOne() {
+    UUID organizationId = Organization.DEFAULT_ID;
+    Instant firstRun = Instant.now();
+
+    statusRecorder.record(
+        organizationId, firstRun, DirectorySyncOutcome.APPLIED, "Erster Lauf", 0.1);
+    statusRecorder.record(
+        organizationId,
+        firstRun.plusSeconds(60),
+        DirectorySyncOutcome.UNREACHABLE,
+        "Zweiter Lauf",
+        0.0);
+
+    List<DirectorySyncStatus> persisted = statusRepository.findAll();
+    assertThat(persisted).hasSize(1);
+    DirectorySyncStatus status = persisted.getFirst();
+    assertThat(status.getLastOutcome()).isEqualTo(DirectorySyncOutcome.UNREACHABLE);
+    assertThat(status.getLastMessage()).isEqualTo("Zweiter Lauf");
+    // lastAppliedAt is the timestamp of the last run that actually changed rights, so the later
+    // UNREACHABLE run must not advance it past the earlier APPLIED one.
+    assertThat(status.getLastAppliedAt()).isBefore(status.getLastRunAt());
+  }
+
+  private Callable<Void> recordTask(
+      UUID organizationId, Instant runAt, CountDownLatch ready, CountDownLatch start) {
+    return () -> {
+      ready.countDown();
+      start.await();
+      statusRecorder.record(organizationId, runAt, DirectorySyncOutcome.APPLIED, "Race", 0.25);
+      return null;
+    };
+  }
+}


### PR DESCRIPTION
## Zusammenfassung

`DirectorySyncStatusRecorder.record` folgte dem Muster `findByOrganizationId(...).orElseGet(() -> new DirectorySyncStatus(...))` gegen die Unique-Constraint `uk_directory_sync_status_organization`, ohne das Fenster zwischen Prüfung und Anlage abzusichern. Zwei gleichzeitige **Erstläufe** derselben Organisation liefen damit in eine `DataIntegrityViolationException`. Da `DirectorySyncService.recordStatusSafely` Fehler bewusst nur protokolliert (bewusste Entscheidung aus #297), ging die Statuszeile dabei still verloren — der Lauf meldete Erfolg, die Statustabelle blieb leer.

Behoben mit demselben Muster wie `UserService.findOrCreateUser` (#293) und `SpaceService.ensurePersonalSpace` (#265): Insert-Versuch per `saveAndFlush`, bei Constraint-Verletzung die inzwischen committete Zeile neu lesen und aktualisieren. Nur der allererste Lauf einer Organisation erreicht diesen Pfad überhaupt; jeder spätere Lauf nimmt den Update-Zweig.

**Zur in #300 geforderten Prüfung der `REQUIRES_NEW`-Historie:** `record` ist nicht mehr `@Transactional`, und es wird auch keine innere `REQUIRES_NEW`-Transaktion eingeführt.

- Ohne Entfernung der Annotation würde der fehlgeschlagene Insert die gemeinsame, noch offene Transaktion als rollback-only markieren — das Nachlesen liefe auf einer vergifteten Transaktion und der Aufrufer sähe weiterhin eine Exception.
- `REQUIRES_NEW` scheidet aus zwei Gründen aus: Die Konstruktion hat in #280 (Fremdschlüsselverletzung gegen eine noch nicht committete `users`-Zeile) und #297 (Statuswrite committete vor einem später zurückgerollten Apply) je einen Fehler verursacht, und sie ließe jeden Aufrufer zwei Verbindungen gleichzeitig halten — die Pool-Erschöpfung aus dem Review zu #299.
- Die Entfernung ist gefahrlos: `DirectorySyncService` trägt nirgends `@Transactional` (siehe dessen Klassen-Javadoc), es gab hier also nie einen umgebenden Transaktionskontext. Jeder einzelne Repository-Aufruf läuft weiterhin in seiner eigenen impliziten Transaktion.

Die in #300 alternativ erwogene Serialisierung gleichzeitiger Läufe per Advisory-Lock ist **nicht** enthalten: Sie wäre eine Verhaltensänderung an `DirectorySyncService.run` mit eigenem Testbedarf und würde das dort dokumentierte Fenster zwischen Verzeichnisabruf und Anwendung mitbetreffen — ein eigener Vorgang, nicht dieser Bugfix.

Nicht geändert: Zwei Läufe, die eine **bestehende** Zeile gleichzeitig aktualisieren, bleiben last-writer-wins. Das ist die beabsichtigte Semantik einer Tabelle, die „das Ergebnis des letzten Laufs" hält.

## Zugehörige Issues

Closes #300

## Art der Änderung

- [x] Bugfix
- [ ] Neues Feature
- [ ] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal
- [x] Bei Bugfix: Reproduktionsnachweis erbracht — der Test schlägt auf dem fehlerhaften Stand fehl und besteht mit dem Fix (rote Fehlermeldung unten einfügen)
- [x] Dokumentation aktualisiert (falls zutreffend)
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA unterzeichnet (Erstbeitragende: Unterzeichnungskommentar unten posten, oder wurde bereits unterzeichnet)

### Reproduktionsnachweis

Neuer Test `DirectorySyncStatusRecorderRaceIntegrationTest` — echte Threads (8 gleichzeitige Erstläufe) gegen ein echtes Postgres mit dem versionierten Liquibase-Schema (`spring.liquibase.enabled=true`, `ddl-auto=none`).

Auf dem fehlerhaften Stand (nur der Test, ohne die Änderung an `DirectorySyncStatusRecorder`):

```
DirectorySyncStatusRecorderRaceIntegrationTest > concurrentFirstRunsOfTheSameOrganizationRecordExactlyOneStatusRow() FAILED
    java.util.concurrent.ExecutionException
        Caused by: org.springframework.dao.DataIntegrityViolationException
            Caused by: org.hibernate.exception.ConstraintViolationException
                Caused by: org.postgresql.util.PSQLException:
                    FEHLER: duplicate key value violates unique constraint "uk_directory_sync_status_organization"

2 tests completed, 1 failed
```

Mit dem Fix: `BUILD SUCCESSFUL`. Ebenso `./gradlew spotlessApply build` (gesamte Backend-Suite) grün.

Der Test greift bewusst direkt auf `record` zu statt über `DirectorySyncService.run`: `recordStatusSafely` schluckt und protokolliert jeden Fehler hier, ein End-to-End-Lauf würde also Erfolg melden und genau das Symptom verdecken, das nachzuweisen ist.

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: _Claude Opus 5 via Claude Code_)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
