### PR TITLE
feat(library): Rechtemodell verschlanken — Asset-Rolle USER und Gruppenrollen streichen

### DIFF
--- a/backend/src/main/java/io/opaa/library/AssetRole.java
+++ b/backend/src/main/java/io/opaa/library/AssetRole.java
@@ -7,16 +7,15 @@ package io.opaa.library;
  * so "I have admin rights here" always refers to a space and "I have manager/owner rights" always
  * refers to an asset.
  *
- * <p>Declared in ascending order so {@link #atLeast(AssetRole)} can compare via {@link #ordinal()};
- * the separation between {@link #USER} (use without seeing configuration) and {@link #VIEWER} (see
- * configuration) is the feature's central gain - a vetted agent or library can be rolled out widely
- * without exposing its sources to every user of it.
+ * <p>Declared in ascending order so {@link #atLeast(AssetRole)} can compare via {@link #ordinal()}.
+ *
+ * <p>An earlier draft placed a {@code USER} rank below {@link #VIEWER} that allowed using an asset
+ * without seeing its configuration. It was dropped in #330: for an agent the guarantee is not
+ * enforceable, because whoever may invoke it can ask it for its own instructions, and for a library
+ * it runs largely empty, because cited answers expose the document titles anyway.
  */
 public enum AssetRole {
-  /** Use the asset (query a library, invoke an agent) without seeing its configuration. */
-  USER,
-
-  /** Additionally see the configuration: description, bound libraries, document list. */
+  /** Use the asset (query a library, invoke an agent) and see its configuration. */
   VIEWER,
 
   /** Additionally change the configuration. */

--- a/backend/src/main/resources/db/changelog/changes/014-drop-asset-role-user.yaml
+++ b/backend/src/main/resources/db/changelog/changes/014-drop-asset-role-user.yaml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  # Two changeSets, in dependency order, removing the AssetRole.USER rank (#330, see
+  # docs/features/spaces-and-assets.md#asset-rollen):
+  #   1. 014-promote-user-grants-to-viewer - existing grants are lifted before the constraint
+  #                                          narrows, otherwise the ALTER fails on live data
+  #   2. 014-narrow-asset-role-check       - the check constraint stops accepting 'USER'
+  #
+  # Rollback order (reverse of apply order):
+  # 014-narrow-asset-role-check
+  # 014-promote-user-grants-to-viewer
+
+  - changeSet:
+      id: 014-promote-user-grants-to-viewer
+      author: opaa
+      comment: >
+        Lift every existing AssetRole.USER grant to VIEWER. The USER rank allowed using an asset
+        without seeing its configuration; it is dropped because the guarantee is not enforceable for
+        an agent - whoever may invoke it can ask it for its own instructions - and runs largely
+        empty for a library, since cited answers expose the document titles anyway. Promoting rather
+        than deleting is deliberate: a holder of USER was meant to be able to use the asset, and
+        revoking that on migration would silently take working access away. VIEWER is the smallest
+        rank that preserves it.
+      changes:
+        - update:
+            tableName: asset_grants
+            columns:
+              - column:
+                  name: role
+                  value: "VIEWER"
+            where: role = 'USER'
+      rollback:
+        # Intentionally empty: which VIEWER grants were USER before is not recoverable, and the
+        # rank no longer exists to return them to. The narrowing changeSet below is the reversible
+        # half; this one is a one-way data lift.
+        - empty
+
+  - changeSet:
+      id: 014-narrow-asset-role-check
+      author: opaa
+      comment: >
+        Narrow chk_asset_grants_role to the four remaining AssetRole values. Note that
+        chk_asset_grants_subject_type keeps its own 'USER' value - that is PermissionSubjectType,
+        a different enum on a different column, and it is deliberately left untouched.
+      changes:
+        - sql:
+            comment: "Drop the five-value role check from migration 013"
+            sql: >
+              ALTER TABLE asset_grants
+              DROP CONSTRAINT chk_asset_grants_role;
+        - sql:
+            comment: "Re-add it without 'USER' - AssetRole, disjoint from SpaceRole"
+            sql: >
+              ALTER TABLE asset_grants
+              ADD CONSTRAINT chk_asset_grants_role
+              CHECK (role IN ('VIEWER', 'EDITOR', 'MANAGER', 'OWNER'));
+      rollback:
+        - sql:
+            sql: >
+              ALTER TABLE asset_grants
+              DROP CONSTRAINT chk_asset_grants_role;
+        - sql:
+            sql: >
+              ALTER TABLE asset_grants
+              ADD CONSTRAINT chk_asset_grants_role
+              CHECK (role IN ('USER', 'VIEWER', 'EDITOR', 'MANAGER', 'OWNER'));

--- a/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
+++ b/backend/src/test/java/io/opaa/library/KnowledgeLibraryServiceIntegrationTest.java
@@ -773,7 +773,7 @@ class KnowledgeLibraryServiceIntegrationTest {
         libraryService.createLibrary(new LibraryRequest("Rechtsquellen Soziales"), owner);
     grantService.upsertGrant(
         library.getId(),
-        new AssetGrantRequest(PermissionSubjectType.USER, reader, AssetRole.USER),
+        new AssetGrantRequest(PermissionSubjectType.USER, reader, AssetRole.VIEWER),
         owner,
         false);
 

--- a/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
+++ b/backend/src/test/java/io/opaa/library/LibraryAccessServiceTest.java
@@ -142,15 +142,18 @@ class LibraryAccessServiceTest {
   }
 
   @Test
-  void aUserOnlyGrantDoesNotAllowReadingConfiguration() {
-    // #202's central distinction: USER can use the asset but not see its configuration.
+  void theLowestGrantAllowsReadingButNotManaging() {
+    // #330 dropped the USER rank that sat below VIEWER, so the lowest grant that still exists
+    // carries read access to the configuration. Replaces aUserOnlyGrantDoesNotAllowReadingConfigu-
+    // ration, which asserted exactly the distinction that was removed.
     UUID libraryId = UUID.randomUUID();
     KnowledgeLibrary library = privateUserOwnedLibrary(libraryId);
     AssetGrant grant =
-        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.USER, null, userId);
+        AssetGrant.forUser(libraryId, organizationId, userId, AssetRole.VIEWER, null, userId);
     when(grantRepository.findByLibraryId(libraryId)).thenReturn(List.of(grant));
 
-    assertThat(accessService.canRead(library, userId, false)).isFalse();
+    assertThat(accessService.canRead(library, userId, false)).isTrue();
+    assertThat(accessService.canManage(library, userId, false)).isFalse();
   }
 
   @Test

--- a/backend/src/test/java/io/opaa/migration/Migration014DropAssetRoleUserTest.java
+++ b/backend/src/test/java/io/opaa/migration/Migration014DropAssetRoleUserTest.java
@@ -1,0 +1,235 @@
+package io.opaa.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Applies Liquibase changelog 014 in isolation against a database built from the real, versioned
+ * changelog through changeSet 013 - the same pattern as {@code Migration013AssetGrantsTest}, with
+ * {@code test-master-through-013.yaml} as the pre-migration fixture. {@code
+ * connection.setAutoCommit(true)} is called after every {@code liquibase.update(...)} call, and the
+ * public schema is dropped and recreated between test methods, per the package Javadoc's mandatory
+ * teardown pattern.
+ *
+ * <p>The point of these tests is that changelog 014 runs against <em>live data</em>: an existing
+ * {@code USER} grant must survive as {@code VIEWER} rather than be deleted or block the narrowing
+ * ALTER. Ordering the two changeSets the other way round - constraint first, data second - would
+ * fail on any database that already holds a USER grant, which is precisely the case the migration
+ * exists for.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class Migration014DropAssetRoleUserTest {
+
+  @Container
+  static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse("pgvector/pgvector:pg18"));
+
+  private static final String SEEDED_ORGANIZATION_ID = "00000000-0000-0000-0000-000000000001";
+
+  private Connection connection;
+  private Database database;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+    database =
+        DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/test-master-through-013.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  @AfterEach
+  void tearDown() throws SQLException {
+    connection.setAutoCommit(true);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+    connection.close();
+  }
+
+  @Test
+  void anExistingUserGrantIsPromotedToViewerRatherThanDeleted() throws Exception {
+    UUID library = insertLibrary(UUID.randomUUID());
+    UUID user = insertUser(UUID.randomUUID());
+    insertGrant(library, user, "USER");
+
+    applyChangelog014();
+
+    // Promoting rather than deleting is the deliberate choice: a holder of USER was meant to be
+    // able to use the asset, and revoking that on migration would silently take working access
+    // away. VIEWER is the smallest rank that preserves it.
+    assertThat(grantCountFor(library)).isEqualTo(1);
+    assertThat(roleOfGrantFor(library, user)).isEqualTo("VIEWER");
+  }
+
+  @Test
+  void aGrantThatAlreadyHeldAHigherRankIsLeftUntouched() throws Exception {
+    UUID library = insertLibrary(UUID.randomUUID());
+    UUID manager = insertUser(UUID.randomUUID());
+    insertGrant(library, manager, "MANAGER");
+
+    applyChangelog014();
+
+    assertThat(roleOfGrantFor(library, manager)).isEqualTo("MANAGER");
+  }
+
+  @Test
+  void theNarrowedCheckConstraintRejectsUserAsARole() throws Exception {
+    applyChangelog014();
+    UUID library = insertLibrary(UUID.randomUUID());
+    UUID user = insertUser(UUID.randomUUID());
+
+    assertThatThrownBy(() -> insertGrant(library, user, "USER"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("chk_asset_grants_role");
+  }
+
+  @Test
+  void theFourRemainingRolesStayAccepted() throws Exception {
+    applyChangelog014();
+    UUID library = insertLibrary(UUID.randomUUID());
+
+    for (String role : new String[] {"VIEWER", "EDITOR", "MANAGER", "OWNER"}) {
+      insertGrant(library, insertUser(UUID.randomUUID()), role);
+    }
+
+    assertThat(grantCountFor(library)).isEqualTo(4);
+  }
+
+  @Test
+  void subjectTypeUserRemainsValidBecauseItIsADifferentEnum() throws Exception {
+    applyChangelog014();
+    UUID library = insertLibrary(UUID.randomUUID());
+    UUID user = insertUser(UUID.randomUUID());
+
+    // chk_asset_grants_subject_type keeps its own 'USER' value - that is PermissionSubjectType on
+    // a different column. Narrowing the role check must not touch it; this test fails loudly if a
+    // future edit conflates the two.
+    insertGrant(library, user, "VIEWER");
+
+    assertThat(subjectTypeOfGrantFor(library, user)).isEqualTo("USER");
+  }
+
+  private void applyChangelog014() throws Exception {
+    Liquibase liquibase =
+        new Liquibase(
+            "db/changelog/changes/014-drop-asset-role-user.yaml",
+            new ClassLoaderResourceAccessor(),
+            database);
+    liquibase.update(new Contexts());
+    connection.setAutoCommit(true);
+  }
+
+  private UUID insertUser(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO users (id, subject, issuer, system_role, organization_id, created_at) "
+              + "VALUES ('"
+              + id
+              + "', '"
+              + id
+              + "', 'test-issuer', 'USER', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', now())");
+    }
+    return id;
+  }
+
+  private UUID insertLibrary(UUID id) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO knowledge_libraries "
+              + "(id, organization_id, name, owner_type, owner_user_id, owner_group_id,"
+              + " visibility, listed, personal, created_at, updated_at) VALUES ('"
+              + id
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', 'Bibliothek "
+              + id
+              + "', 'SYSTEM', NULL, NULL, 'PRIVATE', false, false, now(), now())");
+    }
+    return id;
+  }
+
+  private void insertGrant(UUID libraryId, UUID userId, String role) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "INSERT INTO asset_grants (id, library_id, organization_id, subject_type,"
+              + " subject_user_id, role, created_at, updated_at) VALUES ('"
+              + UUID.randomUUID()
+              + "', '"
+              + libraryId
+              + "', '"
+              + SEEDED_ORGANIZATION_ID
+              + "', 'USER', '"
+              + userId
+              + "', '"
+              + role
+              + "', now(), now())");
+    }
+  }
+
+  private int grantCountFor(UUID libraryId) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet result =
+            statement.executeQuery(
+                "SELECT count(*) FROM asset_grants WHERE library_id = '" + libraryId + "'")) {
+      result.next();
+      return result.getInt(1);
+    }
+  }
+
+  private String roleOfGrantFor(UUID libraryId, UUID userId) throws SQLException {
+    return singleColumnOfGrant("role", libraryId, userId);
+  }
+
+  private String subjectTypeOfGrantFor(UUID libraryId, UUID userId) throws SQLException {
+    return singleColumnOfGrant("subject_type", libraryId, userId);
+  }
+
+  private String singleColumnOfGrant(String column, UUID libraryId, UUID userId)
+      throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet result =
+            statement.executeQuery(
+                "SELECT "
+                    + column
+                    + " FROM asset_grants WHERE library_id = '"
+                    + libraryId
+                    + "' AND subject_user_id = '"
+                    + userId
+                    + "'")) {
+      return result.next() ? result.getString(1) : null;
+    }
+  }
+}

--- a/backend/src/test/resources/db/changelog/test-master-through-013.yaml
+++ b/backend/src/test/resources/db/changelog/test-master-through-013.yaml
@@ -1,3 +1,13 @@
+# Test-only fixture: the real changelog (db.changelog-master.yaml) up to and including
+# changeSet 013 - i.e. the schema exactly as it existed immediately before migration 014, which
+# builds on this same pre-migration state.
+#
+# Used by:
+# - Migration014DropAssetRoleUserTest, to build a realistic pre-migration database (via the real,
+#   versioned changelog files, not a hand-rolled schema) and then apply 014 in isolation.
+#
+# See test-master-through-012.yaml and Migration013AssetGrantsTest for the pattern this
+# fixture follows.
 databaseChangeLog:
   - include:
       file: db/changelog/changes/001-enable-pgvector-extension.yaml
@@ -25,5 +35,3 @@ databaseChangeLog:
       file: db/changelog/changes/012-knowledge-libraries.yaml
   - include:
       file: db/changelog/changes/013-asset-grants.yaml
-  - include:
-      file: db/changelog/changes/014-drop-asset-role-user.yaml

--- a/docs/features/access-control.md
+++ b/docs/features/access-control.md
@@ -102,7 +102,7 @@ Wenn ein Nutzer die Organisation verlässt:
 
 1. Die Verzeichnis-Synchronisation entfernt ihn; er kann sich nicht mehr anmelden.
 2. **Die Deaktivierung wird nie durch offene Eigentumsfragen aufgehalten.** Eine Regel, die das verlangt, wird am Freitagnachmittag umgangen und schützt dann gerade nicht.
-3. Seine Assets gehen in den Zustand **„Nachfolge offen"**: nutzbar und mit unveränderten Rechten, aber mit **eingefrorener Reichweite** — keine neuen Grants, keine höhere Freigabestufe, keine neue Bereitstellung. Zuständig für die Nachfolge ist der Kurator seiner Organisationseinheit, mit Frist und Eskalation.
+3. Seine Assets gehen in den Zustand **„Nachfolge offen"**: nutzbar und mit unveränderten Rechten, aber mit **eingefrorener Reichweite** — keine neuen Grants, keine höhere Freigabestufe, keine neue Bereitstellung. Zuständig für die Nachfolge ist der System-Admin; der Vorgang erscheint mit Frist auf der Governance-Arbeitsliste.
 4. Für zentral gepflegte Bestände ist Gruppen-Eigentum der Regelfall und verhindert das Problem von vornherein.
 5. Sein persönlicher Space wird deaktiviert, nicht gelöscht (Nachweisgründe) — und **nicht lesbar gemacht**. Entwürfe darin bleiben unzugänglich. Chats und Artefakte unterliegen der Aufbewahrungsregel.
 

--- a/docs/features/spaces-and-assets.md
+++ b/docs/features/spaces-and-assets.md
@@ -62,15 +62,26 @@ Die Ausdifferenzierung der Asset-Typen ist **nicht** Gegenstand dieses Dokuments
 
 | Rolle | Darf |
 |---|---|
-| `USER` | benutzen, ohne die Konfiguration zu sehen — Agent aufrufen, Bibliothek liefert Treffer in Antworten |
-| `VIEWER` | zusätzlich die Konfiguration einsehen: Aufgabenbeschreibung, Wissensbindung, Dokumentenliste |
+| `VIEWER` | das Asset benutzen und seine Konfiguration einsehen — Agent aufrufen, Bibliothek liefert Treffer, Aufgabenbeschreibung und Dokumentenliste sind sichtbar |
 | `EDITOR` | zusätzlich ändern |
 | `MANAGER` | zusätzlich teilen, Rechte vergeben, Freigabestufe und Auffindbarkeit setzen |
 | `OWNER` | zusätzlich löschen und Eigentum übertragen |
 
-Die Trennung **`USER` gegen `VIEWER`** ist der wesentliche Zugewinn: Ein Sachgebiet soll einen geprüften Agenten nutzen können, ohne dass jeder Nutzer seine Aufgabenbeschreibung ändern oder die zugrundeliegende Dokumentenliste einsehen kann.
-
 Asset-Rollen sind eine **eigene Rangordnung**, getrennt von den Space-Rollen. **Kein Rollenname kommt in beiden Systemen vor** — deshalb heißt die verwaltende Asset-Rolle `MANAGER` und nicht `ADMIN`. Wer sagt „ich habe hier Admin-Rechte", meint damit immer einen Space; wer Asset-Rechte meint, sagt `MANAGER` oder `OWNER`. Das ist keine Kosmetik: Bei der Übergabe eines Vorgangs muss ohne Rückfrage klar sein, wovon die Rede ist.
+
+#### Die beiden Rollensysteme im Überblick
+
+Es gibt **zwei Rollensysteme** plus eine systemweite Rolle. Sie beantworten verschiedene Fragen und werden nie miteinander verrechnet:
+
+| System | Rollen | Beantwortet die Frage |
+|---|---|---|
+| **Asset** | `VIEWER` · `EDITOR` · `MANAGER` · `OWNER` | Was darf ich mit diesem Agenten, dieser Bibliothek, dieser Prompt-Sammlung tun? |
+| **Space** | `MEMBER` · `CURATOR` · `ADMIN` (+ `ownerId` als Attribut) | Was darf ich in diesem Arbeitsraum tun? |
+| **systemweit** | System-Admin | Wer verwaltet Konnektoren, Verzeichnis, Policies und offene Nachfolgen? |
+
+Beide Systeme sind **unabhängig**: Ein Space-`ADMIN` hat dadurch keinerlei Recht an den dort assoziierten Assets, und ein Asset-`OWNER` ist dadurch in keinem Space Mitglied.
+
+**Gruppen tragen keine Rollen.** Eine Gruppe ist ausschließlich Rechtesubjekt — ein Grant an sie wirkt für ihre Mitglieder, mehr nicht. Es gibt keine Rolle „innerhalb" einer Gruppe und keine Instanz, die einer Freigabe an eine Gruppe zustimmen müsste (siehe [Verteilung von Assets](#verteilung-von-assets)).
 
 ### Rechte an einem Asset erhalten
 
@@ -112,7 +123,7 @@ Die Stufe ergibt sich stattdessen daraus, **wem** der Grant gilt, kombiniert mit
 | **Fachbereich** | `visibility = SHARED`, **Grant an die Abteilungs- oder Amts-Gruppe** |
 | organisationsweit | `visibility = ORGANIZATION` |
 
-Ein Asset „an die ganze Abteilung freigeben" heißt also: **Grant an die Gruppe, die die Abteilung abbildet** — erteilt mit Zustimmung des Kurators dieser Einheit. Ohne Gruppen gäbe es die Stufe „Fachbereich" nicht; sie ist der Punkt, an dem das flache Space-Modell sonst eine Lücke hätte. Das ist der eigentliche Grund, warum Gruppen früh und nicht später gebraucht werden. Einzelheiten unter [Verteilung von Assets](#verteilung-von-assets).
+Ein Asset „an die ganze Abteilung freigeben" heißt also: **Grant an die Gruppe, die die Abteilung abbildet** — erteilt von einem `MANAGER` des Assets, ohne dass die Abteilung zustimmen muss. Ohne Gruppen gäbe es die Stufe „Fachbereich" nicht; sie ist der Punkt, an dem das flache Space-Modell sonst eine Lücke hätte. Das ist der eigentliche Grund, warum Gruppen früh und nicht später gebraucht werden. Einzelheiten unter [Verteilung von Assets](#verteilung-von-assets).
 
 Zwei Felder steuern das:
 
@@ -134,7 +145,7 @@ Jedes Asset hat genau einen Eigentümer. Wenn dieser Eigentümer eine **Person**
 1. **Eigentümer kann eine Person oder eine Gruppe sein.** Für zentral gepflegte Assets — Rechtsquellen, Dienstanweisungen, hausweite Agenten — ist die **Gruppe der Regelfall**: Eigentümer ist „Referat Z 2", nicht Frau Müller. Damit übersteht das Asset jeden Personalwechsel, und die Zuständigkeit ist im Katalog als Organisationseinheit ausgewiesen. Das ist die eigentliche Lösung; alles Folgende ist Auffangnetz.
 2. **Die Deaktivierung eines Kontos ist immer sofort möglich** und wird nie blockiert.
 3. **Assets des Ausgeschiedenen gehen in den Zustand „Nachfolge offen".** Sie funktionieren weiter und behalten ihre Rechte, damit die laufende Arbeit nicht abreißt — **aber ihre Reichweite kann nicht mehr wachsen**: keine neuen Grants, keine Erhöhung der Freigabestufe, keine neue Assoziation. Ein Asset ohne fachlich Verantwortlichen darf sich nicht weiter verbreiten.
-4. **Die Nachfolge hat einen benannten Adressaten und eine Frist.** Zuständig ist der Kurator der Organisationseinheit des Ausgeschiedenen; ist keiner benannt, greift die Eskalation nach oben (siehe [Kuratoren](#kuratoren)). Der Vorgang erscheint auf seiner Liste mit Frist und wird bei Ablauf eskaliert — er verfällt nicht und landet nicht in einer namenlosen Sammelliste.
+4. **Die Nachfolge hat einen benannten Adressaten und eine Frist.** Zuständig ist der System-Admin; der Vorgang erscheint mit Frist auf der Governance-Arbeitsliste. Er verfällt nicht und landet nicht in einer namenlosen Sammelliste.
 5. **Nichts wird stillschweigend gelöscht oder in seiner Reichweite verändert.**
 
 Damit gibt es keine Regel mehr, die eine andere aufhebt: Der Zugang endet sofort, die Zuständigkeit wird nachgezogen, und in der Zwischenzeit ist das Asset nutzbar, aber eingefroren.
@@ -155,35 +166,31 @@ Gruppen haben zwei Ausprägungen:
 
 | `Group.kind` | Herkunft | Verwendung |
 |---|---|---|
-| `ORG_UNIT` | aus dem Verzeichnis synchronisiert (Referat, Abteilung, Amt) | Rechtesubjekt **und** Freigabeziel; kennt ihre übergeordnete Einheit; kann Kuratoren haben |
+| `ORG_UNIT` | aus dem Verzeichnis synchronisiert (Referat, Abteilung, Amt) | Rechtesubjekt **und** Freigabeziel; kennt ihre übergeordnete Einheit |
 | `AD_HOC` | im System angelegt | nur Rechtesubjekt (z. B. „Projektbeteiligte Phoenix", „Stabsstelle Leserunde") |
 
-**Verhältnis von Rechtesubjekt und Freigabeziel:** Es ist **dasselbe Objekt in zwei Verwendungen**, und materiell derselbe Vorgang. „Ein Asset an die Abteilung 5 freigeben" heißt: ein Grant an die Gruppe „Abteilung 5". Neu ist nicht *was* passiert, sondern *wer es erteilen darf* — bei einer Organisationseinheit ist dafür deren Kurator zuständig (siehe unten). Ein Grant an eine `AD_HOC`-Gruppe braucht keinen Kurator und wird wie jede andere Rechtevergabe von einem `MANAGER` des Assets erteilt.
+**Verhältnis von Rechtesubjekt und Freigabeziel:** Es ist **dasselbe Objekt in zwei Verwendungen**, und materiell derselbe Vorgang. „Ein Asset an die Abteilung 5 freigeben" heißt: ein Grant an die Gruppe „Abteilung 5". Erteilt wird er wie jede andere Rechtevergabe von einem `MANAGER` des Assets — für beide Gruppenarten gleich.
 
-**Zwei Richtungen, die nicht verwechselt werden dürfen:**
+**Mitgliedschaft vererbt nicht.** Wer in einer Einheit Mitglied ist, sagt das Verzeichnis. OPAA erfindet keine Vererbung nach unten: Ein Grant an „Amt 5" erreicht nur, wen das Verzeichnis dieser Gruppe zurechnet.
 
-- **Mitgliedschaft vererbt nicht.** Wer in einer Einheit Mitglied ist, sagt das Verzeichnis. OPAA erfindet keine Vererbung nach unten: Ein Grant an „Amt 5" erreicht nur, wen das Verzeichnis dieser Gruppe zurechnet.
-- **Zuständigkeit vererbt aufwärts.** Ist für eine Einheit kein Kurator benannt, fällt die Zuständigkeit an die nächsthöhere Einheit, im Zweifel an die Gesamtorganisation.
+Damit ist auch die frühere Aussage „keine Hierarchie" präzisiert: **Die einzige Hierarchie im System ist die Aufbauorganisation, und sie kommt aus dem Verzeichnis.** Sie dient der Anzeige und der Aggregation von Auswertungen, trägt aber keine Zuständigkeit. Spaces bleiben flach, Assets bleiben flach.
 
-Damit ist auch die frühere Aussage „keine Hierarchie" präzisiert: **Die einzige Hierarchie im System ist die Aufbauorganisation, und sie kommt aus dem Verzeichnis.** Spaces bleiben flach, Assets bleiben flach.
+### Freigabe an eine Gruppe braucht keine Zustimmung
 
-### Kuratoren
+Eine Verteilung hätte zwei Seiten haben können: die Gebeseite — ein `MANAGER` des Assets erteilt den Grant — und eine Annahmeseite, auf der die empfangende Einheit zustimmt. **Die Annahmeseite gibt es nicht.**
 
-Ein **Kurator** ist an eine Organisationseinheit gebunden, nicht global. Es gibt Kuratoren für Referate, für Abteilungen und für die Gesamtorganisation.
+> Ein Grant an eine Gruppe wird allein vom `MANAGER` des Assets erteilt. Niemand muss ihn annehmen, und es gibt keine Größenschwelle, ab der eine Zustimmung nötig würde.
 
-- Eine Freigabe an eine Einheit erfordert die Zustimmung ihres Kurators.
-- Ist für eine Einheit kein Kurator benannt, greift der Kurator der nächsthöheren Einheit.
-- Die Besetzung ist damit **optional und wächst mit**: Eine Pilotbehörde benennt einen einzigen zentralen Kurator und ist sofort arbeitsfähig. Eine große Behörde besetzt Referats- und Abteilungsebene und steuert fein.
+Der Grund ist die Asymmetrie zwischen Geben und Empfangen: **Ein Grant setzt niemanden etwas aus.** Er gewährt Zugriff, er verteilt keine Inhalte an Unbeteiligte. Wer ihn nicht nutzen will, nutzt ihn nicht. Das Risiko ist deshalb kein Datenabfluss, sondern Katalog-Rauschen — dass jemand vierhundert Personen ein Asset in die Liste legt, das sie nicht angefordert haben.
 
-Der Kurator entscheidet über die Aufnahme in seinen Verantwortungsbereich — er wird dadurch nicht Eigentümer des Assets. Eigentum und Kuratierung sind getrennt.
+Dagegen wirken zwei Mittel, die es ohnehin gibt:
 
-**Die Zuständigkeit hängt an der Reichweite, nicht an der Gruppenart.** Sonst gäbe es einen offenen Umgehungsweg: Wer eine Freigabe an „Abteilung 5" nicht durch den Kurator bringt, legt eine `AD_HOC`-Gruppe mit denselben Personen an und erteilt den Grant ohne jede Kuratierung — materiell dieselbe Reichweite, formal keine Freigabe an die Einheit. Deshalb gilt:
+- **`listed` ist standardmäßig `false`.** Ein Asset ist zugänglich, ohne im Katalog aufzutauchen; die Aufnahme in den Katalog ist eine eigene, bewusste Entscheidung (siehe [Freigabestufen und Auffindbarkeit](#freigabestufen-und-auffindbarkeit)).
+- **Die Governance-Arbeitsliste.** Der System-Admin sieht, was breit verteilt wurde, und kann eingreifen — Freigaben laufen frei, die Aufsicht schaut hinterher.
 
-> Ein Grant an eine Gruppe ab einer konfigurierbaren Größe erfordert die Zustimmung eines Kurators — **unabhängig davon, ob es eine Organisationseinheit oder eine Ad-hoc-Gruppe ist.**
+**Was damit ersatzlos entfällt:** Kuratoren als Objekt an der Organisationseinheit, die Zuständigkeitsvererbung nach oben, die konfigurierbare Größenschwelle, die Sonderbehandlung des Umgehungswegs über `AD_HOC`-Gruppen sowie Freigabeanfragen mit Frist, Eskalation und Liegezeit-Listen. Eine frühere Fassung sah das alles vor; die Begründung für die Streichung steht unter [Geprüfte und verworfene Alternativen](#verteilung-von-assets-1).
 
-Zuständig ist bei einer Ad-hoc-Gruppe der Kurator der Organisationseinheit des Erteilenden. Kleine Ad-hoc-Gruppen — der übliche Projektkreis — bleiben frei von Kuratierung; sie sind der Grund, warum es diese Gruppenart überhaupt gibt.
-
-**Voraussetzung dafür ist, dass die Kuratorenrolle tatsächlich besetzt und mit Arbeitszeit hinterlegt ist.** Bleibt sie unbesetzt, fällt über die Eskalation alles auf die zentrale Ebene, dort stapeln sich die Anfragen, und die dokumentierte Freigabekette ist nicht mehr die gelebte. Das ist keine Frage der Technik, sondern der Einführung — die einführende Stelle muss die Rolle benennen und ausstatten. Das Produkt macht sie sichtbar: Offene Anfragen mit Liegezeit stehen auf einer Liste, und die Liegezeit ist auswertbar.
+**Wo eine Obergrenze bleibt:** Bibliotheken, die aus einem Konnektor gespeist werden, tragen weiterhin eine vom System-Admin gesetzte Freigabe-Obergrenze (siehe [Konnektoren und Quellzuordnung](#konnektoren-und-quellzuordnung)). Sie ist die einzige Stelle, an der die Reichweite eines Grants technisch gedeckelt ist — und sie schützt den Fall, der es braucht: einen Bestand, den ein Admin eingespeist hat und über den ein Bibliotheks-Eigentümer sonst frei verfügen könnte.
 
 ### Referenz statt Kopie
 
@@ -352,7 +359,7 @@ Warum drei statt der bisherigen vier Rollen:
 
 ### Assets in einen Space assoziieren
 
-Ein Kurator kann jedes Asset, auf das er selbst Zugriff hat, in seinen Space assoziieren. Das ist unbedenklich, weil die Assoziation **keine Rechte gewährt** — sie stellt das Asset lediglich im Space zur Verfügung, und zwar nur für die Mitglieder, die ohnehin Zugriff darauf haben.
+Ein Space-`CURATOR` kann jedes Asset, auf das er selbst Zugriff hat, in seinen Space assoziieren. Das ist unbedenklich, weil die Assoziation **keine Rechte gewährt** — sie stellt das Asset lediglich im Space zur Verfügung, und zwar nur für die Mitglieder, die ohnehin Zugriff darauf haben.
 
 Der Eigentümer des Assets sieht alle Assoziationen und kann jede davon jederzeit einseitig lösen. Das Asset bleibt Herr über seine Verbreitung.
 
@@ -517,7 +524,7 @@ Der Gedanke, alles einheitlich als Asset zu modellieren, ist naheliegend, trägt
 [docs/migrations/012-knowledge-library.md](../migrations/012-knowledge-library.md)) — Eigentümerschaft
 (Nutzer oder Gruppe), Organisationsgrenze, Sichtbarkeitsstufen, `listed`-Flag und die Zuweisung jedes
 bestehenden Dokuments an eine System-Bibliothek. Die abgestuften Asset-Rollen weiter unten
-(`USER`/`VIEWER`/`EDITOR`/`MANAGER`/`OWNER`) und die rechtebewusste Vektorsuche folgen mit #202 — bis
+(`VIEWER`/`EDITOR`/`MANAGER`/`OWNER`) und die rechtebewusste Vektorsuche folgen mit #202 — bis
 dahin gilt eine grobe Zugriffslogik (Eigentümer, Gruppenmitglied, `ORGANIZATION`-Sichtbarkeit,
 System-Admin), dokumentiert auf `KnowledgeLibraryService`.
 
@@ -569,7 +576,7 @@ Eine Teilablehnung blockiert die Weitergabe nicht. Der Agent wird geteilt und ar
 
 **Nicht-Reaktion ist der Regelfall, nicht die Ablehnung** — Urlaub, unklare Zuständigkeit, Postfach ohne Betreuung. Ohne Behandlung hinge ein Agent dauerhaft unvollständig, ohne dass jemand weiß, woran es liegt. Deshalb:
 
-- Jede Anfrage hat eine **Frist**. Läuft sie ab, wird sie an den Kurator der Organisationseinheit des Bibliotheks-Eigentümers eskaliert, von dort nach oben.
+- Jede Anfrage hat eine **Frist**. Läuft sie ab, erscheint sie auf der Governance-Arbeitsliste des System-Admins.
 - Der Zustand ist für beide Seiten **jederzeit sichtbar**: „wartet seit 6 Tagen auf Referat 34".
 - **Der Empfänger sieht am Agenten selbst**, dass eine Wissensquelle fehlt — nicht erst an schlechteren Antworten. Sonst hält er den Agenten für untauglich, statt zu erkennen, dass eine Freigabe aussteht.
 
@@ -617,7 +624,7 @@ Drei Mechanismen aus einem früheren Entwurf sind ersatzlos gestrichen, weil sie
 
 | Entfallen | Grund |
 |---|---|
-| **Bestätigungspflicht des Kurators bei gemischter Assoziation** | Die Assoziation setzt niemanden mehr etwas aus. Sie stellt eine Bibliothek bereit; sichtbar wird ein Ergebnis erst durch das Ablegen |
+| **Bestätigungspflicht des Space-`CURATOR` bei gemischter Assoziation** | Die Assoziation setzt niemanden mehr etwas aus. Sie stellt eine Bibliothek bereit; sichtbar wird ein Ergebnis erst durch das Ablegen |
 | **Dauerhafte Kennzeichnung gemischter Spaces** | In einer realen Behörde fallen Leserkreise praktisch nie exakt zusammen — ein Teilzeitbeschäftigter, eine externe Kraft, ein Abgeordneter genügt. Damit wäre so gut wie *jeder* Space gekennzeichnet, und ein Warnzeichen, das an allem klebt, informiert über nichts |
 | **Herkunftsabhängiger Sonderweg bei Artefakten** | Ein Ergebnis war mal sofort sichtbar und mal nicht, ohne dass der Ersteller den Unterschied erklären konnte. Jetzt gilt für alles dieselbe Regel |
 
@@ -661,8 +668,8 @@ Das System löst dann **weder Assoziationen automatisch** (das entzöge einem ga
 
 Das ist fail-closed für neue Exposition, ohne etwas zu zerstören, und es gibt keinen stillschweigenden Zustandswechsel im Hintergrund. Ein Sperrzustand ohne Zuständigen wäre allerdings nur die halbe Regelung — er erzeugt **Arbeitsstillstand**, und zwar in genau dem Raum, für den dieses Dokument den Strikt-Modus empfiehlt. Deshalb gilt derselbe Zuschnitt wie bei „Nachfolge offen":
 
-- **Benannter Adressat, Frist und Eskalation.** Der Vorgang erscheint auf der Liste des Kurators der Organisationseinheit des betroffenen Bibliotheks-Eigentümers, mit Frist und Eskalation nach oben. Ohne das hängt die Arbeitsfähigkeit einer Prüfstelle an der Reaktionszeit eines Referatsleiters, den sie unter Umständen gerade prüft.
-- **Der System-Admin erhält eine Liste mit Liegezeit** — wie bei offenen Kuratorenanfragen und bei der Nachfolge. Sonst sieht niemand, wie viele Räume betroffen sind und wie lange schon, und ein Space kann monatelang gesperrt daliegen, weil eine Nachricht im Urlaub ankam.
+- **Benannter Adressat und Frist.** Der Vorgang erscheint mit Frist auf der Governance-Arbeitsliste des System-Admins. Ohne das hängt die Arbeitsfähigkeit einer Prüfstelle an der Reaktionszeit eines Referatsleiters, den sie unter Umständen gerade prüft.
+- **Der System-Admin erhält eine Liste mit Liegezeit** — wie bei der Nachfolge. Sonst sieht niemand, wie viele Räume betroffen sind und wie lange schon, und ein Space kann monatelang gesperrt daliegen, weil eine Nachricht im Urlaub ankam.
 - **Die Neubewertung wird von jeder Rechteänderung an jeder Bibliothek ausgelöst, die in irgendeinem Strikt-Space bereitgestellt ist.** Sonst löst sich der Zustand nicht von selbst, wenn seine Ursache wegfällt, sondern bleibt hängen, bis jemand einen Knopf drückt.
 - **Die Ursache geht im Klartext an den Space-Verantwortlichen:** welche Bibliothek, welches Ereignis, welcher Zeitpunkt.
 - **Die Meldung an den Nutzer weist den Zustand als fachlichen Vorgang aus, nicht als Störung**, und benennt die zuständige Stelle. Sinngemäß: „Dieser Raum ist gesperrt, weil eine Zugriffsvoraussetzung nicht mehr erfüllt ist. Zuständig ist der Space-Verantwortliche."
@@ -682,7 +689,7 @@ erlaubte Modelle = Systempolicy
                  ∩ Policy des Agenten
 ```
 
-Die Bibliothek trägt ihre Obergrenze **selbst mit sich**. Das ist wesentlich: Unter diesem Modell hat der Space keine Hoheit über die Bibliotheken, die in ihm auftauchen — jeder Kurator kann jede Bibliothek assoziieren, auf die er Zugriff hat. Eine Bibliothek mit besonders geschützten Daten kann also in einem Space landen, dessen Policy Cloud-Modelle erlaubt. Eine ausschließlich space-gebundene Policy schützt genau diesen Fall nicht.
+Die Bibliothek trägt ihre Obergrenze **selbst mit sich**. Das ist wesentlich: Unter diesem Modell hat der Space keine Hoheit über die Bibliotheken, die in ihm auftauchen — jeder Space-`CURATOR` kann jede Bibliothek assoziieren, auf die er Zugriff hat. Eine Bibliothek mit besonders geschützten Daten kann also in einem Space landen, dessen Policy Cloud-Modelle erlaubt. Eine ausschließlich space-gebundene Policy schützt genau diesen Fall nicht.
 
 > **Datenschutzrelevante Modellbeschränkungen gehören an die Daten, nicht an den Raum.**
 
@@ -827,9 +834,17 @@ Das Modell weicht **von beiden Mustern ab**, aber nicht in derselben Sache — e
 
 ### Rechtemodell
 
-- **Vereinigung — Space-Mitgliedschaft gewährt automatisch Asset-Rechte.** Bequem und intuitiv, aber ein Kurator könnte ein Asset, das ihm nicht gehört, in einen großen Space hängen und damit dessen Mitgliedern Zugriff verschaffen. Confluence verbietet genau diese Richtung ausdrücklich.
+- **Vereinigung — Space-Mitgliedschaft gewährt automatisch Asset-Rechte.** Bequem und intuitiv, aber ein Space-`CURATOR` könnte ein Asset, das ihm nicht gehört, in einen großen Space hängen und damit dessen Mitgliedern Zugriff verschaffen. Confluence verbietet genau diese Richtung ausdrücklich.
 - **Schnittmenge — Space-Rolle und Asset-Recht müssen beide erlauben.** Scheitert an der Mehrfachzuordnung (welcher Space ist maßgeblich, wenn das Asset in zweien mit unterschiedlichen Rollen liegt) und zerstört das direkte Teilen ohne gemeinsamen Space.
 - **Assoziation mit explizitem, gedeckeltem Grant.** Sicher, aber sie verlangt bei jeder Zuordnung eine zusätzliche Entscheidung durch den Asset-Verantwortlichen. Zugunsten des einfacheren und strikteren Modells verworfen.
+- **Eine Asset-Rolle `USER` unterhalb von `VIEWER`** — benutzen, ohne die Konfiguration zu sehen. Zunächst als „wesentlicher Zugewinn" vorgesehen, dann verworfen: **Die Zusage ist nicht durchsetzbar.** Wer einen Agenten aufrufen darf, kann ihn nach seinen Anweisungen fragen — die Aufgabenbeschreibung steht in seinem Kontext, und kein Rechtemodell hält ein Sprachmodell davon ab, sie wiederzugeben. Bei einer Bibliothek läuft die Trennung weitgehend leer, weil eine Antwort mit Quellenangabe die Dokumenttitel ohnehin nennt. Eine Rolle, die etwas zusichert, was die Technik nicht hält, ist schlechter als keine: Sie verleitet dazu, Bestände breiter freizugeben, als man es täte, wenn man die Wirkung richtig einschätzte. `VIEWER` ist damit die unterste Asset-Rolle.
+- **Kuratoren als Objekt an der Organisationseinheit, mit Zuständigkeitsvererbung nach oben.** Eine Freigabe an eine Einheit hätte die Zustimmung ihres Kurators erfordert; bei Nichtbesetzung wäre die Zuständigkeit an die nächsthöhere Einheit gefallen, im Zweifel bis zur Gesamtorganisation. Verworfen zugunsten der Regel, dass ein Grant an eine Gruppe **keine** Zustimmung braucht:
+  1. **Ein Grant setzt niemanden etwas aus.** Er gewährt Zugriff, er verteilt keine Inhalte. Das Risiko ist Katalog-Rauschen, nicht Datenabfluss — und dagegen wirken `listed = false` und die Governance-Arbeitsliste.
+  2. **Der Auffangfall endet ohnehin zentral.** Ist niemand benannt, landet die Entscheidung beim System-Admin. Die Eskalationskette ist der teurere Weg zum selben Ergebnis.
+  3. **Sie setzt eine Besetzung voraus, die eine Pilotbehörde nicht hat.** Referats- und Abteilungsebene mit Arbeitszeit zu hinterlegen ist ein Einführungsprojekt; bis dahin ist die Kette auf jeder Stufe leer.
+  4. **Sie erzeugt einen Zustandsautomaten für einen Verwaltungsvorgang** — Frist je Stufe, Weiterreichen bei Ablauf, Liegezeit je Station.
+
+  Mit den Kuratoren entfallen auch die konfigurierbare Größenschwelle und die Sonderbehandlung des Umgehungswegs über `AD_HOC`-Gruppen: Ohne Zustimmungspflicht gibt es nichts zu umgehen. Die Aufbauorganisation bleibt als Herkunft der Gruppen und als Aggregationsachse erhalten. Wer die Annahmeseite später doch braucht, kann sie als Rolle *in* der Gruppe ergänzen — so löst es Langdock —, ohne das Rechtemodell anzufassen.
 - **Space-Hierarchie zur Abbildung der Verteilungsstufen.** Die Stufen „persönlich → Team → Fachbereich → organisationsweit" werden über das Rechtesubjekt abgebildet — persönlich, Team-Gruppe, Abteilungs-Gruppe, organisationsweit — kombiniert mit `visibility` und `listed`. Keine Topologie der Spaces, kein Abteilungs-Objekt.
 - **Chat und Artefakt als Asset-Typen.** Falsche Kardinalität (viele, wegwerfbar statt wenige, kuratiert), falsche Beziehung (Komposition statt Assoziation), falsche Rechtelogik (die Chats eines Projekt-Space wären für die Projektmitglieder unsichtbar) und ein abweichendes Sicherheitsprofil (Ergebnisse statt Fähigkeiten). Siehe [Warum Chats und Artefakte keine Assets sind](#warum-chats-und-artefakte-keine-assets-sind).
 


### PR DESCRIPTION
## Zusammenfassung

Zwei Elemente des Rechtemodells entfallen, weil sie Aufwand erzeugen, ohne einen durchsetzbaren Gewinn zu liefern. Anlass war ein Vergleich mit Langdock und RelationFlow: Beide kommen ohne diese Konstrukte aus, und bei genauem Hinsehen tragen sie auch bei OPAA nicht.

### 1. Asset-Rolle `USER` entfällt

Die Trennung `USER` (nutzen, ohne die Konfiguration zu sehen) gegen `VIEWER` galt in der Spezifikation als „wesentlicher Zugewinn". Sie ist nicht haltbar:

- **Bei Agenten ist die Zusage nicht durchsetzbar.** Wer einen Agenten aufrufen darf, kann ihn nach seinen Anweisungen fragen — die Aufgabenbeschreibung steht in seinem Kontext, und kein Rechtemodell hält ein Sprachmodell davon ab, sie wiederzugeben.
- **Bei Bibliotheken läuft sie leer.** Eine Antwort mit Quellenangabe nennt die Dokumenttitel ohnehin.
- **Sie war bereits tot im Code.** `AssetRole.USER` kam im Produktivcode nicht vor; `LibraryAccessService` prüft durchgängig `atLeast(VIEWER)`.

Eine Rolle, die etwas zusagt, was die Technik nicht hält, ist schlechter als keine — sie verleitet dazu, Bestände breiter freizugeben, als man es bei richtiger Einschätzung der Wirkung täte. `VIEWER` ist damit die unterste Asset-Rolle.

### 2. Gruppenrollen und die Annahmeseite einer Freigabe entfallen

**Ein Grant an eine Gruppe braucht keine Zustimmung.** Damit entfallen ersatzlos: Kuratoren als Objekt an der Organisationseinheit, die Zuständigkeitsvererbung nach oben, die konfigurierbare Größenschwelle, die Sonderbehandlung des Umgehungswegs über `AD_HOC`-Gruppen sowie Freigabeanfragen mit Frist, Eskalation und Liegezeit-Listen.

Begründung: Ein Grant **setzt niemanden etwas aus** — er gewährt Zugriff, er verteilt keine Inhalte. Das Risiko ist Katalog-Rauschen, nicht Datenabfluss; dagegen wirken `listed = false` (Voreinstellung) und die Governance-Arbeitsliste. Der Auffangfall — niemand ist benannt — endete ohnehin beim System-Admin, die Eskalationskette war der teurere Weg zum selben Ergebnis.

Die Aufbauorganisation bleibt als Herkunft der Gruppen (`ORG_UNIT` gegen `AD_HOC`) und als Aggregationsachse erhalten. Die einzige verbliebene technische Deckelung ist die Freigabe-Obergrenze konnektor-gespeister Bibliotheken.

## Migration

`014-drop-asset-role-user.yaml`, zwei changeSets in zwingender Reihenfolge:

1. bestehende `USER`-Grants auf `VIEWER` heben
2. `chk_asset_grants_role` auf `('VIEWER','EDITOR','MANAGER','OWNER')` verengen

**Promoted statt gelöscht**, weil ein `USER`-Grant Nutzung gewähren sollte und ein Entzug bei der Migration stillschweigend funktionierenden Zugriff nähme. **Die Reihenfolge ist zwingend:** Constraint zuerst würde auf jeder Datenbank scheitern, die bereits einen `USER`-Grant hält — also genau in dem Fall, für den die Migration existiert. `chk_asset_grants_subject_type` behält sein eigenes `'USER'` (`PermissionSubjectType`, andere Spalte) und wird bewusst nicht angefasst.

## Reproduktionsnachweis

Changeset 014 vorübergehend durch ein No-op (`SELECT 1`) ersetzt, `Migration014DropAssetRoleUserTest` laufen lassen:

```
Migration014DropAssetRoleUserTest > theNarrowedCheckConstraintRejectsUserAsARole() FAILED
Migration014DropAssetRoleUserTest > anExistingUserGrantIsPromotedToViewerRatherThanDeleted() FAILED
5 tests completed, 2 failed
```

Fehlermeldungen:

```
org.opentest4j.AssertionFailedError: expected: "VIEWER" but was: "USER"
java.lang.AssertionError: Expecting code to raise a throwable.
```

Genau die zwei Tests, die die neue Semantik prüfen, schlagen fehl — die übrigen drei sind bewusst unabhängig vom Changeset und bleiben grün. Nach Wiederherstellung des Changesets: `BUILD SUCCESSFUL`.

Ein erster roter Lauf schlug mit `column "external_id" of relation "users" does not exist` in allen fünf Tests fehl — das war ein Fehler im Testaufbau, nicht der Nachweis. Die Insert-Helfer sind auf das Schema aus `Migration013AssetGrantsTest` korrigiert; die oben zitierten Meldungen stammen aus dem Lauf danach.

## Zugehörige Issues

Closes #330. Schließt #208 gegenstandslos ab (dort bereits vermerkt), ersetzt den geschlossenen PR #329. Teil von #198.

## Art der Änderung

- [x] Neue Funktion / Änderung bestehenden Verhaltens
- [x] Datenbankmigration
- [x] Dokumentation

## Checkliste

- [x] Backend-Formatierung (`spotlessCheck`)
- [x] Backend-Build und Test (`./gradlew build`) — grün
- [x] Reproduktionsnachweis geführt, beide Läufe dokumentiert
- [x] Migrationstest nach dem Muster in `io.opaa.migration` mit `test-master-through-013.yaml`
- [x] Beide verworfenen Alternativen in „Geprüfte und verworfene Alternativen" festgehalten
- [x] Keine verbliebenen mehrdeutigen „Kurator"-Erwähnungen; Space-Rolle durchgängig als `Space-CURATOR` qualifiziert
- [x] Keine toten Anker-Verweise
- [ ] Frontend nicht betroffen

## KI-Agenten-Offenlegung

Erstellt von Claude Opus 5 (Claude Code) auf Anweisung des Maintainers.
