### PR TITLE
docs: verpflichtendes Auth-Profil in den Startbefehlen nennen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,19 @@ Die Projektsprache ist **Deutsch**. Englisch bleibt ausschließlich dem Quellcod
 # Backend (aus backend/)
 ./gradlew build
 ./gradlew test
-./gradlew bootRun
 ./gradlew spotlessCheck
 ./gradlew spotlessApply
+
+# Backend starten — das Auth-Profil MUSS gesetzt sein, sonst bricht der Start
+# mit einer Meldung von AuthProfileGuard ab (siehe ADR-0005).
+SPRING_PROFILES_ACTIVE=local,dev ./gradlew bootRun
 
 # Frontend (aus frontend/)
 npm ci                                  # Abhängigkeiten installieren
 VITE_ENABLE_MOCKS=true npm run dev      # Dev-Server mit MSW-Mocks
 npm run dev                             # Dev-Server (benötigt Backend auf :8080)
+# Im dev-Auth-Modus laufen Anfragen als "dev-admin"; auf einen regulären Nutzer
+# wechseln mit http://localhost:5173/?devUser=dev-user
 npm run build                           # Production-Build
 npm run lint                            # Lint (ESLint)
 npm run test                            # Tests (Vitest)

--- a/docs/MVP-VERIFICATION.md
+++ b/docs/MVP-VERIFICATION.md
@@ -159,14 +159,18 @@ Die GitHub-Actions-Pipeline (`.github/workflows/ci.yml`) läuft bei jedem Push u
 
 2. **Backend starten:**
 
+   Das Auth-Profil muss gesetzt sein — ohne `dev` (oder `oidc`) bricht der Start
+   mit einer Meldung von `AuthProfileGuard` ab (siehe [ADR-0005](decisions/0005-authentication-strategy.md)).
+   Im `dev`-Modus findet keine Anmeldung statt; Anfragen laufen als `dev-admin`.
+
    ```bash
    cd backend
 
    # Mit Ollama (lokal, kein API-Schlüssel nötig):
-   ./gradlew bootRun
+   SPRING_PROFILES_ACTIVE=local,dev ./gradlew bootRun
 
    # Mit OpenAI (erfordert API-Schlüssel):
-   OPAA_OPENAI_API_KEY=sk-... ./gradlew bootRun
+   SPRING_PROFILES_ACTIVE=local,dev OPAA_OPENAI_API_KEY=sk-... ./gradlew bootRun
    ```
 
 3. **Frontend starten:**


### PR DESCRIPTION
## Zusammenfassung

Behebt eine Lücke, die #328 hinterlassen hat: Der in `AGENTS.md` dokumentierte Startbefehl funktionierte nicht mehr.

```
$ ./gradlew bootRun
INFO io.opaa.OpaaApplication : No active profile set, falling back to 1 default profile: "local"
Caused by: java.lang.IllegalStateException: No authentication profile is active. Set
SPRING_PROFILES_ACTIVE to include either "oidc" (production) or "dev" (local development
and tests). See docs/deployment.md.
```

`application.yml` setzt `spring.profiles.default: local`. Ein Default-Profil greift nur, solange **kein** aktives Profil gesetzt ist — `local` enthält aber kein Auth-Profil, also greift `AuthProfileGuard`. Das ist genau das beabsichtigte Verhalten des Guards; falsch war die Dokumentation.

Geändert:

- **`AGENTS.md`** — `SPRING_PROFILES_ACTIVE=local,dev ./gradlew bootRun` als eigener, kommentierter Block, statt `./gradlew bootRun` in der Befehlsliste. Dazu ein Hinweis auf den Nutzerwechsel über `?devUser=dev-user` bei der Beschreibung des Frontend-Dev-Servers.
- **`docs/MVP-VERIFICATION.md`** — beide Startvarianten (Ollama und OpenAI) um das Profil ergänzt, mit kurzer Begründung und Verweis auf ADR-0005.

## Zugehörige Issues

Closes #332

## Art der Änderung

- [ ] Bugfix
- [ ] Neues Feature
- [x] Dokumentation
- [ ] Refactoring
- [ ] CI/Build

## Checkliste

- [x] Tests bestehen lokal — reine Dokumentationsänderung, Pre-Push-Checkliste entfällt laut AGENTS.md
- [ ] Bei Bugfix: Reproduktionsnachweis erbracht — nicht zutreffend
- [x] Dokumentation aktualisiert
- [x] Keine Secrets oder Anmeldeinformationen committet
- [x] Commit-Nachrichten folgen Conventional Commits
- [x] CLA bereits unterzeichnet

### Verifikation

Beide Befehle wurden gegen den aktuellen `main`-Stand (`76b6b73`) mit lokaler Postgres-Instanz ausgeführt:

| Befehl | Ergebnis |
|---|---|
| `./gradlew bootRun` | bricht ab — `No authentication profile is active` |
| `SPRING_PROFILES_ACTIVE=local,dev ./gradlew bootRun` | startet, `Tomcat started on port 8080`, Warnbanner des `dev`-Profils im Log |

Funktionsprüfung der laufenden Instanz:

| Aufruf | Ergebnis |
|---|---|
| `GET /api/v1/auth/config` | `{"authority":null,"clientId":null,"mode":"dev"}` |
| `GET /api/v1/auth/me` ohne Header | `dev-admin`, `SYSTEM_ADMIN` |
| `GET /api/v1/auth/me` mit `X-OPAA-Dev-User: dev-user` | `dev-user`, `USER` |
| `GET /api/v1/auth/me` mit unbekanntem Nutzer | `401` |

## KI-Agenten-Offenlegung

- [ ] Dieser PR wurde von einem Menschen verfasst
- [x] Dieser PR wurde von einem KI-Agenten verfasst (angeben: **Claude Opus 5 via Claude Code**)
- [ ] Dieser PR wurde von Mensch + KI-Agent gemeinsam verfasst
